### PR TITLE
OpenJDK test uses a local path for mmtk-core

### DIFF
--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -115,7 +115,7 @@ jobs:
           path: mmtk-openjdk
           submodules: true
       - name: Overwrite MMTk core in openjdk binding
-        run: rsync -avLe mmtk-core/* mmtk-openjdk/repos/mmtk-core/
+        run: cp -r mmtk-core mmtk-openjdk/repos/
       - name: Setup
         run: |
           cd mmtk-openjdk


### PR DESCRIPTION
This resolves https://github.com/mmtk/mmtk-core/issues/101. 

The old check fetches mmtk-openjdk, and build with the master of mmtk-core as defind in `Cargo.toml`. This is not correct, as we expect mmtk-openjdk to run with the PR branch of mmtk-core. The new check fixes this. 