### PR TITLE
Fix JikesRVM stress test

### DIFF
--- a/.github/workflows/stress-ci.yml
+++ b/.github/workflows/stress-ci.yml
@@ -1,7 +1,12 @@
 name: Stress Test CI
 
+# on:
+#   push:
+#     branches:
+#       - master
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - master
 

--- a/.github/workflows/stress-ci.yml
+++ b/.github/workflows/stress-ci.yml
@@ -1,12 +1,7 @@
 name: Stress Test CI
 
-# on:
-#   push:
-#     branches:
-#       - master
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
+  push:
     branches:
       - master
 

--- a/.github/workflows/stress-ci.yml
+++ b/.github/workflows/stress-ci.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true
       # setup
       - name: Overwrite MMTk core in JikesRVM binding
-        run: rsync -avLe mmtk-core/* mmtk-jikesrvm/repos/mmtk-core/
+        run: cp -r mmtk-core mmtk-jikesrvm/repos/
       - name: Setup
         run: |
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-jikesrvm/mmtk/Cargo.toml


### PR DESCRIPTION
This PR fixes wrong workflow steps for building JikesRVM binding. The stress tests will still fail. 