### PR TITLE
Add config for protected-workflows

### DIFF
--- a/.github/protected-workflows.yml
+++ b/.github/protected-workflows.yml
@@ -6,13 +6,6 @@ events:
           - ".github/**"
           - ".github/protected-workflows.yml"
     - trustOrgMembers: true
-
-    # - trustedUserNames:
-    #     - "caizixian"
-    #     - "javadamiri"
-    #     - "qinsoon"
-    #     - "steveblackburn"
-    #     - "wenyuzhao"
   
   pull_request_target: *config
   push: *config


### PR DESCRIPTION
This adds configuration for the Github app `protected-workflows` (https://github.com/apps/protected-workflows). From the discussion with the author (https://github.com/eladchen/protected-workflows/issues/2), the config needs to be added first, before enabling the app on the repo, as the app always looks into the configuration on the master branch. 

This config forbids unauthorised users to change the app configuration itself, and our workflow configurations. Only org members are allowed to change the configs. 