### PR TITLE
Using self-hosted runner

### DIFF
--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -47,7 +47,7 @@ jobs:
           export RESULT_REPO_BRANCH=self-hosted
           export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
           export FROM_DATE=2020-07-10
-          JAVA_HOME=/usr/lib/jvm/default-java ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports
+          JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports
       # deploy
       - name: Deploy to Github Page
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Compare Performance
         id: run
         run: |
-          JAVA_HOME=/usr/lib/jvm/default-java RUSTUP_TOOLCHAIN=nightly-2019-08-26 ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm/ mmtk-core-master/ mmtk-core-branch/ jikesrvm-compare-report.md
+          JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 RUSTUP_TOOLCHAIN=nightly-2019-08-26 ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm/ mmtk-core-master/ mmtk-core-branch/ jikesrvm-compare-report.md
       # set report.md to output
       - uses: pCYSl5EDgo/cat@master
         id: cat


### PR DESCRIPTION
This PR uses the self-hosted runner for performance tests. 
* Move to self-hosted runner, change the CI configs for adapting to self-hosted runner.
* Use latest ci-perf-kit (https://github.com/mmtk/ci-perf-kit/releases/tag/0.2.1), which runs more invocations and outputs more statistics for the result (see the comments of this PR). 