### PR TITLE
Better Plotting of Performance History Data

### DIFF
--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -117,7 +117,7 @@ jobs:
           publish_branch: gh-pages
           keep_files: true
 
-  # openjdk-mutator-perf:
+  openjdk-mutator-perf:
     runs-on: [self-hosted, Linux, freq-scaling-off]
     steps:
       - name: Checkout MMTk Core

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.3.3"
+          ref: "0.3.5"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -208,7 +208,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.3.3"
+          ref: "0.3.5"
           path: ci-perf-kit
           submodules: true
       # setup


### PR DESCRIPTION
Changes:
* Update ci-perf-kit to 0.3.5
  * plot 10-point moving average with performance history data
  * plot +-1 standard deviation from 10p moving average
  * highlight the max/min number in the graph
  * normalize all the data to the min value
  * log timeline
* Plots for each branch are now stored in separate directories
  * Plots for a branch can co-exist with the plots for master

Examples for the new graph:
* https://mmtk.github.io/ci-perf-result/refs_pull_125_merge/jikesrvm_semispace_history.html
* https://mmtk.github.io/ci-perf-result/refs_pull_125_merge/jikesrvm_nogc_history.html
* https://mmtk.github.io/ci-perf-result/refs_pull_125_merge/openjdk_semispace_history.html
* https://mmtk.github.io/ci-perf-result/refs_pull_125_merge/openjdk_nogc_history.html