### PR TITLE
Performance Regression CI

### DIFF
--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
       - master
-  # Remove this trigger when we have done the testing
-  pull_request:
-    branches:
-      - master
 
 jobs:
   # JikesRVM

--- a/.github/workflows/pre-review-ci.yml
+++ b/.github/workflows/pre-review-ci.yml
@@ -1,12 +1,9 @@
 name: Pre Code Review Checks
 
-# Disable this check for testing
 on:
   pull_request:
-    # branches:
-    #   - master
-    branches-ignore:
-      - '**'
+    branches:
+      - master
 
 jobs:
   pre-code-review-checks:


### PR DESCRIPTION
This PR adds configs for mmtk-core performance regression CI. 
* The performance regression tests will be triggered _after_ a PR is merged. 
* The raw data is stored in the repo (https://github.com/mmtk/ci-perf-result). Currently the results are stored in the `test` branch. We should start another branch when we use our own CI machines. 
* The data is rendered after each performance run, and uploaded as github pages following this pattern: https://mmtk.github.io/ci-perf-result/[vm]_[plan]_history.html. For example:
  * https://mmtk.github.io/ci-perf-result/jikesrvm_nogc_history.html
  * https://mmtk.github.io/ci-perf-result/jikesrvm_semispace_history.html
  * https://mmtk.github.io/ci-perf-result/openjdk_nogc_history.html
  * https://mmtk.github.io/ci-perf-result/openjdk_semispace_history.html