### PR TITLE
CI should always install rustfmt

### DIFF
--- a/.github/workflows/pre-review-ci.yml
+++ b/.github/workflows/pre-review-ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2019-08-26
-          components: clippy
+          components: rustfmt, clippy
           target: i686-unknown-linux-gnu
           # This overwrites the default toolchain with the toolchain specified above.
           override: true


### PR DESCRIPTION
This should fix the problem we had before that `cargo-fmt` was missing. 