### PR TITLE
Rename enum Allocator to AllocationSemantic

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.2"
+          ref: "0.4.3"
           path: ci-perf-kit
           submodules: true
       # run compare

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.2"
+          ref: "0.4.3"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -84,7 +84,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.2"
+          ref: "0.4.3"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -139,7 +139,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.2"
+          ref: "0.4.3"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.2"
+          ref: "0.4.3"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -213,7 +213,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.2"
+          ref: "0.4.3"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,5 +67,5 @@ pub use crate::plan::selected_plan::{SelectedConstraints, SelectedPlan};
 pub use crate::mm::memory_manager;
 pub use crate::mmtk::MMTK;
 pub use crate::plan::{
-    Allocator, CopyContext, Mutator, MutatorContext, Plan, TraceLocal, TransitiveClosure,
+    AllocationSemantic, CopyContext, Mutator, MutatorContext, Plan, TraceLocal, TransitiveClosure,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,5 +67,5 @@ pub use crate::plan::selected_plan::{SelectedConstraints, SelectedPlan};
 pub use crate::mm::memory_manager;
 pub use crate::mmtk::MMTK;
 pub use crate::plan::{
-    AllocationSemantic, CopyContext, Mutator, MutatorContext, Plan, TraceLocal, TransitiveClosure,
+    AllocationSemantics, CopyContext, Mutator, MutatorContext, Plan, TraceLocal, TransitiveClosure,
 };

--- a/src/mm/memory_manager.rs
+++ b/src/mm/memory_manager.rs
@@ -26,7 +26,7 @@ use crate::plan::selected_plan;
 use crate::util::alloc::allocators::AllocatorSelector;
 
 use crate::mmtk::MMTK;
-use crate::plan::AllocationSemantic;
+use crate::plan::AllocationSemantics;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::heap::layout::vm_layout_constants::HEAP_END;
 use crate::util::heap::layout::vm_layout_constants::HEAP_START;
@@ -96,7 +96,7 @@ pub fn alloc<VM: VMBinding>(
     size: usize,
     align: usize,
     offset: isize,
-    allocator: AllocationSemantic,
+    allocator: AllocationSemantics,
 ) -> Address {
     mutator.alloc(size, align, offset, allocator)
 }
@@ -116,7 +116,7 @@ pub fn post_alloc<VM: VMBinding>(
     refer: ObjectReference,
     type_refer: ObjectReference,
     bytes: usize,
-    allocator: AllocationSemantic,
+    allocator: AllocationSemantics,
 ) {
     mutator.post_alloc(refer, type_refer, bytes, allocator);
 }
@@ -129,7 +129,7 @@ pub fn post_alloc<VM: VMBinding>(
 /// * `allocator`: The allocation semantic to query.
 pub fn get_allocator_mapping<VM: VMBinding>(
     mmtk: &MMTK<VM>,
-    allocator: AllocationSemantic,
+    allocator: AllocationSemantics,
 ) -> AllocatorSelector {
     mmtk.plan.get_allocator_mapping()[allocator]
 }

--- a/src/mm/memory_manager.rs
+++ b/src/mm/memory_manager.rs
@@ -26,7 +26,7 @@ use crate::plan::selected_plan;
 use crate::util::alloc::allocators::AllocatorSelector;
 
 use crate::mmtk::MMTK;
-use crate::plan::Allocator;
+use crate::plan::AllocationSemantic;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::heap::layout::vm_layout_constants::HEAP_END;
 use crate::util::heap::layout::vm_layout_constants::HEAP_START;
@@ -96,7 +96,7 @@ pub fn alloc<VM: VMBinding>(
     size: usize,
     align: usize,
     offset: isize,
-    allocator: Allocator,
+    allocator: AllocationSemantic,
 ) -> Address {
     mutator.alloc(size, align, offset, allocator)
 }
@@ -116,7 +116,7 @@ pub fn post_alloc<VM: VMBinding>(
     refer: ObjectReference,
     type_refer: ObjectReference,
     bytes: usize,
-    allocator: Allocator,
+    allocator: AllocationSemantic,
 ) {
     mutator.post_alloc(refer, type_refer, bytes, allocator);
 }
@@ -129,7 +129,7 @@ pub fn post_alloc<VM: VMBinding>(
 /// * `allocator`: The allocation semantic to query.
 pub fn get_allocator_mapping<VM: VMBinding>(
     mmtk: &MMTK<VM>,
-    allocator: Allocator,
+    allocator: AllocationSemantic,
 ) -> AllocatorSelector {
     mmtk.plan.get_allocator_mapping()[allocator]
 }

--- a/src/mm/memory_manager.rs
+++ b/src/mm/memory_manager.rs
@@ -90,15 +90,15 @@ pub fn flush_mutator<VM: VMBinding>(mutator: &mut Mutator<SelectedPlan<VM>>) {
 /// * `size`: The number of bytes required for the object.
 /// * `align`: Required alignment for the object.
 /// * `offset`: Offset associated with the alignment.
-/// * `allocator`: The allocation semantic required for the allocation.
+/// * `semantics`: The allocation semantic required for the allocation.
 pub fn alloc<VM: VMBinding>(
     mutator: &mut Mutator<SelectedPlan<VM>>,
     size: usize,
     align: usize,
     offset: isize,
-    allocator: AllocationSemantics,
+    semantics: AllocationSemantics,
 ) -> Address {
-    mutator.alloc(size, align, offset, allocator)
+    mutator.alloc(size, align, offset, semantics)
 }
 
 /// Perform post-allocation actions, usually initializing object metadata. For many allocators none are
@@ -110,15 +110,15 @@ pub fn alloc<VM: VMBinding>(
 /// * `refer`: The newly allocated object.
 /// * `type_refer`: The type reference for the instance being created (unused).
 /// * `bytes`: The size of the space allocated for the object (in bytes).
-/// * `allocator`: The allocation semantics used for the allocation.
+/// * `semantics`: The allocation semantics used for the allocation.
 pub fn post_alloc<VM: VMBinding>(
     mutator: &mut Mutator<SelectedPlan<VM>>,
     refer: ObjectReference,
     type_refer: ObjectReference,
     bytes: usize,
-    allocator: AllocationSemantics,
+    semantics: AllocationSemantics,
 ) {
-    mutator.post_alloc(refer, type_refer, bytes, allocator);
+    mutator.post_alloc(refer, type_refer, bytes, semantics);
 }
 
 /// Return an AllocatorSelector for the given allocation semantic. This method is provided
@@ -126,12 +126,12 @@ pub fn post_alloc<VM: VMBinding>(
 ///
 /// Arguments:
 /// * `mmtk`: The reference to an MMTk instance.
-/// * `allocator`: The allocation semantic to query.
+/// * `semantics`: The allocation semantic to query.
 pub fn get_allocator_mapping<VM: VMBinding>(
     mmtk: &MMTK<VM>,
-    allocator: AllocationSemantics,
+    semantics: AllocationSemantics,
 ) -> AllocatorSelector {
-    mmtk.plan.get_allocator_mapping()[allocator]
+    mmtk.plan.get_allocator_mapping()[semantics]
 }
 
 /// Run the main loop of a GC worker. This method does not return.

--- a/src/plan/gencopy/gc_works.rs
+++ b/src/plan/gencopy/gc_works.rs
@@ -40,7 +40,7 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
         bytes: usize,
         align: usize,
         offset: isize,
-        _allocator: crate::AllocationSemantic,
+        _allocator: crate::AllocationSemantics,
     ) -> Address {
         debug_assert!(VM::VMActivePlan::global().base().gc_in_progress_proper());
         self.ss.alloc(bytes, align, offset)
@@ -51,7 +51,7 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
         obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: crate::AllocationSemantic,
+        _allocator: crate::AllocationSemantics,
     ) {
         forwarding_word::clear_forwarding_bits::<VM>(obj);
     }

--- a/src/plan/gencopy/gc_works.rs
+++ b/src/plan/gencopy/gc_works.rs
@@ -40,7 +40,7 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
         bytes: usize,
         align: usize,
         offset: isize,
-        _allocator: crate::AllocationSemantics,
+        _semantics: crate::AllocationSemantics,
     ) -> Address {
         debug_assert!(VM::VMActivePlan::global().base().gc_in_progress_proper());
         self.ss.alloc(bytes, align, offset)
@@ -51,7 +51,7 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
         obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: crate::AllocationSemantics,
+        _semantics: crate::AllocationSemantics,
     ) {
         forwarding_word::clear_forwarding_bits::<VM>(obj);
     }

--- a/src/plan/gencopy/gc_works.rs
+++ b/src/plan/gencopy/gc_works.rs
@@ -40,7 +40,7 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
         bytes: usize,
         align: usize,
         offset: isize,
-        _allocator: crate::Allocator,
+        _allocator: crate::AllocationSemantic,
     ) -> Address {
         debug_assert!(VM::VMActivePlan::global().base().gc_in_progress_proper());
         self.ss.alloc(bytes, align, offset)
@@ -51,7 +51,7 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
         obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: crate::Allocator,
+        _allocator: crate::AllocationSemantic,
     ) {
         forwarding_word::clear_forwarding_bits::<VM>(obj);
     }

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -6,7 +6,7 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::GcStatus;
 use crate::plan::mutator_context::Mutator;
-use crate::plan::Allocator;
+use crate::plan::AllocationSemantic;
 use crate::plan::Plan;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
@@ -30,7 +30,7 @@ use std::sync::Arc;
 
 pub type SelectedPlan<VM> = GenCopy<VM>;
 
-pub const ALLOC_SS: Allocator = Allocator::Default;
+pub const ALLOC_SS: AllocationSemantic = AllocationSemantic::Default;
 pub const NURSERY_SIZE: usize = 16 * 1024 * 1024;
 
 pub struct GenCopy<VM: VMBinding> {
@@ -148,7 +148,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         Box::new(create_gencopy_mutator(tls, mmtk))
     }
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<Allocator, AllocatorSelector> {
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }
 

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -6,7 +6,7 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::GcStatus;
 use crate::plan::mutator_context::Mutator;
-use crate::plan::AllocationSemantic;
+use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
@@ -30,7 +30,7 @@ use std::sync::Arc;
 
 pub type SelectedPlan<VM> = GenCopy<VM>;
 
-pub const ALLOC_SS: AllocationSemantic = AllocationSemantic::Default;
+pub const ALLOC_SS: AllocationSemantics = AllocationSemantics::Default;
 pub const NURSERY_SIZE: usize = 16 * 1024 * 1024;
 
 pub struct GenCopy<VM: VMBinding> {
@@ -148,7 +148,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         Box::new(create_gencopy_mutator(tls, mmtk))
     }
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector> {
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }
 

--- a/src/plan/gencopy/mutator.rs
+++ b/src/plan/gencopy/mutator.rs
@@ -3,7 +3,7 @@ use super::GenCopy;
 use crate::plan::barriers::*;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
-use crate::plan::Allocator as AllocationType;
+use crate::plan::AllocationSemantic as AllocationType;
 use crate::policy::copyspace::CopySpace;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::BumpAllocator;

--- a/src/plan/gencopy/mutator.rs
+++ b/src/plan/gencopy/mutator.rs
@@ -3,7 +3,7 @@ use super::GenCopy;
 use crate::plan::barriers::*;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
-use crate::plan::AllocationSemantic as AllocationType;
+use crate::plan::AllocationSemantics as AllocationType;
 use crate::policy::copyspace::CopySpace;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::BumpAllocator;

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -45,14 +45,14 @@ pub trait CopyContext: Sized + 'static + Sync + Send {
         bytes: usize,
         align: usize,
         offset: isize,
-        allocator: Allocator,
+        allocator: AllocationSemantic,
     ) -> Address;
     fn post_copy(
         &mut self,
         _obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: Allocator,
+        _allocator: AllocationSemantic,
     ) {
     }
     fn copy_check_allocator(
@@ -60,15 +60,15 @@ pub trait CopyContext: Sized + 'static + Sync + Send {
         _from: ObjectReference,
         bytes: usize,
         align: usize,
-        allocator: Allocator,
-    ) -> Allocator {
+        allocator: AllocationSemantic,
+    ) -> AllocationSemantic {
         let large = crate::util::alloc::allocator::get_maximum_aligned_size::<Self::VM>(
             bytes,
             align,
             Self::VM::MIN_ALIGNMENT,
         ) > Self::MAX_NON_LOS_COPY_BYTES;
         if large {
-            Allocator::Los
+            AllocationSemantic::Los
         } else {
             allocator
         }
@@ -91,7 +91,7 @@ impl<VM: VMBinding> CopyContext for NoCopy<VM> {
         _bytes: usize,
         _align: usize,
         _offset: isize,
-        _allocator: Allocator,
+        _allocator: AllocationSemantic,
     ) -> Address {
         unreachable!()
     }
@@ -156,7 +156,7 @@ pub trait Plan: Sized + 'static + Sync + Send {
         mmtk: &'static MMTK<Self::VM>,
     ) -> Box<Self::Mutator>;
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<Allocator, AllocatorSelector>;
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector>;
 
     fn in_nursery(&self) -> bool {
         false
@@ -750,7 +750,7 @@ use enum_map::Enum;
 /// Each allocation request requires a desired semantic for the object to allocate.
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Enum)]
-pub enum Allocator {
+pub enum AllocationSemantic {
     Default = 0,
     Immortal = 1,
     Los = 2,

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -45,14 +45,14 @@ pub trait CopyContext: Sized + 'static + Sync + Send {
         bytes: usize,
         align: usize,
         offset: isize,
-        allocator: AllocationSemantic,
+        allocator: AllocationSemantics,
     ) -> Address;
     fn post_copy(
         &mut self,
         _obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: AllocationSemantic,
+        _allocator: AllocationSemantics,
     ) {
     }
     fn copy_check_allocator(
@@ -60,15 +60,15 @@ pub trait CopyContext: Sized + 'static + Sync + Send {
         _from: ObjectReference,
         bytes: usize,
         align: usize,
-        allocator: AllocationSemantic,
-    ) -> AllocationSemantic {
+        allocator: AllocationSemantics,
+    ) -> AllocationSemantics {
         let large = crate::util::alloc::allocator::get_maximum_aligned_size::<Self::VM>(
             bytes,
             align,
             Self::VM::MIN_ALIGNMENT,
         ) > Self::MAX_NON_LOS_COPY_BYTES;
         if large {
-            AllocationSemantic::Los
+            AllocationSemantics::Los
         } else {
             allocator
         }
@@ -91,7 +91,7 @@ impl<VM: VMBinding> CopyContext for NoCopy<VM> {
         _bytes: usize,
         _align: usize,
         _offset: isize,
-        _allocator: AllocationSemantic,
+        _allocator: AllocationSemantics,
     ) -> Address {
         unreachable!()
     }
@@ -156,7 +156,7 @@ pub trait Plan: Sized + 'static + Sync + Send {
         mmtk: &'static MMTK<Self::VM>,
     ) -> Box<Self::Mutator>;
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector>;
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector>;
 
     fn in_nursery(&self) -> bool {
         false
@@ -750,7 +750,7 @@ use enum_map::Enum;
 /// Each allocation request requires a desired semantic for the object to allocate.
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Enum)]
-pub enum AllocationSemantic {
+pub enum AllocationSemantics {
     Default = 0,
     Immortal = 1,
     Los = 2,

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -45,14 +45,14 @@ pub trait CopyContext: Sized + 'static + Sync + Send {
         bytes: usize,
         align: usize,
         offset: isize,
-        allocator: AllocationSemantics,
+        semantics: AllocationSemantics,
     ) -> Address;
     fn post_copy(
         &mut self,
         _obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: AllocationSemantics,
+        _semantics: AllocationSemantics,
     ) {
     }
     fn copy_check_allocator(
@@ -60,7 +60,7 @@ pub trait CopyContext: Sized + 'static + Sync + Send {
         _from: ObjectReference,
         bytes: usize,
         align: usize,
-        allocator: AllocationSemantics,
+        semantics: AllocationSemantics,
     ) -> AllocationSemantics {
         let large = crate::util::alloc::allocator::get_maximum_aligned_size::<Self::VM>(
             bytes,
@@ -70,7 +70,7 @@ pub trait CopyContext: Sized + 'static + Sync + Send {
         if large {
             AllocationSemantics::Los
         } else {
-            allocator
+            semantics
         }
     }
 }
@@ -91,7 +91,7 @@ impl<VM: VMBinding> CopyContext for NoCopy<VM> {
         _bytes: usize,
         _align: usize,
         _offset: isize,
-        _allocator: AllocationSemantics,
+        _semantics: AllocationSemantics,
     ) -> Address {
         unreachable!()
     }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -6,7 +6,7 @@ pub mod plan_constraints;
 mod trace;
 pub mod tracelocal;
 pub mod transitive_closure;
-pub use self::global::Allocator;
+pub use self::global::AllocationSemantic;
 pub use self::global::CopyContext;
 pub use self::global::Plan;
 pub use self::mutator_context::Mutator;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -6,7 +6,7 @@ pub mod plan_constraints;
 mod trace;
 pub mod tracelocal;
 pub mod transitive_closure;
-pub use self::global::AllocationSemantic;
+pub use self::global::AllocationSemantics;
 pub use self::global::CopyContext;
 pub use self::global::Plan;
 pub use self::mutator_context::Mutator;

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -1,6 +1,6 @@
 use crate::plan::barriers::{Barrier, WriteTarget};
 use crate::plan::global::Plan;
-use crate::plan::Allocator as AllocationType;
+use crate::plan::AllocationSemantic as AllocationType;
 use crate::policy::space::Space;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::OpaquePointer;

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -1,6 +1,6 @@
 use crate::plan::barriers::{Barrier, WriteTarget};
 use crate::plan::global::Plan;
-use crate::plan::AllocationSemantic as AllocationType;
+use crate::plan::AllocationSemantics as AllocationType;
 use crate::policy::space::Space;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::OpaquePointer;

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -3,7 +3,7 @@ use crate::plan::global::{BasePlan, NoCopy};
 use crate::plan::mutator_context::Mutator;
 use crate::plan::nogc::mutator::create_nogc_mutator;
 use crate::plan::nogc::mutator::ALLOCATOR_MAPPING;
-use crate::plan::Allocator;
+use crate::plan::AllocationSemantic;
 use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::scheduler::MMTkScheduler;
@@ -101,7 +101,7 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         unreachable!()
     }
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<Allocator, AllocatorSelector> {
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }
 

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -3,7 +3,7 @@ use crate::plan::global::{BasePlan, NoCopy};
 use crate::plan::mutator_context::Mutator;
 use crate::plan::nogc::mutator::create_nogc_mutator;
 use crate::plan::nogc::mutator::ALLOCATOR_MAPPING;
-use crate::plan::AllocationSemantic;
+use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::scheduler::MMTkScheduler;
@@ -101,7 +101,7 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         unreachable!()
     }
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector> {
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }
 

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -2,7 +2,7 @@ use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::nogc::NoGC;
-use crate::plan::AllocationSemantic as AllocationType;
+use crate::plan::AllocationSemantics as AllocationType;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::OpaquePointer;
 use crate::vm::VMBinding;

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -2,7 +2,7 @@ use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::nogc::NoGC;
-use crate::plan::Allocator as AllocationType;
+use crate::plan::AllocationSemantic as AllocationType;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::OpaquePointer;
 use crate::vm::VMBinding;

