### PR TITLE
Bump version for v0.1

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -1,7 +1,10 @@
 name: Post Code Review Checks (Micro Benchmarks)
 
 on:
-  pull_request
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - master
 
 jobs:
   openjdk-microbm:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmtk"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["The MMTk Developers <>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ name = "mmtk"
 crate-type = ["rlib"]
 doctest = false
 
+[package.metadata.docs.rs]
+features = ["semispace"]
+
 [dependencies]
 custom_derive = "0.1"
 enum_derive = "0.1"


### PR DESCRIPTION
* Change `micro-bm.yml` so it is triggered in the same way as `post-review-ci.yml`.
* Bump version to 0.1.0
* Add metadata for building docs on https://docs.rs.