### PR TITLE
Make the policy module public 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod util;
 mod mm;
 mod mmtk;
 mod plan;
-mod policy;
+pub mod policy;
 pub mod vm;
 
 pub use crate::mm::memory_manager;


### PR DESCRIPTION
We need to use space types to expose allocator slow paths. 