--- a/src/plan/semispace/gc_works.rs
+++ b/src/plan/semispace/gc_works.rs
@@ -39,7 +39,7 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
         bytes: usize,
         align: usize,
         offset: isize,
-        _allocator: crate::Allocator,
+        _allocator: crate::AllocationSemantic,
     ) -> Address {
         self.ss.alloc(bytes, align, offset)
     }
@@ -49,7 +49,7 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
         obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: crate::Allocator,
+        _allocator: crate::AllocationSemantic,
     ) {
         forwarding_word::clear_forwarding_bits::<VM>(obj);
     }

--- a/src/plan/semispace/gc_works.rs
+++ b/src/plan/semispace/gc_works.rs
@@ -39,7 +39,7 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
         bytes: usize,
         align: usize,
         offset: isize,
-        _allocator: crate::AllocationSemantic,
+        _allocator: crate::AllocationSemantics,
     ) -> Address {
         self.ss.alloc(bytes, align, offset)
     }
@@ -49,7 +49,7 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
         obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: crate::AllocationSemantic,
+        _allocator: crate::AllocationSemantics,
     ) {
         forwarding_word::clear_forwarding_bits::<VM>(obj);
     }

--- a/src/plan/semispace/gc_works.rs
+++ b/src/plan/semispace/gc_works.rs
@@ -39,7 +39,7 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
         bytes: usize,
         align: usize,
         offset: isize,
