### PR TITLE
Add a shorter timeout for jobs on github-hosted runner

### DIFF
--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -10,6 +10,7 @@ jobs:
   # JikesRVM
   jikesrvm-binding-test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     if: contains(github.event.pull_request.labels.*.name, 'PR-approved') || contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Checkout MMTk Core
@@ -132,6 +133,7 @@ jobs:
   # OpenJDK
   openjdk-binding-test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     if: contains(github.event.pull_request.labels.*.name, 'PR-approved') || contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Checkout MMTk Core

--- a/.github/workflows/pre-review-ci.yml
+++ b/.github/workflows/pre-review-ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   pre-code-review-checks:
     runs-on: ubuntu-18.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly


### PR DESCRIPTION
This PR adds a shorter timeout to avoid any stuck code executed in the job consuming excessive runner minutes. 