### PR TITLE
Add API: is_in_space()

### DIFF
--- a/src/mm/memory_manager.rs
+++ b/src/mm/memory_manager.rs
@@ -63,6 +63,14 @@ pub fn destroy_mutator<VM: VMBinding>(mutator: Box<SelectedMutator<VM>>) {
     drop(mutator);
 }
 
+pub fn is_in_space<VM: VMBinding>(
+    mmtk: &'static MMTK<VM>,
+    obj: ObjectReference,
+    allocator: Allocator,
+) -> bool {
+    mmtk.plan.is_in_space(obj, allocator)
+}
+
 pub fn alloc<VM: VMBinding>(
     mutator: &mut SelectedMutator<VM>,
     size: usize,

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -10,11 +10,13 @@ use super::NoGCCollector;
 use super::NoGCMutator;
 use super::NoGCTraceLocal;
 use crate::plan::global::BasePlan;
+use crate::plan::Allocator as AllocationType;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::options::UnsafeOptionsWrapper;
+use crate::util::ObjectReference;
 use crate::vm::VMBinding;
 use std::sync::Arc;
 
@@ -97,6 +99,13 @@ impl<VM: VMBinding> Plan<VM> for NoGC<VM> {
 
     fn handle_user_collection_request(&self, _tls: OpaquePointer, _force: bool) {
         println!("Warning: User attempted a collection request, but it is not supported in NoGC. The request is ignored.");
+    }
+
+    /// Whether the object is in a space that matches the allocation type.
+    /// Its implementation needs to be consistent with Mutator.alloc()
+    fn is_in_space(&self, obj: ObjectReference, _allocator: AllocationType) -> bool {
+        let unsync = unsafe { &*self.unsync.get() };
+        unsync.nogc_space.in_space(obj)
     }
 }
 

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -10,12 +10,13 @@ use crate::plan::Phase;
 use crate::plan::Plan;
 use crate::policy::copyspace::CopySpace;
 use crate::util::heap::VMRequest;
-use crate::util::OpaquePointer;
+use crate::util::{ObjectReference, OpaquePointer};
 
 use std::cell::UnsafeCell;
 
 use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
+use crate::plan::Allocator as AllocationType;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
@@ -182,6 +183,15 @@ impl<VM: VMBinding> Plan<VM> for SemiSpace<VM> {
 
     fn common(&self) -> &CommonPlan<VM> {
         &self.common
+    }
+
+    /// Whether the object is in a space that matches the allocation type.
+    /// Its implementation needs to be consistent with Mutator.alloc()
+    fn is_in_space(&self, obj: ObjectReference, allocator: AllocationType) -> bool {
+        match allocator {
+            AllocationType::Default => self.tospace().in_space(obj),
+            _ => self.common.is_in_space(obj, allocator),
+        }
     }
 }
 


### PR DESCRIPTION
Add an API: `pub fn is_in_space(mmtk, obj, allocator) -> bool`. It checks if the object is located in a space with the given allocation type (allocation semantics). Its implementation should be consistent with the `alloc()` implementation for each plan (i.e. it should check whether an object is in a space in the same way as how `alloc()` maps allocation types to each space). 

Currently no VM binding is using it, so it is not covered in any tests. The V8 binding needs this API. 