### PR TITLE
Migrate to Rust Edition 2018.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mmtk"
 version = "0.0.1"
 authors = [" <>"]
+edition = "2018"
 
 [lib]
 name = "mmtk"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ mod plan;
 mod mm;
 mod mmtk;
 
-pub use mm::memory_manager;
-pub use plan::{TransitiveClosure, TraceLocal, Allocator, MutatorContext, CollectorContext, ParallelCollector, Plan};
-pub use plan::selected_plan::{SelectedPlan, SelectedConstraints, SelectedMutator, SelectedTraceLocal, SelectedCollector};
-pub use mmtk::MMTK;
-pub use mmtk::{VM_MAP, MMAPPER};
+pub use crate::mm::memory_manager;
+pub use crate::plan::{TransitiveClosure, TraceLocal, Allocator, MutatorContext, CollectorContext, ParallelCollector, Plan};
+pub use crate::plan::selected_plan::{SelectedPlan, SelectedConstraints, SelectedMutator, SelectedTraceLocal, SelectedCollector};
+pub use crate::mmtk::MMTK;
+pub use crate::mmtk::{VM_MAP, MMAPPER};

--- a/src/mm/memory_manager.rs
+++ b/src/mm/memory_manager.rs
@@ -1,25 +1,25 @@
 use std::sync::atomic::Ordering;
 
-use plan::Plan;
-use ::plan::MutatorContext;
-use ::plan::TraceLocal;
-use ::plan::CollectorContext;
-use ::plan::transitive_closure::TransitiveClosure;
+use crate::plan::Plan;
+use crate::plan::MutatorContext;
+use crate::plan::TraceLocal;
+use crate::plan::CollectorContext;
+use crate::plan::transitive_closure::TransitiveClosure;
 
-use ::vm::Collection;
+use crate::vm::Collection;
 
-use ::util::{Address, ObjectReference};
+use crate::util::{Address, ObjectReference};
 
-use ::plan::selected_plan;
+use crate::plan::selected_plan;
 use self::selected_plan::SelectedPlan;
 
-use ::plan::Allocator;
-use util::constants::LOG_BYTES_IN_PAGE;
-use util::heap::layout::vm_layout_constants::HEAP_START;
-use util::heap::layout::vm_layout_constants::HEAP_END;
-use util::OpaquePointer;
-use vm::VMBinding;
-use mmtk::MMTK;
+use crate::plan::Allocator;
+use crate::util::constants::LOG_BYTES_IN_PAGE;
+use crate::util::heap::layout::vm_layout_constants::HEAP_START;
+use crate::util::heap::layout::vm_layout_constants::HEAP_END;
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
+use crate::mmtk::MMTK;
 use self::selected_plan::{SelectedMutator, SelectedTraceLocal, SelectedCollector};
 
 // This file provides a safe Rust API for mmtk-core.