-        _allocator: crate::AllocationSemantics,
+        _semantics: crate::AllocationSemantics,
     ) -> Address {
         self.ss.alloc(bytes, align, offset)
     }
@@ -49,7 +49,7 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
         obj: ObjectReference,
         _tib: Address,
         _bytes: usize,
-        _allocator: crate::AllocationSemantics,
+        _semantics: crate::AllocationSemantics,
     ) {
         forwarding_word::clear_forwarding_bits::<VM>(obj);
     }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -6,7 +6,7 @@ use crate::plan::global::GcStatus;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::semispace::mutator::create_ss_mutator;
 use crate::plan::semispace::mutator::ALLOCATOR_MAPPING;
-use crate::plan::Allocator;
+use crate::plan::AllocationSemantic;
 use crate::plan::Plan;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
@@ -30,7 +30,7 @@ use enum_map::EnumMap;
 
 pub type SelectedPlan<VM> = SemiSpace<VM>;
 
-pub const ALLOC_SS: Allocator = Allocator::Default;
+pub const ALLOC_SS: AllocationSemantic = AllocationSemantic::Default;
 
 pub struct SemiSpace<VM: VMBinding> {
     pub hi: AtomicBool,
@@ -115,7 +115,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         Box::new(create_ss_mutator(tls, self))
     }
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<Allocator, AllocatorSelector> {
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }
 

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -6,7 +6,7 @@ use crate::plan::global::GcStatus;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::semispace::mutator::create_ss_mutator;
 use crate::plan::semispace::mutator::ALLOCATOR_MAPPING;