@@ -43,7 +43,7 @@ pub fn start_control_collector<VM: VMBinding>(mmtk: &MMTK<VM>, tls: OpaquePointe
 }
 
 pub fn gc_init<VM: VMBinding>(mmtk: &MMTK<VM>, heap_size: usize) {
-    ::util::logger::init().unwrap();
+    crate::util::logger::init().unwrap();
     mmtk.plan.gc_init(heap_size, &mmtk.vm_map);
     mmtk.plan.common().initialized.store(true, Ordering::SeqCst);
 
@@ -92,7 +92,7 @@ pub fn is_valid_ref<VM: VMBinding>(mmtk: &MMTK<VM>, val: ObjectReference) -> boo
 // and use unsafe transmute when we know it is a SanityChcker ref.
 #[cfg(feature = "sanity")]
 pub fn report_delayed_root_edge<VM: VMBinding>(mmtk: &MMTK<VM>, trace_local: &mut SelectedTraceLocal<VM>, addr: Address) {
-    use ::util::sanity::sanity_checker::SanityChecker;
+    use crate::util::sanity::sanity_checker::SanityChecker;
     if mmtk.plan.common().is_in_sanity() {
         let sanity_checker: &mut SanityChecker<VM> = unsafe { &mut *(trace_local as *mut SelectedTraceLocal<VM> as *mut SanityChecker<VM>) };
         sanity_checker.report_delayed_root_edge(addr);
@@ -107,7 +107,7 @@ pub fn report_delayed_root_edge<VM: VMBinding>(_: &MMTK<VM>, trace_local: &mut S
 
 #[cfg(feature = "sanity")]
 pub fn will_not_move_in_current_collection<VM: VMBinding>(mmtk: &MMTK<VM>, trace_local: &mut SelectedTraceLocal<VM>, obj: ObjectReference) -> bool {
-    use ::util::sanity::sanity_checker::SanityChecker;
+    use crate::util::sanity::sanity_checker::SanityChecker;
     if mmtk.plan.common().is_in_sanity() {
         let sanity_checker: &mut SanityChecker<VM> = unsafe { &mut *(trace_local as *mut SelectedTraceLocal<VM> as *mut SanityChecker<VM>) };
         sanity_checker.will_not_move_in_current_collection(obj)
@@ -122,7 +122,7 @@ pub fn will_not_move_in_current_collection<VM: VMBinding>(_: &MMTK<VM>, trace_lo
 
 #[cfg(feature = "sanity")]
 pub fn process_interior_edge<VM: VMBinding>(mmtk: &MMTK<VM>, trace_local: &mut SelectedTraceLocal<VM>, target: ObjectReference, slot: Address, root: bool) {
-    use ::util::sanity::sanity_checker::SanityChecker;
+    use crate::util::sanity::sanity_checker::SanityChecker;
     if mmtk.plan.common().is_in_sanity() {
         let sanity_checker: &mut SanityChecker<VM> = unsafe { &mut *(trace_local as *mut SelectedTraceLocal<VM> as *mut SanityChecker<VM>) };
         sanity_checker.process_interior_edge(target, slot, root)
@@ -176,7 +176,7 @@ pub fn total_bytes<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
 
 #[cfg(feature = "sanity")]
 pub fn scan_region<VM: VMBinding>(mmtk: &MMTK<VM>){
-    ::util::sanity::memory_scan::scan_region(&mmtk.plan);
+    crate::util::sanity::memory_scan::scan_region(&mmtk.plan);
 }
 
 pub fn trace_get_forwarded_referent<VM: VMBinding>(trace_local: &mut SelectedTraceLocal<VM>, object: ObjectReference) -> ObjectReference {

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -6,12 +6,12 @@ use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::OpaquePointer;
 
 use std::default::Default;
-use util::reference_processor::ReferenceProcessors;
-use util::options::{UnsafeOptionsWrapper, Options};
+use crate::util::reference_processor::ReferenceProcessors;
+use crate::util::options::{UnsafeOptionsWrapper, Options};
 use std::sync::atomic::{Ordering, AtomicBool};
 
 use std::sync::Arc;
-use vm::VMBinding;
+use crate::vm::VMBinding;
 
 // TODO: remove this singleton at some point to allow multiple instances of MMTK
 // This helps refactoring.

--- a/src/plan/collector_context.rs
+++ b/src/plan/collector_context.rs
@@ -1,9 +1,9 @@
-use ::util::{Address, ObjectReference};
-use ::plan::{Phase, Allocator};
-use ::plan::selected_plan::SelectedConstraints::*;
-use ::util::OpaquePointer;
-use mmtk::MMTK;
-use vm::VMBinding;
+use crate::util::{Address, ObjectReference};
+use crate::plan::{Phase, Allocator};
+use crate::plan::selected_plan::SelectedConstraints::*;
+use crate::util::OpaquePointer;
+use crate::mmtk::MMTK;
+use crate::vm::VMBinding;
 
 pub trait CollectorContext<VM: VMBinding> {
     fn new(mmtk: &'static MMTK<VM>) -> Self;
@@ -20,8 +20,8 @@ pub trait CollectorContext<VM: VMBinding> {
 
     fn copy_check_allocator(&self, _from: ObjectReference, bytes: usize, align: usize,
                             allocator: Allocator) -> Allocator {
-        let large = ::util::alloc::allocator::get_maximum_aligned_size(bytes, align,
-            ::util::alloc::allocator::MIN_ALIGNMENT) > MAX_NON_LOS_COPY_BYTES;
+        let large = crate::util::alloc::allocator::get_maximum_aligned_size(bytes, align,
+            crate::util::alloc::allocator::MIN_ALIGNMENT) > MAX_NON_LOS_COPY_BYTES;
         if large { Allocator::Los } else { allocator }
     }
 

--- a/src/plan/controller_collector_context.rs
+++ b/src/plan/controller_collector_context.rs
@@ -4,13 +4,13 @@ use std::cell::UnsafeCell;
 use std::sync::{Mutex, Condvar};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use ::vm::Collection;
+use crate::vm::Collection;
 
-use ::plan::Plan;
-use ::plan::selected_plan::SelectedPlan;
+use crate::plan::Plan;
+use crate::plan::selected_plan::SelectedPlan;
 
-use util::OpaquePointer;
-use vm::VMBinding;
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
 
 struct RequestSync {
     tls: OpaquePointer,

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -1,7 +1,7 @@
-use ::plan::Phase;
-use ::util::{Address, ObjectReference};
-use ::plan::Allocator;
-use ::util::OpaquePointer;
+use crate::plan::Phase;
+use crate::util::{Address, ObjectReference};
+use crate::plan::Allocator;
+use crate::util::OpaquePointer;
 
 pub trait MutatorContext {
     fn collection_phase(&mut self, tls: OpaquePointer, phase: &Phase, primary: bool);

--- a/src/plan/nogc/nogc.rs
+++ b/src/plan/nogc/nogc.rs
@@ -1,28 +1,28 @@
-use ::policy::space::Space;
-use ::policy::immortalspace::ImmortalSpace;
-use ::policy::largeobjectspace::LargeObjectSpace;
-use ::plan::{Plan, Phase};
-use ::util::ObjectReference;
-use ::util::heap::VMRequest;
-use ::util::heap::layout::Mmapper as IMmapper;
-use ::util::Address;
-use ::util::OpaquePointer;
+use crate::policy::space::Space;
+use crate::policy::immortalspace::ImmortalSpace;
+use crate::policy::largeobjectspace::LargeObjectSpace;
+use crate::plan::{Plan, Phase};
+use crate::util::ObjectReference;
+use crate::util::heap::VMRequest;
+use crate::util::heap::layout::Mmapper as IMmapper;
+use crate::util::Address;
+use crate::util::OpaquePointer;
 
 use std::cell::UnsafeCell;
 
 use super::NoGCTraceLocal;
 use super::NoGCMutator;
 use super::NoGCCollector;
-use util::conversions::bytes_to_pages;
-use plan::plan::{create_vm_space, CommonPlan};
-use util::heap::layout::heap_layout::VMMap;
-use util::heap::layout::heap_layout::Mmapper;
-use util::options::UnsafeOptionsWrapper;
+use crate::util::conversions::bytes_to_pages;
+use crate::plan::plan::{create_vm_space, CommonPlan};
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::util::heap::layout::heap_layout::Mmapper;
+use crate::util::options::UnsafeOptionsWrapper;
 use std::sync::Arc;
-use util::heap::HeapMeta;
-use util::heap::layout::vm_layout_constants::{HEAP_START, HEAP_END};
+use crate::util::heap::HeapMeta;
+use crate::util::heap::layout::vm_layout_constants::{HEAP_START, HEAP_END};
 use std::sync::atomic::Ordering;
-use vm::VMBinding;
+use crate::vm::VMBinding;
 
 pub type SelectedPlan<VM> = NoGC<VM>;
 

--- a/src/plan/nogc/nogccollector.rs
+++ b/src/plan/nogc/nogccollector.rs
@@ -7,10 +7,10 @@ use super::super::Allocator;
 
 use std::process;
 
-use ::util::{Address, ObjectReference};
-use util::OpaquePointer;
-use mmtk::MMTK;
-use vm::VMBinding;
+use crate::util::{Address, ObjectReference};
+use crate::util::OpaquePointer;
+use crate::mmtk::MMTK;
+use crate::vm::VMBinding;
 
 pub struct NoGCCollector<VM: VMBinding> {
     pub tls: OpaquePointer,

--- a/src/plan/nogc/nogcconstraints.rs
+++ b/src/plan/nogc/nogcconstraints.rs
@@ -1,4 +1,4 @@
-pub use ::plan::plan_constraints::*;
+pub use crate::plan::plan_constraints::*;
 
 pub const GC_HEADER_BITS: usize = 0;
 pub const GC_HEADER_WORDS: usize = 0;

--- a/src/plan/nogc/nogcmutator.rs
+++ b/src/plan/nogc/nogcmutator.rs
@@ -1,14 +1,14 @@
-use ::policy::immortalspace::ImmortalSpace;
-use ::util::alloc::{BumpAllocator, LargeObjectAllocator};
-use ::plan::mutator_context::MutatorContext;
-use ::plan::Phase;
-use ::util::{Address, ObjectReference};
-use ::util::alloc::Allocator;
-use ::plan::Allocator as AllocationType;
-use ::util::heap::MonotonePageResource;
-use ::util::OpaquePointer;
-use plan::nogc::NoGC;
-use vm::VMBinding;
+use crate::policy::immortalspace::ImmortalSpace;
+use crate::util::alloc::{BumpAllocator, LargeObjectAllocator};
+use crate::plan::mutator_context::MutatorContext;
+use crate::plan::Phase;
+use crate::util::{Address, ObjectReference};
+use crate::util::alloc::Allocator;
+use crate::plan::Allocator as AllocationType;
+use crate::util::heap::MonotonePageResource;
+use crate::util::OpaquePointer;
+use crate::plan::nogc::NoGC;
+use crate::vm::VMBinding;
 
 #[repr(C)]
 pub struct NoGCMutator<VM: VMBinding> {

--- a/src/plan/nogc/nogctracelocal.rs
+++ b/src/plan/nogc/nogctracelocal.rs
@@ -1,7 +1,7 @@
-use ::plan::transitive_closure::TransitiveClosure;
-use ::util::address::{Address, ObjectReference};
-use ::plan::tracelocal::TraceLocal;
-use vm::VMBinding;
+use crate::plan::transitive_closure::TransitiveClosure;
+use crate::util::address::{Address, ObjectReference};
+use crate::plan::tracelocal::TraceLocal;
+use crate::vm::VMBinding;
 use std::marker::PhantomData;
 
 pub struct NoGCTraceLocal<VM: VMBinding> {

--- a/src/plan/parallel_collector.rs
+++ b/src/plan/parallel_collector.rs
@@ -1,7 +1,7 @@
 use super::ParallelCollectorGroup;
 use super::CollectorContext;
 use super::TraceLocal;
-use vm::VMBinding;
+use crate::vm::VMBinding;
 
 pub trait ParallelCollector<VM: VMBinding>: CollectorContext<VM> + Sized {
     type T: TraceLocal;

--- a/src/plan/parallel_collector_group.rs
+++ b/src/plan/parallel_collector_group.rs
@@ -1,13 +1,13 @@
 use std::vec::Vec;
 use std::sync::{Mutex, Condvar};
-use ::util::OpaquePointer;
+use crate::util::OpaquePointer;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::ParallelCollector;
-use ::vm::Collection;
+use crate::vm::Collection;
 
-use mmtk::MMTK;
-use vm::VMBinding;
+use crate::mmtk::MMTK;
+use crate::vm::VMBinding;
 use std::marker::PhantomData;
 
 pub struct ParallelCollectorGroup<VM: VMBinding, C: ParallelCollector<VM>> {

--- a/src/plan/phase.rs
+++ b/src/plan/phase.rs
@@ -1,17 +1,17 @@
-use ::plan;
-use ::plan::{CollectorContext, MutatorContext, ParallelCollector, Plan};
-use ::vm::ActivePlan;
+use crate::plan;
+use crate::plan::{CollectorContext, MutatorContext, ParallelCollector, Plan};
+use crate::vm::ActivePlan;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
-use util::statistics::phase_timer::PhaseTimer;
-use ::util::OpaquePointer;
-use util::statistics::{Counter, Timer};
-use util::statistics::stats::Stats;
-use plan::phase::Schedule::*;
-use plan::phase::Phase::*;
-use vm::VMBinding;
+use crate::util::statistics::phase_timer::PhaseTimer;
+use crate::util::OpaquePointer;
+use crate::util::statistics::{Counter, Timer};
+use crate::util::statistics::stats::Stats;
+use crate::plan::phase::Schedule::*;
+use crate::plan::phase::Phase::*;
+use crate::vm::VMBinding;
 
 #[derive(Clone)]
 #[derive(PartialEq)]

--- a/src/plan/plan.rs
+++ b/src/plan/plan.rs
@@ -1,24 +1,24 @@
-use ::util::ObjectReference;
+use crate::util::ObjectReference;
 use super::{MutatorContext, ParallelCollector, TraceLocal};
-use plan::phase::Phase;
+use crate::plan::phase::Phase;
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
-use ::util::OpaquePointer;
-use ::policy::space::Space;
-use ::util::heap::PageResource;
-use ::vm::{Collection, ObjectModel};
+use crate::util::OpaquePointer;
+use crate::policy::space::Space;
+use crate::util::heap::PageResource;
+use crate::vm::{Collection, ObjectModel};
 use super::controller_collector_context::ControllerCollectorContext;
-use util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
-use util::constants::LOG_BYTES_IN_MBYTE;
-use util::heap::{VMRequest, HeapMeta};
-use policy::immortalspace::ImmortalSpace;
-use util::{Address, conversions};
-use util::statistics::stats::Stats;
-use util::heap::layout::heap_layout::VMMap;
-use util::heap::layout::heap_layout::Mmapper;
-use util::heap::layout::Mmapper as IMmapper;
-use util::options::{Options, UnsafeOptionsWrapper};
+use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
+use crate::util::constants::LOG_BYTES_IN_MBYTE;
+use crate::util::heap::{VMRequest, HeapMeta};
+use crate::policy::immortalspace::ImmortalSpace;
+use crate::util::{Address, conversions};
+use crate::util::statistics::stats::Stats;
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::util::heap::layout::heap_layout::Mmapper;
+use crate::util::heap::layout::Mmapper as IMmapper;
+use crate::util::options::{Options, UnsafeOptionsWrapper};
 use std::sync::{Arc, Mutex};
-use vm::VMBinding;
+use crate::vm::VMBinding;
 
 // FIXME: Move somewhere more appropriate
 pub fn create_vm_space<VM: VMBinding>(vm_map: &'static VMMap, mmapper: &'static Mmapper, heap: &mut HeapMeta, boot_segment_bytes: usize) -> ImmortalSpace<VM> {

--- a/src/plan/plan_constraints.rs
+++ b/src/plan/plan_constraints.rs
@@ -2,7 +2,7 @@
 // the constants that get overwritten are unused.
 #![allow(unused)]
 
-use ::util::constants::*;
+use crate::util::constants::*;
 
 pub const MOVES_OBJECTS: bool = false;
 pub const NUM_SPECIALIZED_SCANS: usize = 0;

--- a/src/plan/semispace/ss.rs
+++ b/src/plan/semispace/ss.rs
@@ -1,36 +1,36 @@
-use ::policy::space::Space;
+use crate::policy::space::Space;
 
 use super::SSMutator;
 use super::SSTraceLocal;
 use super::SSCollector;
 
-use ::plan::plan;
-use ::plan::Plan;
-use ::plan::Allocator;
-use ::policy::copyspace::CopySpace;
-use ::policy::immortalspace::ImmortalSpace;
-use ::policy::largeobjectspace::LargeObjectSpace;
-use ::plan::Phase;
-use ::plan::trace::Trace;
-use ::util::ObjectReference;
-use ::util::heap::layout::Mmapper as IMmapper;
-use ::util::Address;
-use ::util::heap::VMRequest;
-use ::util::OpaquePointer;
+use crate::plan::plan;
+use crate::plan::Plan;
+use crate::plan::Allocator;
+use crate::policy::copyspace::CopySpace;
+use crate::policy::immortalspace::ImmortalSpace;
+use crate::policy::largeobjectspace::LargeObjectSpace;
+use crate::plan::Phase;
+use crate::plan::trace::Trace;
+use crate::util::ObjectReference;
+use crate::util::heap::layout::Mmapper as IMmapper;
+use crate::util::Address;
+use crate::util::heap::VMRequest;
+use crate::util::OpaquePointer;
 
 use std::cell::UnsafeCell;
 use std::sync::atomic::{self, Ordering};
 
-use ::vm::Scanning;
-use util::conversions::bytes_to_pages;
-use plan::plan::{create_vm_space, CommonPlan};
-use util::heap::layout::heap_layout::VMMap;
-use util::heap::layout::heap_layout::Mmapper;
-use util::options::UnsafeOptionsWrapper;
+use crate::vm::Scanning;
+use crate::util::conversions::bytes_to_pages;
+use crate::plan::plan::{create_vm_space, CommonPlan};
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::util::heap::layout::heap_layout::Mmapper;
+use crate::util::options::UnsafeOptionsWrapper;
 use std::sync::Arc;
-use util::heap::HeapMeta;
-use util::heap::layout::vm_layout_constants::{HEAP_START, HEAP_END};
-use vm::VMBinding;
+use crate::util::heap::HeapMeta;
+use crate::util::heap::layout::vm_layout_constants::{HEAP_START, HEAP_END};
+use crate::vm::VMBinding;
 
 pub type SelectedPlan<VM> = SemiSpace<VM>;
 
@@ -165,7 +165,7 @@ impl<VM: VMBinding> Plan<VM> for SemiSpace<VM> {
             Phase::Prepare => {
                 #[cfg(feature = "sanity")]
                 {
-                    use ::util::sanity::sanity_checker::SanityChecker;
+                    use crate::util::sanity::sanity_checker::SanityChecker;
                     println!("Pre GC sanity check");
                     SanityChecker::new(tls, &self).check();
                 }
@@ -198,9 +198,9 @@ impl<VM: VMBinding> Plan<VM> for SemiSpace<VM> {
             &Phase::Release => {
                 #[cfg(feature = "sanity")]
                 {
-                    use ::util::constants::LOG_BYTES_IN_PAGE;
+                    use crate::util::constants::LOG_BYTES_IN_PAGE;
                     use libc::memset;
-                    use ::util::heap::PageResource;
+                    use crate::util::heap::PageResource;
                     if self.fromspace().common().contiguous {
                         let fromspace_start = self.fromspace().common().start;
                         let fromspace_commited = self.fromspace().common().pr.as_ref().unwrap().common().committed.load(Ordering::Relaxed);
@@ -226,8 +226,8 @@ impl<VM: VMBinding> Plan<VM> for SemiSpace<VM> {
             Phase::Complete => {
                 #[cfg(feature = "sanity")]
                 {
-                    use ::util::sanity::sanity_checker::SanityChecker;
-                    use ::util::sanity::memory_scan;
+                    use crate::util::sanity::sanity_checker::SanityChecker;
+                    use crate::util::sanity::memory_scan;
                     println!("Post GC sanity check");
                     SanityChecker::new(tls, &self).check();
                     println!("Post GC memory scan");

--- a/src/plan/semispace/sscollector.rs
+++ b/src/plan/semispace/sscollector.rs
@@ -1,25 +1,25 @@
-use ::plan::{phase, Phase};
-use ::plan::Allocator as AllocationType;
-use ::plan::CollectorContext;
-use ::plan::ParallelCollector;
-use ::plan::ParallelCollectorGroup;
-use ::plan::TraceLocal;
-use ::plan::phase::PhaseManager;
-use ::policy::copyspace::CopySpace;
-use ::util::{Address, ObjectReference};
-use ::util::alloc::Allocator;
-use ::util::alloc::{BumpAllocator, LargeObjectAllocator};
-use ::util::forwarding_word::clear_forwarding_bits;
-use ::util::heap::MonotonePageResource;
-use ::util::reference_processor::*;
-use ::vm::Scanning;
+use crate::plan::{phase, Phase};
+use crate::plan::Allocator as AllocationType;
+use crate::plan::CollectorContext;
+use crate::plan::ParallelCollector;
+use crate::plan::ParallelCollectorGroup;
+use crate::plan::TraceLocal;
+use crate::plan::phase::PhaseManager;
+use crate::policy::copyspace::CopySpace;
+use crate::util::{Address, ObjectReference};
+use crate::util::alloc::Allocator;
+use crate::util::alloc::{BumpAllocator, LargeObjectAllocator};
+use crate::util::forwarding_word::clear_forwarding_bits;
+use crate::util::heap::MonotonePageResource;
+use crate::util::reference_processor::*;
+use crate::vm::Scanning;
 use super::sstracelocal::SSTraceLocal;
-use ::plan::selected_plan::SelectedConstraints;
-use util::OpaquePointer;
-use plan::semispace::SemiSpace;
-use plan::phase::ScheduledPhase;
-use mmtk::MMTK;
-use vm::VMBinding;
+use crate::plan::selected_plan::SelectedConstraints;
+use crate::util::OpaquePointer;
+use crate::plan::semispace::SemiSpace;
+use crate::plan::phase::ScheduledPhase;
+use crate::mmtk::MMTK;
+use crate::vm::VMBinding;
 
 /// per-collector thread behavior and state for the SS plan
 pub struct SSCollector<VM: VMBinding> {
@@ -65,7 +65,7 @@ impl<VM: VMBinding> CollectorContext<VM> for SSCollector<VM> {
     fn alloc_copy(&mut self, _original: ObjectReference, bytes: usize, align: usize, offset: isize,
                   allocator: AllocationType) -> Address {
         match allocator {
-            ::plan::Allocator::Los => self.los.alloc(bytes, align, offset),
+            crate::plan::Allocator::Los => self.los.alloc(bytes, align, offset),
             _ => self.ss.alloc(bytes, align, offset)
         }
 
@@ -152,11 +152,11 @@ impl<VM: VMBinding> CollectorContext<VM> for SSCollector<VM> {
         self.tls
     }
 
-    fn post_copy(&self, object: ObjectReference, _rvm_type: Address, _bytes: usize, allocator: ::plan::Allocator) {
+    fn post_copy(&self, object: ObjectReference, _rvm_type: Address, _bytes: usize, allocator: crate::plan::Allocator) {
         clear_forwarding_bits::<VM>(object);
         match allocator {
-            ::plan::Allocator::Default => {}
-            ::plan::Allocator::Los => {
+            crate::plan::Allocator::Default => {}
+            crate::plan::Allocator::Los => {
                 self.los.get_space().unwrap().initialize_header(object, false);
             }
             _ => {

--- a/src/plan/semispace/ssconstraints.rs
+++ b/src/plan/semispace/ssconstraints.rs
@@ -1,5 +1,5 @@
 //pub use ::plan::plan_constraints::{NEEDS_LOG_BIT_IN_HEADER, NEEDS_LOG_BIT_IN_HEADER_NUM};
-pub use ::plan::plan_constraints::*;
+pub use crate::plan::plan_constraints::*;
 
 pub const MOVES_OBJECTS: bool = true;
 pub const GC_HEADER_BITS: usize = 2;

--- a/src/plan/semispace/ssmutator.rs
+++ b/src/plan/semispace/ssmutator.rs
@@ -1,17 +1,17 @@
-use ::policy::copyspace::CopySpace;
-use ::policy::immortalspace::ImmortalSpace;
-use ::util::alloc::{BumpAllocator, LargeObjectAllocator};
-use ::plan::mutator_context::MutatorContext;
-use ::plan::Phase;
-use ::util::{Address, ObjectReference};
-use ::util::alloc::Allocator;
-use ::plan::Allocator as AllocationType;
-use ::vm::Collection;
-use ::util::heap::MonotonePageResource;
-use ::util::OpaquePointer;
+use crate::policy::copyspace::CopySpace;
+use crate::policy::immortalspace::ImmortalSpace;
+use crate::util::alloc::{BumpAllocator, LargeObjectAllocator};
+use crate::plan::mutator_context::MutatorContext;
+use crate::plan::Phase;
+use crate::util::{Address, ObjectReference};
+use crate::util::alloc::Allocator;
+use crate::plan::Allocator as AllocationType;
+use crate::vm::Collection;
+use crate::util::heap::MonotonePageResource;
+use crate::util::OpaquePointer;
 
-use plan::semispace::SemiSpace;
-use vm::VMBinding;
+use crate::plan::semispace::SemiSpace;
+use crate::vm::VMBinding;
 
 #[repr(C)]
 pub struct SSMutator<VM: VMBinding> {

--- a/src/plan/semispace/sstracelocal.rs
+++ b/src/plan/semispace/sstracelocal.rs
@@ -1,12 +1,12 @@
-use ::plan::{TraceLocal, TransitiveClosure};
-use ::policy::space::Space;
-use ::util::{Address, ObjectReference};
-use ::util::queue::LocalQueue;
-use ::vm::Scanning;
+use crate::plan::{TraceLocal, TransitiveClosure};
+use crate::policy::space::Space;
+use crate::util::{Address, ObjectReference};
+use crate::util::queue::LocalQueue;
+use crate::vm::Scanning;
 use super::ss;
-use util::OpaquePointer;
-use plan::semispace::SemiSpace;
-use vm::VMBinding;
+use crate::util::OpaquePointer;
+use crate::plan::semispace::SemiSpace;
+use crate::vm::VMBinding;
 
 pub struct SSTraceLocal<VM: VMBinding> {
     tls: OpaquePointer,

--- a/src/plan/trace.rs
+++ b/src/plan/trace.rs
@@ -1,5 +1,5 @@
-use ::util::{Address, ObjectReference};
-use ::util::queue::SharedQueue;
+use crate::util::{Address, ObjectReference};
+use crate::util::queue::SharedQueue;
 
 pub struct Trace {
     pub values: SharedQueue<ObjectReference>,

--- a/src/plan/tracelocal.rs
+++ b/src/plan/tracelocal.rs
@@ -1,5 +1,5 @@
-use ::plan::TransitiveClosure;
-use ::util::{ObjectReference, Address};
+use crate::plan::TransitiveClosure;
+use crate::util::{ObjectReference, Address};
 
 pub trait TraceLocal: TransitiveClosure {
     fn process_roots(&mut self);

--- a/src/plan/transitive_closure.rs
+++ b/src/plan/transitive_closure.rs
@@ -1,4 +1,4 @@
-use ::util::{Address, ObjectReference};
+use crate::util::{Address, ObjectReference};
 
 pub trait TransitiveClosure {
     // The signature of this function changes during the port

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -1,20 +1,20 @@
-use ::util::heap::PageResource;
-use ::util::heap::MonotonePageResource;
-use ::util::heap::VMRequest;
-use ::util::constants::CARD_META_PAGES_PER_REGION;
-use ::util::OpaquePointer;
-use ::policy::space::{Space, CommonSpace};
-use ::util::{Address, ObjectReference};
-use ::plan::TransitiveClosure;
-use ::util::forwarding_word as ForwardingWord;
-use ::plan::Allocator;
+use crate::util::heap::PageResource;
+use crate::util::heap::MonotonePageResource;
+use crate::util::heap::VMRequest;
+use crate::util::constants::CARD_META_PAGES_PER_REGION;
+use crate::util::OpaquePointer;
+use crate::policy::space::{Space, CommonSpace};
+use crate::util::{Address, ObjectReference};
+use crate::plan::TransitiveClosure;
+use crate::util::forwarding_word as ForwardingWord;
+use crate::plan::Allocator;
 
 use std::cell::UnsafeCell;
 use libc::{mprotect, PROT_NONE, PROT_EXEC, PROT_WRITE, PROT_READ};
-use util::heap::layout::heap_layout::{VMMap, Mmapper};
-use util::heap::HeapMeta;
-use vm::VMBinding;
-use policy::space::SpaceOptions;
+use crate::util::heap::layout::heap_layout::{VMMap, Mmapper};
+use crate::util::heap::HeapMeta;
+use crate::vm::VMBinding;
+use crate::policy::space::SpaceOptions;
 
 const META_DATA_PAGES_PER_REGION: usize = CARD_META_PAGES_PER_REGION;
 

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -1,19 +1,19 @@
-use ::policy::space::{Space, CommonSpace};
-use ::util::heap::{PageResource, MonotonePageResource, VMRequest};
-use ::util::address::Address;
+use crate::policy::space::{Space, CommonSpace};
+use crate::util::heap::{PageResource, MonotonePageResource, VMRequest};
+use crate::util::address::Address;
 
-use ::util::ObjectReference;
-use ::util::constants::CARD_META_PAGES_PER_REGION;
+use crate::util::ObjectReference;
+use crate::util::constants::CARD_META_PAGES_PER_REGION;
 
-use ::vm::ObjectModel;
-use ::plan::TransitiveClosure;
-use ::util::header_byte;
+use crate::vm::ObjectModel;
+use crate::plan::TransitiveClosure;
+use crate::util::header_byte;
 
 use std::cell::UnsafeCell;
-use util::heap::layout::heap_layout::{VMMap, Mmapper};
-use util::heap::HeapMeta;
-use vm::VMBinding;
-use policy::space::SpaceOptions;
+use crate::util::heap::layout::heap_layout::{VMMap, Mmapper};
+use crate::util::heap::HeapMeta;
+use crate::vm::VMBinding;
+use crate::policy::space::SpaceOptions;
 
 pub struct ImmortalSpace<VM: VMBinding> {
     common: UnsafeCell<CommonSpace<VM, MonotonePageResource<VM, ImmortalSpace<VM>>>>,

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -1,19 +1,19 @@
 use std::cell::UnsafeCell;
 
-use ::plan::TransitiveClosure;
-use ::policy::space::{CommonSpace, Space};
-use ::util::{Address, ObjectReference};
-use ::util::constants::{BYTES_IN_PAGE, LOG_BYTES_IN_WORD};
-use ::util::header_byte;
-use ::util::heap::{FreeListPageResource, PageResource, VMRequest};
-use ::util::treadmill::TreadMill;
-use ::vm::ObjectModel;
-use util::heap::layout::heap_layout::{VMMap, Mmapper};
-use util::heap::HeapMeta;
+use crate::plan::TransitiveClosure;
+use crate::policy::space::{CommonSpace, Space};
+use crate::util::{Address, ObjectReference};
+use crate::util::constants::{BYTES_IN_PAGE, LOG_BYTES_IN_WORD};
+use crate::util::header_byte;
+use crate::util::heap::{FreeListPageResource, PageResource, VMRequest};
+use crate::util::treadmill::TreadMill;
+use crate::vm::ObjectModel;
+use crate::util::heap::layout::heap_layout::{VMMap, Mmapper};
+use crate::util::heap::HeapMeta;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use util::OpaquePointer;
-use vm::VMBinding;
-use policy::space::SpaceOptions;
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
+use crate::policy::space::SpaceOptions;
 
 #[allow(unused)]
 const PAGE_MASK: usize = !(BYTES_IN_PAGE - 1);

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -1,25 +1,25 @@
-use ::util::Address;
-use ::util::ObjectReference;
-use ::util::conversions::*;
+use crate::util::Address;
+use crate::util::ObjectReference;
+use crate::util::conversions::*;
 
-use ::vm::{ActivePlan, Collection, ObjectModel};
-use ::util::heap::{VMRequest, PageResource};
-use ::util::heap::layout::vm_layout_constants::{AVAILABLE_BYTES, LOG_BYTES_IN_CHUNK};
-use ::util::heap::layout::vm_layout_constants::{AVAILABLE_START, AVAILABLE_END};
+use crate::vm::{ActivePlan, Collection, ObjectModel};
+use crate::util::heap::{VMRequest, PageResource};
+use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_BYTES, LOG_BYTES_IN_CHUNK};
+use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_START, AVAILABLE_END};
 
-use ::plan::Plan;
+use crate::plan::Plan;
 
-use ::util::constants::LOG_BYTES_IN_MBYTE;
-use ::util::conversions;
-use ::util::OpaquePointer;
+use crate::util::constants::LOG_BYTES_IN_MBYTE;
+use crate::util::conversions;
+use crate::util::OpaquePointer;
 
-use util::heap::layout::heap_layout::VMMap;
-use util::heap::layout::heap_layout::Mmapper;
-use util::heap::HeapMeta;
-use util::heap::space_descriptor::SpaceDescriptor;
-use vm::VMBinding;
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::util::heap::layout::heap_layout::Mmapper;
+use crate::util::heap::HeapMeta;
+use crate::util::heap::space_descriptor::SpaceDescriptor;
+use crate::vm::VMBinding;
 use std::marker::PhantomData;
-use util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
+use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
 
 pub trait Space<VM: VMBinding>: Sized + 'static {
     type PR: PageResource<VM, Space = Self>;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -221,20 +221,20 @@ impl Address {
     /// aligns up the address to the given alignment
     #[inline(always)]
     pub const fn align_up(self, align: ByteSize) -> Address {
-        use util::conversions;
+        use crate::util::conversions;
         Address(conversions::raw_align_up(self.0, align))
     }
 
     /// aligns down the address to the given alignment
     #[inline(always)]
     pub const fn align_down(self, align: ByteSize) -> Address {
-        use util::conversions;
+        use crate::util::conversions;
         Address(conversions::raw_align_down(self.0, align))
     }
 
     /// is this address aligned to the given alignment
     pub fn is_aligned_to(self, align: usize) -> bool {
-        use util::conversions;
+        use crate::util::conversions;
         conversions::raw_is_aligned(self.0, align)
     }
 
@@ -296,7 +296,7 @@ impl fmt::Debug for Address {
 
 #[cfg(test)]
 mod tests {
-    use util::Address;
+    use crate::util::Address;
 
     #[test]
     fn align_up() {

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -1,14 +1,14 @@
-use ::util::address::Address;
+use crate::util::address::Address;
 
 use std::sync::atomic::Ordering;
 
-use ::util::constants::*;
-use ::util::heap::PageResource;
-use ::vm::{ActivePlan, Collection};
-use ::plan::selected_plan::SelectedPlan;
-use ::plan::Plan;
-use ::util::OpaquePointer;
-use vm::VMBinding;
+use crate::util::constants::*;
+use crate::util::heap::PageResource;
+use crate::vm::{ActivePlan, Collection};
+use crate::plan::selected_plan::SelectedPlan;
+use crate::plan::Plan;
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
 
 // FIXME: Put this somewhere more appropriate
 pub const ALIGNMENT_VALUE: usize = 0xdead_beef;

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -1,18 +1,18 @@
-use ::util::{Address, ObjectReference};
+use crate::util::{Address, ObjectReference};
 use super::allocator::{align_allocation_no_fill, fill_alignment_gap};
 
-use ::util::alloc::Allocator;
-use ::util::heap::PageResource;
-use ::util::alloc::linear_scan::LinearScan;
-use ::util::alloc::dump_linear_scan::DumpLinearScan;
+use crate::util::alloc::Allocator;
+use crate::util::heap::PageResource;
+use crate::util::alloc::linear_scan::LinearScan;
+use crate::util::alloc::dump_linear_scan::DumpLinearScan;
 
-use ::vm::ObjectModel;
+use crate::vm::ObjectModel;
 
-use ::policy::space::Space;
-use util::conversions::bytes_to_pages;
-use ::util::OpaquePointer;
-use ::plan::selected_plan::SelectedPlan;
-use vm::VMBinding;
+use crate::policy::space::Space;
+use crate::util::conversions::bytes_to_pages;
+use crate::util::OpaquePointer;
+use crate::plan::selected_plan::SelectedPlan;
+use crate::vm::VMBinding;
 
 const BYTES_IN_PAGE: usize = 1 << 12;
 const BLOCK_SIZE: usize = 8 * BYTES_IN_PAGE;

--- a/src/util/alloc/dump_linear_scan.rs
+++ b/src/util/alloc/dump_linear_scan.rs
@@ -1,8 +1,8 @@
-use ::util::alloc::linear_scan::LinearScan;
-use ::util::ObjectReference;
+use crate::util::alloc::linear_scan::LinearScan;
+use crate::util::ObjectReference;
 
-use ::vm::ObjectModel;
-use vm::VMBinding;
+use crate::vm::ObjectModel;
+use crate::vm::VMBinding;
 
 pub struct DumpLinearScan {}
 

--- a/src/util/alloc/embedded_meta_data.rs
+++ b/src/util/alloc/embedded_meta_data.rs
@@ -1,5 +1,5 @@
-use ::util::constants::LOG_BYTES_IN_PAGE;
-use ::util::Address;
+use crate::util::constants::LOG_BYTES_IN_PAGE;
+use crate::util::Address;
 
 /* The (log of the) size of each region of meta data management */
 pub const LOG_BYTES_IN_REGION: usize = 22;

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -1,10 +1,10 @@
-use ::policy::largeobjectspace::LargeObjectSpace;
-use ::util::Address;
-use ::util::alloc::{allocator, Allocator};
-use ::util::heap::FreeListPageResource;
-use ::util::OpaquePointer;
-use ::plan::selected_plan::SelectedPlan;
-use vm::VMBinding;
+use crate::policy::largeobjectspace::LargeObjectSpace;
+use crate::util::Address;
+use crate::util::alloc::{allocator, Allocator};
+use crate::util::heap::FreeListPageResource;
+use crate::util::OpaquePointer;
+use crate::plan::selected_plan::SelectedPlan;
+use crate::vm::VMBinding;
 
 #[repr(C)]
 pub struct LargeObjectAllocator<VM: VMBinding> {
@@ -37,7 +37,7 @@ impl<VM: VMBinding> Allocator<VM, FreeListPageResource<VM, LargeObjectSpace<VM>>
     fn alloc_slow_once(&mut self, size: usize, align: usize, _offset: isize) -> Address {
         let header = 0; // HashSet is used instead of DoublyLinkedList
         let maxbytes = allocator::get_maximum_aligned_size(size + header, align, allocator::MIN_ALIGNMENT);
-        let pages = ::util::conversions::bytes_to_pages_up(maxbytes);
+        let pages = crate::util::conversions::bytes_to_pages_up(maxbytes);
         let sp = self.space.unwrap().allocate_pages(self.tls, pages);
         if sp.is_zero() {
             sp

--- a/src/util/alloc/linear_scan.rs
+++ b/src/util/alloc/linear_scan.rs
@@ -1,5 +1,5 @@
-use ::util::ObjectReference;
-use vm::VMBinding;
+use crate::util::ObjectReference;
+use crate::vm::VMBinding;
 
 pub trait LinearScan{
     fn scan<VM: VMBinding>(&self, object: ObjectReference);

--- a/src/util/constants.rs
+++ b/src/util/constants.rs
@@ -1,5 +1,5 @@
-use ::vm::unboxed_size_constants;
-use ::util::alloc::embedded_meta_data::LOG_BYTES_IN_REGION;
+use crate::vm::unboxed_size_constants;
+use crate::util::alloc::embedded_meta_data::LOG_BYTES_IN_REGION;
 
 /**
    * Modes.

--- a/src/util/conversions.rs
+++ b/src/util/conversions.rs
@@ -1,6 +1,6 @@
-use ::util::Address;
-use ::util::heap::layout::vm_layout_constants::*;
-use ::util::constants::*;
+use crate::util::Address;
+use crate::util::heap::layout::vm_layout_constants::*;
+use crate::util::constants::*;
 
 /* Alignment */
 
@@ -66,8 +66,8 @@ pub fn bytes_to_pages(bytes: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use util::Address;
-    use util::conversions::*;
+    use crate::util::Address;
+    use crate::util::conversions::*;
 
     #[test]
     fn test_page_align() {

--- a/src/util/forwarding_word.rs
+++ b/src/util/forwarding_word.rs
@@ -1,11 +1,11 @@
 /// https://github.com/JikesRVM/JikesRVM/blob/master/MMTk/src/org/mmtk/utility/ForwardingWord.java
-use ::util::{Address, ObjectReference};
-use ::vm::ObjectModel;
-use ::util::OpaquePointer;
+use crate::util::{Address, ObjectReference};
+use crate::vm::ObjectModel;
+use crate::util::OpaquePointer;
 use std::sync::atomic::Ordering;
 
-use ::plan::Allocator;
-use vm::VMBinding;
+use crate::plan::Allocator;
+use crate::vm::VMBinding;
 
 // ...00
 const FORWARDING_NOT_TRIGGERED_YET: u8 = 0;

--- a/src/util/header_byte.rs
+++ b/src/util/header_byte.rs
@@ -1,7 +1,7 @@
-use ::plan::SelectedConstraints;
-use ::util::ObjectReference;
-use ::vm::ObjectModel;
-use vm::VMBinding;
+use crate::plan::SelectedConstraints;
+use crate::util::ObjectReference;
+use crate::vm::ObjectModel;
+use crate::vm::VMBinding;
 
 pub const TOTAL_BITS: usize = 8;
 pub const NEEDS_UNLOGGED_BIT: bool = SelectedConstraints::NEEDS_LOG_BIT_IN_HEADER;

--- a/src/util/heap/freelistpageresource.rs
+++ b/src/util/heap/freelistpageresource.rs
@@ -3,24 +3,24 @@ use std::sync::atomic::AtomicUsize;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::Ordering;
 
-use util::address::Address;
-use util::heap::pageresource::CommonPageResource;
-use util::alloc::embedded_meta_data::*;
-use util::{generic_freelist, memory};
-use util::generic_freelist::GenericFreeList;
+use crate::util::address::Address;
+use crate::util::heap::pageresource::CommonPageResource;
+use crate::util::alloc::embedded_meta_data::*;
+use crate::util::{generic_freelist, memory};
+use crate::util::generic_freelist::GenericFreeList;
 // #[cfg(target_pointer_width = "32")]
 // FIXME: Use `RawMemoryFreeList` for 64-bit machines
-use util::int_array_freelist::IntArrayFreeList as FreeList;
-use util::heap::layout::vm_layout_constants::*;
-use util::conversions;
-use util::constants::*;
-use util::OpaquePointer;
-use policy::space::Space;
+use crate::util::int_array_freelist::IntArrayFreeList as FreeList;
+use crate::util::heap::layout::vm_layout_constants::*;
+use crate::util::conversions;
+use crate::util::constants::*;
+use crate::util::OpaquePointer;
+use crate::policy::space::Space;
 use super::vmrequest::HEAP_LAYOUT_64BIT;
 use super::layout::Mmapper;
 use super::PageResource;
-use util::heap::layout::heap_layout::VMMap;
-use vm::VMBinding;
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::vm::VMBinding;
 use std::mem::MaybeUninit;
 
 pub struct CommonFreeListPageResource {
@@ -183,7 +183,7 @@ impl<VM: VMBinding, S: Space<VM, PR = FreeListPageResource<VM, S>>> FreeListPage
     fn allocate_contiguous_chunks(&mut self, pages: usize, sync: &mut MutexGuard<FreeListPageResourceSync>) -> i32 {
         debug_assert!(self.meta_data_pages_per_region == 0 || pages <= PAGES_IN_CHUNK - self.meta_data_pages_per_region);
         let mut rtn = generic_freelist::FAILURE;
-        let required_chunks = ::policy::space::required_chunks(pages);
+        let required_chunks = crate::policy::space::required_chunks(pages);
         let region = unsafe {
             self.common.space.unwrap().grow_discontiguous_space(required_chunks)
         };

--- a/src/util/heap/heap_meta.rs
+++ b/src/util/heap/heap_meta.rs
@@ -1,4 +1,4 @@
-use util::Address;
+use crate::util::Address;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 

--- a/src/util/heap/layout/byte_map_mmapper.rs
+++ b/src/util/heap/layout/byte_map_mmapper.rs
@@ -1,18 +1,18 @@
 use super::Mmapper;
-use ::util::Address;
+use crate::util::Address;
 
-use ::util::constants::*;
+use crate::util::constants::*;
 use std::fmt;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
-use util::heap::layout::vm_layout_constants::*;
-use util::conversions::pages_to_bytes;
+use crate::util::heap::layout::vm_layout_constants::*;
+use crate::util::conversions::pages_to_bytes;
 
 use super::mmapper::MMAP_CHUNK_BYTES;
 
 use std::mem::transmute;
-use util::memory::{dzmmap, munprotect, mprotect};
+use crate::util::memory::{dzmmap, munprotect, mprotect};
 
 const UNMAPPED: u8 = 0;
 const MAPPED: u8 = 1;
@@ -176,14 +176,14 @@ impl Default for ByteMapMmapper {
 
 #[cfg(test)]
 mod tests {
-    use util::heap::layout::{ByteMapMmapper, Mmapper};
-    use util::{Address, conversions};
-    use util::heap::layout::vm_layout_constants::HEAP_START;
-    use util::conversions::pages_to_bytes;
+    use crate::util::heap::layout::{ByteMapMmapper, Mmapper};
+    use crate::util::{Address, conversions};
+    
+    use crate::util::conversions::pages_to_bytes;
     use std::sync::atomic::Ordering;
-    use util::heap::layout::byte_map_mmapper::{MAPPED, PROTECTED};
-    use util::heap::layout::mmapper::MMAP_CHUNK_BYTES;
-    use util::constants::LOG_BYTES_IN_PAGE;
+    use crate::util::heap::layout::byte_map_mmapper::{MAPPED, PROTECTED};
+    use crate::util::heap::layout::mmapper::MMAP_CHUNK_BYTES;
+    use crate::util::constants::LOG_BYTES_IN_PAGE;
 
     const MEGABYTE: usize = 1 << 20;
     #[cfg(target_os="linux")]

--- a/src/util/heap/layout/heap_layout.rs
+++ b/src/util/heap/layout/heap_layout.rs
@@ -1,5 +1,5 @@
-use util::heap::layout::ByteMapMmapper;
-use util::heap::layout::map32::Map32;
+use crate::util::heap::layout::ByteMapMmapper;
+use crate::util::heap::layout::map32::Map32;
 
 // FIXME: Use FragmentMmapper for 64-bit heaps
 // FIXME: Use Map64 for 64-bit heaps

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -1,13 +1,13 @@
-use ::util::conversions;
-use ::util::heap::layout::vm_layout_constants::*;
-use ::util::heap::layout::heap_parameters::*;
-use ::util::Address;
-use ::util::int_array_freelist::IntArrayFreeList;
-use ::util::heap::freelistpageresource::CommonFreeListPageResource;
+use crate::util::conversions;
+use crate::util::heap::layout::vm_layout_constants::*;
+use crate::util::heap::layout::heap_parameters::*;
+use crate::util::Address;
+use crate::util::int_array_freelist::IntArrayFreeList;
+use crate::util::heap::freelistpageresource::CommonFreeListPageResource;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use ::util::generic_freelist::GenericFreeList;
-use util::heap::space_descriptor::SpaceDescriptor;
+use crate::util::generic_freelist::GenericFreeList;
+use crate::util::heap::space_descriptor::SpaceDescriptor;
 
 #[cfg(target_pointer_width = "32")]
 const MAP_BASE_ADDRESS: Address = Address::ZERO;

--- a/src/util/heap/layout/mmapper.rs
+++ b/src/util/heap/layout/mmapper.rs
@@ -1,5 +1,5 @@
-use ::util::Address;
-use ::util::heap::layout::vm_layout_constants::*;
+use crate::util::Address;
+use crate::util::heap::layout::vm_layout_constants::*;
 
 pub const MMAP_CHUNK_BYTES: usize = 1 << LOG_MMAP_CHUNK_BYTES;   // the granularity VMResource operates at
 #[allow(unused)]

--- a/src/util/heap/layout/vm_layout_constants.rs
+++ b/src/util/heap/layout/vm_layout_constants.rs
@@ -1,10 +1,10 @@
-use ::util::Address;
-use ::util::constants::*;
+use crate::util::Address;
+use crate::util::constants::*;
 use super::heap_parameters::*;
 
 ///////// FIXME ////////////
 use super::super::vmrequest::{HEAP_LAYOUT_32BIT, HEAP_LAYOUT_64BIT};
-use util::conversions::{chunk_align_down, chunk_align_up};
+use crate::util::conversions::{chunk_align_down, chunk_align_up};
 
 /** log_2 of the addressable virtual space */
 pub const LOG_ADDRESS_SPACE: usize = if_then_else_usize!(HEAP_LAYOUT_32BIT, 32,

--- a/src/util/heap/monotonepageresource.rs
+++ b/src/util/heap/monotonepageresource.rs
@@ -1,16 +1,16 @@
 use std::sync::{Mutex, MutexGuard};
 use std::sync::atomic::AtomicUsize;
-use ::util::address::Address;
-use ::util::conversions::*;
-use ::policy::space::Space;
-use ::policy::space::required_chunks;
+use crate::util::address::Address;
+use crate::util::conversions::*;
+use crate::policy::space::Space;
+use crate::policy::space::required_chunks;
 use super::vmrequest::HEAP_LAYOUT_64BIT;
 use super::layout::vm_layout_constants::BYTES_IN_CHUNK;
 
-use ::util::heap::pageresource::CommonPageResource;
-use ::util::heap::layout::vm_layout_constants::LOG_BYTES_IN_CHUNK;
-use ::util::alloc::embedded_meta_data::*;
-use ::util::OpaquePointer;
+use crate::util::heap::pageresource::CommonPageResource;
+use crate::util::heap::layout::vm_layout_constants::LOG_BYTES_IN_CHUNK;
+use crate::util::alloc::embedded_meta_data::*;
+use crate::util::OpaquePointer;
 
 use super::layout::Mmapper;
 
@@ -18,8 +18,8 @@ use super::PageResource;
 use std::sync::atomic::Ordering;
 
 use libc::{c_void, memset};
-use util::heap::layout::heap_layout::VMMap;
-use vm::VMBinding;
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::vm::VMBinding;
 
 pub struct MonotonePageResource<VM: VMBinding, S: Space<VM, PR = MonotonePageResource<VM, S>>> {
     common: CommonPageResource<VM, MonotonePageResource<VM, S>>,
@@ -282,8 +282,8 @@ impl<VM: VMBinding, S: Space<VM, PR = MonotonePageResource<VM, S>>> MonotonePage
     }
 
     fn release_pages_extent(&self, _first: Address, bytes: usize) {
-        let pages = ::util::conversions::bytes_to_pages(bytes);
-        debug_assert!(bytes == ::util::conversions::pages_to_bytes(pages));
+        let pages = crate::util::conversions::bytes_to_pages(bytes);
+        debug_assert!(bytes == crate::util::conversions::pages_to_bytes(pages));
         // FIXME ZERO_PAGES_ON_RELEASE
         // FIXME Options.protectOnRelease
         // FIXME VM.events.tracePageReleased

--- a/src/util/heap/pageresource.rs
+++ b/src/util/heap/pageresource.rs
@@ -1,12 +1,12 @@
-use ::util::address::Address;
-use ::policy::space::Space;
-use ::vm::ActivePlan;
-use ::util::OpaquePointer;
+use crate::util::address::Address;
+use crate::policy::space::Space;
+use crate::vm::ActivePlan;
+use crate::util::OpaquePointer;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use util::heap::layout::heap_layout::VMMap;
-use vm::VMBinding;
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::vm::VMBinding;
 
 pub trait PageResource<VM: VMBinding>: Sized + 'static {
     type Space: Space<VM, PR = Self>;

--- a/src/util/heap/space_descriptor.rs
+++ b/src/util/heap/space_descriptor.rs
@@ -1,8 +1,8 @@
-use util::Address;
-use util::heap::layout::vm_layout_constants;
-use util::heap::layout::heap_parameters;
+use crate::util::Address;
+use crate::util::heap::layout::vm_layout_constants;
+use crate::util::heap::layout::heap_parameters;
 use super::vmrequest::HEAP_LAYOUT_64BIT;
-use util::constants::*;
+use crate::util::constants::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 

--- a/src/util/heap/vmrequest.rs
+++ b/src/util/heap/vmrequest.rs
@@ -1,5 +1,5 @@
-use ::util::Address;
-use ::util::constants::*;
+use crate::util::Address;
+use crate::util::constants::*;
 use super::layout::vm_layout_constants::*;
 
 ////////// FIXME //////////////

--- a/src/util/int_array_freelist.rs
+++ b/src/util/int_array_freelist.rs
@@ -77,7 +77,7 @@ impl IntArrayFreeList {
 mod tests {
     use super::*;
     use super::GenericFreeList;
-    use std::fmt::Debug;
+    
 
     const LIST_SIZE: usize = 5;
     const TOP_SENTINEL: i32 = -1;
@@ -351,9 +351,9 @@ mod tests {
 
     #[test]
     fn multi_heads_alloc_free() {
-        let mut parent = IntArrayFreeList::new(LIST_SIZE, 1, 2);
+        let parent = IntArrayFreeList::new(LIST_SIZE, 1, 2);
         let mut child1 = IntArrayFreeList::from_parent(&parent, 0);
-        let mut child2 = IntArrayFreeList::from_parent(&parent, 1);
+        let child2 = IntArrayFreeList::from_parent(&parent, 1);
 
         // child1 alloc
         let res = child1.alloc(1);
@@ -372,9 +372,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn multi_heads_exceed_heads() {
-        let mut parent = IntArrayFreeList::new(LIST_SIZE, 1, 2);
-        let mut child1 = IntArrayFreeList::from_parent(&parent, 0);
-        let mut child2 = IntArrayFreeList::from_parent(&parent, 1);
-        let mut child3 = IntArrayFreeList::from_parent(&parent, 2);
+        let parent = IntArrayFreeList::new(LIST_SIZE, 1, 2);
+        let _child1 = IntArrayFreeList::from_parent(&parent, 0);
+        let _child2 = IntArrayFreeList::from_parent(&parent, 1);
+        let _child3 = IntArrayFreeList::from_parent(&parent, 2);
     }
 }

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -1,4 +1,4 @@
-use util::Address;
+use crate::util::Address;
 use std::io::{Result, Error};
 use libc::{PROT_READ, PROT_WRITE, PROT_EXEC, PROT_NONE, c_void};
 

--- a/src/util/opaque_pointer.rs
+++ b/src/util/opaque_pointer.rs
@@ -1,5 +1,5 @@
 use libc::c_void;
-use ::util::Address;
+use crate::util::Address;
 
 // This is mainly used to represent TLS.
 // OpaquePointer does not provide any method for dereferencing, as we should not dereference it in MMTk.

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -1,7 +1,7 @@
 use num_cpus;
 use std::cell::UnsafeCell;
 use std::ops::Deref;
-use util::constants::LOG_BYTES_IN_PAGE;
+use crate::util::constants::LOG_BYTES_IN_PAGE;
 use std::default::Default;
 
 custom_derive! {

--- a/src/util/queue/local_queue.rs
+++ b/src/util/queue/local_queue.rs
@@ -1,4 +1,4 @@
-use ::util::queue::SharedQueue;
+use crate::util::queue::SharedQueue;
 use std::fmt::Debug;
 use std::mem;
 use super::{BUFFER_SIZE, TRACE_QUEUE};
@@ -62,7 +62,7 @@ impl<'a, T> LocalQueue<'a, T> where T: Debug {
 
 #[cfg(test)]
 mod tests {
-    use util::queue::{SharedQueue, BUFFER_SIZE};
+    use crate::util::queue::{SharedQueue, BUFFER_SIZE};
 
     #[test]
     fn new_local_queues() {

--- a/src/util/queue/mod.rs
+++ b/src/util/queue/mod.rs
@@ -1,6 +1,6 @@
 pub use self::local_queue::LocalQueue;
 pub use self::shared_queue::SharedQueue;
-use ::util::constants::LOG_BYTES_IN_PAGE;
+use crate::util::constants::LOG_BYTES_IN_PAGE;
 
 mod local_queue;
 mod shared_queue;

--- a/src/util/queue/shared_queue.rs
+++ b/src/util/queue/shared_queue.rs
@@ -1,4 +1,4 @@
-use ::util::queue::LocalQueue;
+use crate::util::queue::LocalQueue;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
@@ -83,8 +83,8 @@ impl<T> Default for SharedQueue<T> where T: Debug {
 #[cfg(test)]
 mod tests {
     extern crate crossbeam;
-    use util::queue::SharedQueue;
-    use util::test_util::panic_after;
+    use crate::util::queue::SharedQueue;
+    use crate::util::test_util::panic_after;
 
     const SPIN_TIME_OUT: u64 = 200;
 
@@ -92,7 +92,7 @@ mod tests {
     // Calls spin() on a non-empty shared queue. It returns a block immediately.
     fn pull_block() {
         let shared = SharedQueue::<usize>::new();
-        let mut local = shared.spawn_local();
+        let _local = shared.spawn_local();
 
         shared.push(vec![42]);
         let res = shared.spin(0);
@@ -105,7 +105,7 @@ mod tests {
     // Calls spin() on an empty shared queue with no other local queue. It returns None immediately.
     fn spin_empty() {
         let shared = SharedQueue::<usize>::new();
-        let mut local = shared.spawn_local();
+        let _local = shared.spawn_local();
         // This is the only queue. And it is starved. So return None immediately.
         let res = shared.spin(0);
         assert!(res.is_none());
@@ -116,8 +116,8 @@ mod tests {
     // Calls spin() on an empty shared queue with other local queue working. It spins and waits.
     fn spin_wait() {
         let shared = SharedQueue::<usize>::new();
-        let mut local1 = shared.spawn_local();
-        let mut local2 = shared.spawn_local();
+        let _local1 = shared.spawn_local();
+        let _local2 = shared.spawn_local();
 
         panic_after(SPIN_TIME_OUT, move || {
             // Queue #0 calls spin(). However, Queue #1 is not starved. So we spin-wait here.
@@ -133,8 +133,8 @@ mod tests {
 
         panic_after(SPIN_TIME_OUT, move || {
             crossbeam::scope(|scope| {
-                let mut local1 = shared.spawn_local();
-                let mut local2 = shared.spawn_local();
+                let _local1 = shared.spawn_local();
+                let _local2 = shared.spawn_local();
                 let worker1 = scope.spawn(|_| {
                     let res = shared.spin(0);
                     assert!(res.is_none());
@@ -156,8 +156,8 @@ mod tests {
 
         panic_after(SPIN_TIME_OUT, move || {
             crossbeam::scope(|scope| {
-                let mut local1 = shared.spawn_local();
-                let mut local2 = shared.spawn_local();
+                let _local1 = shared.spawn_local();
+                let _local2 = shared.spawn_local();
 
                 let worker1 = scope.spawn(|_| {
                     let res = shared.spin(0);

--- a/src/util/reference_processor.rs
+++ b/src/util/reference_processor.rs
@@ -2,11 +2,11 @@ use std::sync::Mutex;
 use std::cell::UnsafeCell;
 use std::vec::Vec;
 
-use ::util::OpaquePointer;
-use ::util::{Address, ObjectReference};
-use ::vm::{ActivePlan, ReferenceGlue};
-use ::plan::{TraceLocal, MutatorContext};
-use vm::VMBinding;
+use crate::util::OpaquePointer;
+use crate::util::{Address, ObjectReference};
+use crate::vm::{ActivePlan, ReferenceGlue};
+use crate::plan::{TraceLocal, MutatorContext};
+use crate::vm::VMBinding;
 
 pub struct ReferenceProcessors {
     soft: ReferenceProcessor,

--- a/src/util/sanity/memory_scan.rs
+++ b/src/util/sanity/memory_scan.rs
@@ -1,11 +1,11 @@
-use util::Address;
-use util::ObjectReference;
+use crate::util::Address;
+use crate::util::ObjectReference;
 
-use ::plan::SelectedPlan;
-use ::plan::Plan;
+use crate::plan::SelectedPlan;
+use crate::plan::Plan;
 
 use std;
-use vm::VMBinding;
+use crate::vm::VMBinding;
 
 pub fn scan_region<VM: VMBinding>(plan: &SelectedPlan<VM>){
     loop {

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -1,13 +1,13 @@
-use ::plan::{TransitiveClosure, TraceLocal};
-use ::util::{Address, ObjectReference};
-use ::vm::Scanning;
-use ::util::OpaquePointer;
+use crate::plan::{TransitiveClosure, TraceLocal};
+use crate::util::{Address, ObjectReference};
+use crate::vm::Scanning;
+use crate::util::OpaquePointer;
 
 use std::collections::{HashSet, LinkedList};
-use ::plan::Plan;
-use ::plan::SelectedPlan;
+use crate::plan::Plan;
+use crate::plan::SelectedPlan;
 
-use vm::VMBinding;
+use crate::vm::VMBinding;
 
 pub struct SanityChecker<'a, VM: VMBinding> {
     roots: Vec<Address>,

--- a/src/util/statistics/counter.rs
+++ b/src/util/statistics/counter.rs
@@ -1,5 +1,5 @@
 use std::time::Instant;
-use util::statistics::stats::SharedStats;
+use crate::util::statistics::stats::SharedStats;
 use std::sync::Arc;
 use std::fmt;
 

--- a/src/util/statistics/phase_timer.rs
+++ b/src/util/statistics/phase_timer.rs
@@ -1,7 +1,7 @@
-use util::statistics::stats::Stats;
-use plan::Phase::{self, *};
+use crate::util::statistics::stats::Stats;
+use crate::plan::Phase::{self, *};
 use std::sync::{Arc, Mutex};
-use util::statistics::{Timer, Counter};
+use crate::util::statistics::{Timer, Counter};
 
 pub struct PhaseTimer {
     ref_type_time: Arc<Mutex<Timer>>,

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
 use std::sync::Mutex;
-use util::statistics::Timer;
-use util::statistics::counter::{Counter, LongCounter};
+use crate::util::statistics::Timer;
+use crate::util::statistics::counter::{Counter, LongCounter};
 use std::sync::Arc;
 
 pub const MAX_PHASES: usize = 1 << 12;

--- a/src/util/treadmill.rs
+++ b/src/util/treadmill.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::mem::swap;
 use std::sync::Mutex;
 
-use ::util::Address;
+use crate::util::Address;
 
 #[derive(Debug)]
 pub struct TreadMill {

--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -1,6 +1,6 @@
-use ::plan::{Plan, SelectedPlan};
-use ::util::OpaquePointer;
-use vm::VMBinding;
+use crate::plan::{Plan, SelectedPlan};
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
 
 pub trait ActivePlan<VM: VMBinding> {
     // TODO: I don't know how this can be implemented when we have multiple MMTk instances.

--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -1,6 +1,6 @@
-use ::plan::{MutatorContext, ParallelCollector};
-use ::util::OpaquePointer;
-use vm::VMBinding;
+use crate::plan::{MutatorContext, ParallelCollector};
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
 
 pub trait Collection<VM: VMBinding> {
     fn stop_all_mutators(tls: OpaquePointer);

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -1,8 +1,8 @@
-use ::util::{Address, ObjectReference};
-use ::plan::Allocator;
-use ::util::OpaquePointer;
+use crate::util::{Address, ObjectReference};
+use crate::plan::Allocator;
+use crate::util::OpaquePointer;
 use std::sync::atomic::AtomicU8;
-use vm::VMBinding;
+use crate::vm::VMBinding;
 
 /// https://github.com/JikesRVM/JikesRVM/blob/master/MMTk/src/org/mmtk/vm/ObjectModel.java
 pub trait ObjectModel<VM: VMBinding> {

--- a/src/vm/reference_glue.rs
+++ b/src/vm/reference_glue.rs
@@ -1,8 +1,8 @@
-use ::util::ObjectReference;
-use ::util::Address;
-use ::plan::TraceLocal;
-use ::util::OpaquePointer;
-use vm::VMBinding;
+use crate::util::ObjectReference;
+use crate::util::Address;
+use crate::plan::TraceLocal;
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
 
 /**
  * VM-specific stuff for util::ReferenceProcessor

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -1,7 +1,7 @@
-use ::plan::{TransitiveClosure, TraceLocal};
-use ::util::ObjectReference;
-use ::util::OpaquePointer;
-use vm::VMBinding;
+use crate::plan::{TransitiveClosure, TraceLocal};
+use crate::util::ObjectReference;
+use crate::util::OpaquePointer;
+use crate::vm::VMBinding;
 
 pub trait Scanning<VM: VMBinding> {
     fn scan_object<T: TransitiveClosure>(trace: &mut T, object: ObjectReference, tls: OpaquePointer);


### PR DESCRIPTION
This PR migrate our code base to Rust Edition 2018. All changes made are automatically generated by `cargo fix --edition`. `Cargo.toml` now specifies `edition = "2018"`. 