-use crate::plan::AllocationSemantic;
+use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
@@ -30,7 +30,7 @@ use enum_map::EnumMap;
 
 pub type SelectedPlan<VM> = SemiSpace<VM>;
 
-pub const ALLOC_SS: AllocationSemantic = AllocationSemantic::Default;
+pub const ALLOC_SS: AllocationSemantics = AllocationSemantics::Default;
 
 pub struct SemiSpace<VM: VMBinding> {
     pub hi: AtomicBool,
@@ -115,7 +115,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         Box::new(create_ss_mutator(tls, self))
     }
 
-    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantic, AllocatorSelector> {
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }
 

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -2,7 +2,7 @@ use super::SemiSpace;
 use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
-use crate::plan::AllocationSemantic as AllocationType;
+use crate::plan::AllocationSemantics as AllocationType;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::BumpAllocator;
 use crate::util::OpaquePointer;

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -2,7 +2,7 @@ use super::SemiSpace;
 use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
-use crate::plan::Allocator as AllocationType;
+use crate::plan::AllocationSemantic as AllocationType;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::BumpAllocator;
 use crate::util::OpaquePointer;

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -124,10 +124,10 @@ impl<VM: VMBinding> CopySpace<VM> {
         &self,
         trace: &mut T,
         object: ObjectReference,
-        allocator: AllocationSemantics,
+        semantics: AllocationSemantics,
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference {
-        trace!("copyspace.trace_object(, {:?}, {:?})", object, allocator,);
+        trace!("copyspace.trace_object(, {:?}, {:?})", object, semantics,);
         if !self.from_space() {
             return object;
         }
@@ -143,7 +143,7 @@ impl<VM: VMBinding> CopySpace<VM> {
         } else {
             trace!("... no it isn't. Copying");
             let new_object =
-                ForwardingWord::forward_object::<VM, _>(object, allocator, copy_context);
+                ForwardingWord::forward_object::<VM, _>(object, semantics, copy_context);
             trace!("Forwarding pointer");
             trace.process_node(new_object);
             trace!("Copying [{:?} -> {:?}]", object, new_object);

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -1,5 +1,5 @@
 use crate::plan::TransitiveClosure;
-use crate::plan::{Allocator, CopyContext};
+use crate::plan::{AllocationSemantic, CopyContext};
 use crate::policy::space::SpaceOptions;
 use crate::policy::space::{CommonSpace, Space, SFT};
 use crate::util::constants::CARD_META_PAGES_PER_REGION;
@@ -124,7 +124,7 @@ impl<VM: VMBinding> CopySpace<VM> {
         &self,
         trace: &mut T,
         object: ObjectReference,
-        allocator: Allocator,
+        allocator: AllocationSemantic,
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference {
         trace!("copyspace.trace_object(, {:?}, {:?})", object, allocator,);

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -1,5 +1,5 @@
 use crate::plan::TransitiveClosure;
-use crate::plan::{AllocationSemantic, CopyContext};
+use crate::plan::{AllocationSemantics, CopyContext};
 use crate::policy::space::SpaceOptions;
 use crate::policy::space::{CommonSpace, Space, SFT};
 use crate::util::constants::CARD_META_PAGES_PER_REGION;
@@ -124,7 +124,7 @@ impl<VM: VMBinding> CopySpace<VM> {
         &self,
         trace: &mut T,
         object: ObjectReference,
-        allocator: AllocationSemantic,
+        allocator: AllocationSemantics,
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference {
         trace!("copyspace.trace_object(, {:?}, {:?})", object, allocator,);

--- a/src/util/forwarding_word.rs
+++ b/src/util/forwarding_word.rs
@@ -58,10 +58,10 @@ pub fn spin_and_get_forwarded_object<VM: VMBinding>(
 
 pub fn forward_object<VM: VMBinding, CC: CopyContext>(
     object: ObjectReference,
-    allocator: AllocationSemantics,
+    semantics: AllocationSemantics,
     copy_context: &mut CC,
 ) -> ObjectReference {
-    let new_object = VM::VMObjectModel::copy(object, allocator, copy_context);
+    let new_object = VM::VMObjectModel::copy(object, semantics, copy_context);
     let forwarded = (FORWARDED as usize) << VM::VMObjectModel::GC_BYTE_OFFSET;
     VM::VMObjectModel::write_available_bits_word(
         object,

--- a/src/util/forwarding_word.rs
+++ b/src/util/forwarding_word.rs
@@ -3,7 +3,7 @@ use crate::util::{Address, ObjectReference};
 use crate::vm::ObjectModel;
 use std::sync::atomic::Ordering;
 
-use crate::plan::{Allocator, CopyContext};
+use crate::plan::{AllocationSemantic, CopyContext};
 use crate::vm::VMBinding;
 
 // ...00
@@ -58,7 +58,7 @@ pub fn spin_and_get_forwarded_object<VM: VMBinding>(
 
 pub fn forward_object<VM: VMBinding, CC: CopyContext>(
     object: ObjectReference,
-    allocator: Allocator,
+    allocator: AllocationSemantic,
     copy_context: &mut CC,
 ) -> ObjectReference {
     let new_object = VM::VMObjectModel::copy(object, allocator, copy_context);

--- a/src/util/forwarding_word.rs
+++ b/src/util/forwarding_word.rs
@@ -3,7 +3,7 @@ use crate::util::{Address, ObjectReference};
 use crate::vm::ObjectModel;
 use std::sync::atomic::Ordering;
 
-use crate::plan::{AllocationSemantic, CopyContext};
+use crate::plan::{AllocationSemantics, CopyContext};
 use crate::vm::VMBinding;
 
 // ...00
@@ -58,7 +58,7 @@ pub fn spin_and_get_forwarded_object<VM: VMBinding>(
 
 pub fn forward_object<VM: VMBinding, CC: CopyContext>(
     object: ObjectReference,
-    allocator: AllocationSemantic,
+    allocator: AllocationSemantics,
     copy_context: &mut CC,
 ) -> ObjectReference {
     let new_object = VM::VMObjectModel::copy(object, allocator, copy_context);

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -1,7 +1,7 @@
 use crate::plan::CopyContext;
 use crate::util::{Address, ObjectReference};
 use crate::vm::VMBinding;
-use crate::AllocationSemantic;
+use crate::AllocationSemantics;
 use std::sync::atomic::AtomicU8;
 
 /// VM-specific methods for object model.
@@ -30,7 +30,7 @@ pub trait ObjectModel<VM: VMBinding> {
     /// * `copy_context`: The `CopyContext` for the GC thread.
     fn copy(
         from: ObjectReference,
-        allocator: AllocationSemantic,
+        allocator: AllocationSemantics,
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference;
 

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -1,7 +1,7 @@
 use crate::plan::CopyContext;
 use crate::util::{Address, ObjectReference};
 use crate::vm::VMBinding;
-use crate::Allocator;
+use crate::AllocationSemantic;
 use std::sync::atomic::AtomicU8;
 
 /// VM-specific methods for object model.
@@ -30,7 +30,7 @@ pub trait ObjectModel<VM: VMBinding> {
     /// * `copy_context`: The `CopyContext` for the GC thread.
     fn copy(
         from: ObjectReference,
-        allocator: Allocator,
+        allocator: AllocationSemantic,
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference;
 

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -26,11 +26,11 @@ pub trait ObjectModel<VM: VMBinding> {
     ///
     /// Arguments:
     /// * `from`: The address of the object to be copied.
-    /// * `allocator`: The allocation semantic to use.
+    /// * `semantics`: The allocation semantic to use.
     /// * `copy_context`: The `CopyContext` for the GC thread.
     fn copy(
         from: ObjectReference,
-        allocator: AllocationSemantics,
+        semantics: AllocationSemantics,
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference;
 

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -4,7 +4,7 @@
 use libc::c_char;
 use std::ffi::CStr;
 use mmtk::memory_manager;
-use mmtk::Allocator;
+use mmtk::AllocationSemantic;
 use mmtk::util::{ObjectReference, OpaquePointer, Address};
 use mmtk::SelectedPlan;
 use mmtk::scheduler::GCWorker;
@@ -39,13 +39,13 @@ pub extern "C" fn destroy_mutator(mutator: *mut Mutator<SelectedPlan<DummyVM>>) 
 
 #[no_mangle]
 pub extern "C" fn alloc(mutator: *mut Mutator<SelectedPlan<DummyVM>>, size: usize,
-                    align: usize, offset: isize, allocator: Allocator) -> Address {
+                    align: usize, offset: isize, allocator: AllocationSemantic) -> Address {
     memory_manager::alloc::<DummyVM>(unsafe { &mut *mutator }, size, align, offset, allocator)
 }
 
 #[no_mangle]
 pub extern "C" fn post_alloc(mutator: *mut Mutator<SelectedPlan<DummyVM>>, refer: ObjectReference, type_refer: ObjectReference,
-                                        bytes: usize, allocator: Allocator) {
+                                        bytes: usize, allocator: AllocationSemantic) {
     memory_manager::post_alloc::<DummyVM>(unsafe { &mut *mutator }, refer, type_refer, bytes, allocator)
 }
 

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -4,7 +4,7 @@
 use libc::c_char;
 use std::ffi::CStr;
 use mmtk::memory_manager;
-use mmtk::AllocationSemantic;
+use mmtk::AllocationSemantics;
 use mmtk::util::{ObjectReference, OpaquePointer, Address};
 use mmtk::SelectedPlan;
 use mmtk::scheduler::GCWorker;
@@ -39,13 +39,13 @@ pub extern "C" fn destroy_mutator(mutator: *mut Mutator<SelectedPlan<DummyVM>>) 
 
 #[no_mangle]
 pub extern "C" fn alloc(mutator: *mut Mutator<SelectedPlan<DummyVM>>, size: usize,
-                    align: usize, offset: isize, allocator: AllocationSemantic) -> Address {
+                    align: usize, offset: isize, allocator: AllocationSemantics) -> Address {
     memory_manager::alloc::<DummyVM>(unsafe { &mut *mutator }, size, align, offset, allocator)
 }
 
 #[no_mangle]
 pub extern "C" fn post_alloc(mutator: *mut Mutator<SelectedPlan<DummyVM>>, refer: ObjectReference, type_refer: ObjectReference,
-                                        bytes: usize, allocator: AllocationSemantic) {
+                                        bytes: usize, allocator: AllocationSemantics) {
     memory_manager::post_alloc::<DummyVM>(unsafe { &mut *mutator }, refer, type_refer, bytes, allocator)
 }
 

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -39,14 +39,14 @@ pub extern "C" fn destroy_mutator(mutator: *mut Mutator<SelectedPlan<DummyVM>>) 
 
 #[no_mangle]
 pub extern "C" fn alloc(mutator: *mut Mutator<SelectedPlan<DummyVM>>, size: usize,
-                    align: usize, offset: isize, allocator: AllocationSemantics) -> Address {
-    memory_manager::alloc::<DummyVM>(unsafe { &mut *mutator }, size, align, offset, allocator)
+                    align: usize, offset: isize, semantics: AllocationSemantics) -> Address {
+    memory_manager::alloc::<DummyVM>(unsafe { &mut *mutator }, size, align, offset, semantics)
 }
 
 #[no_mangle]
 pub extern "C" fn post_alloc(mutator: *mut Mutator<SelectedPlan<DummyVM>>, refer: ObjectReference, type_refer: ObjectReference,
-                                        bytes: usize, allocator: AllocationSemantics) {
-    memory_manager::post_alloc::<DummyVM>(unsafe { &mut *mutator }, refer, type_refer, bytes, allocator)
+                                        bytes: usize, semantics: AllocationSemantics) {
+    memory_manager::post_alloc::<DummyVM>(unsafe { &mut *mutator }, refer, type_refer, bytes, semantics)
 }
 
 #[no_mangle]

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -1,6 +1,6 @@
 use mmtk::vm::ObjectModel;
 use mmtk::util::{Address, ObjectReference};
-use mmtk::Allocator;
+use mmtk::AllocationSemantic;
 use mmtk::CopyContext;
 use DummyVM;
 use std::sync::atomic::AtomicU8;
@@ -14,7 +14,7 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         unimplemented!()
     }
 
-    fn copy(_from: ObjectReference, _allocator: Allocator, _copy_context: &mut impl CopyContext) -> ObjectReference {
+    fn copy(_from: ObjectReference, _allocator: AllocationSemantic, _copy_context: &mut impl CopyContext) -> ObjectReference {
         unimplemented!()
     }
 

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -1,6 +1,6 @@
 use mmtk::vm::ObjectModel;
 use mmtk::util::{Address, ObjectReference};
-use mmtk::AllocationSemantic;
+use mmtk::AllocationSemantics;
 use mmtk::CopyContext;
 use DummyVM;
 use std::sync::atomic::AtomicU8;
@@ -14,7 +14,7 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         unimplemented!()
     }
 
-    fn copy(_from: ObjectReference, _allocator: AllocationSemantic, _copy_context: &mut impl CopyContext) -> ObjectReference {
+    fn copy(_from: ObjectReference, _allocator: AllocationSemantics, _copy_context: &mut impl CopyContext) -> ObjectReference {
         unimplemented!()
     }
 

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -14,7 +14,7 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         unimplemented!()
     }
 
-    fn copy(_from: ObjectReference, _allocator: AllocationSemantics, _copy_context: &mut impl CopyContext) -> ObjectReference {
+    fn copy(_from: ObjectReference, _semantics: AllocationSemantics, _copy_context: &mut impl CopyContext) -> ObjectReference {
         unimplemented!()
     }
 

--- a/vmbindings/dummyvm/src/tests/issue139.rs
+++ b/vmbindings/dummyvm/src/tests/issue139.rs
@@ -1,6 +1,6 @@
 use crate::api::*;
 use mmtk::util::OpaquePointer;
-use mmtk::Allocator;
+use mmtk::AllocationSemantic;
 
 #[test]
 pub fn issue139_alloc_non_multiple_of_min_alignment() {
@@ -8,10 +8,10 @@ pub fn issue139_alloc_non_multiple_of_min_alignment() {
     let handle = bind_mutator(OpaquePointer::UNINITIALIZED);
 
     // Allocate 6 bytes with 8 bytes ailgnment required
-    let addr = alloc(handle, 6, 8, 0, Allocator::Default);
+    let addr = alloc(handle, 6, 8, 0, AllocationSemantic::Default);
     assert!(addr.is_aligned_to(8));
     // After the allocation, the cursor is not MIN_ALIGNMENT aligned. If we have the assertion in the next allocation to check if the cursor is aligned to MIN_ALIGNMENT, it fails.
     // We have to remove that assertion.
-    let addr2 = alloc(handle, 6, 8, 0, Allocator::Default);
+    let addr2 = alloc(handle, 6, 8, 0, AllocationSemantic::Default);
     assert!(addr2.is_aligned_to(8));
 }

--- a/vmbindings/dummyvm/src/tests/issue139.rs
+++ b/vmbindings/dummyvm/src/tests/issue139.rs
@@ -1,6 +1,6 @@
 use crate::api::*;
 use mmtk::util::OpaquePointer;
-use mmtk::AllocationSemantic;
+use mmtk::AllocationSemantics;
 
 #[test]
 pub fn issue139_alloc_non_multiple_of_min_alignment() {
@@ -8,10 +8,10 @@ pub fn issue139_alloc_non_multiple_of_min_alignment() {
     let handle = bind_mutator(OpaquePointer::UNINITIALIZED);
 
     // Allocate 6 bytes with 8 bytes ailgnment required
-    let addr = alloc(handle, 6, 8, 0, AllocationSemantic::Default);
+    let addr = alloc(handle, 6, 8, 0, AllocationSemantics::Default);
     assert!(addr.is_aligned_to(8));
     // After the allocation, the cursor is not MIN_ALIGNMENT aligned. If we have the assertion in the next allocation to check if the cursor is aligned to MIN_ALIGNMENT, it fails.
     // We have to remove that assertion.
-    let addr2 = alloc(handle, 6, 8, 0, AllocationSemantic::Default);
+    let addr2 = alloc(handle, 6, 8, 0, AllocationSemantics::Default);
     assert!(addr2.is_aligned_to(8));
 }


### PR DESCRIPTION
This PR renames the confusing `enum Allocator` to `enum AllocationSemantic`. This is the first step for https://github.com/mmtk/mmtk-core/issues/142. 
* Rename `enum Allocator`
* Uses ci-perf-kit 0.4.3 which fixed a bug that causes the CI run `jikesrvm-perf-compare` to fail.