### PR TITLE
Include v8 tests in CI

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   openjdk-microbm:
     runs-on: [self-hosted, Linux, freq-scaling-off]
-    if: contains(github.event.pull_request.labels.*.name, 'PR-approved') || contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+    if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
         uses: qinsoon/comment-env-vars@1.0.1

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -29,17 +29,21 @@ jobs:
           ref: ${{ env.V8_BINDING_REF }}
       - name: Overwrite MMTk core in V8 binding
         run: |
-          cp -r mmtk-core mmtk-v8/repos
+          rm -rf mmtk-v8/repos/*
+          mkdir -p mmtk-v8/repos/mmtk-core
+          cp -r mmtk-core/* mmtk-v8/repos/mmtk-core
+          ls mmtk-v8/repos/mmtk-core
       - name: Setup
         run: |
           cd mmtk-v8
           RUSTUP_TOOLCHAIN=nightly-2020-07-08 ./.github/scripts/ci-setup.sh
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
+          cat mmtk/Cargo.toml
       - name: Test
         run: |
           cd mmtk-v8
-          RUSTUP_TOOLCHAIN=nightly-2020-07-08 V8_ROOT=repos/ .github/scripts/ci-test.sh
+          RUSTUP_TOOLCHAIN=nightly-2020-07-08 V8_ROOT=$GITHUB_WORKSPACE/v8_deps .github/scripts/ci-test.sh
 
   # JikesRVM
   jikesrvm-binding-test:

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           path: mmtk-v8
           ref: ${{ env.V8_BINDING_REF }}
-        - name: Overwrite MMTk core in V8 binding
+      - name: Overwrite MMTk core in V8 binding
         run: |
           cp -r mmtk-core mmtk-v8/repos
       - name: Setup

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -10,6 +10,7 @@ jobs:
   v8-binding-test:
     runs-on: [self-hosted, linux, freq-scaling-on]
     timeout-minutes: 60
+    if: contains(github.event.pull_request.labels.*.name, 'PR-testing')
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2
@@ -49,7 +50,7 @@ jobs:
   jikesrvm-binding-test:
     runs-on: ubuntu-18.04
     timeout-minutes: 60
-    if: contains(github.event.pull_request.labels.*.name, 'PR-approved') || contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+    if: contains(github.event.pull_request.labels.*.name, 'PR-testing')
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2
@@ -83,7 +84,7 @@ jobs:
           RUSTUP_TOOLCHAIN=nightly-2020-07-08 ./.github/scripts/ci-test.sh
   jikesrvm-perf-compare:
     runs-on: [self-hosted, Linux, freq-scaling-off]
-    if: contains(github.event.pull_request.labels.*.name, 'PR-approved') || contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+    if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
         uses: qinsoon/comment-env-vars@1.0.1
@@ -173,7 +174,7 @@ jobs:
   openjdk-binding-test:
     runs-on: ubuntu-18.04
     timeout-minutes: 60
-    if: contains(github.event.pull_request.labels.*.name, 'PR-approved') || contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+    if: contains(github.event.pull_request.labels.*.name, 'PR-testing')
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2
@@ -206,7 +207,7 @@ jobs:
           RUSTUP_TOOLCHAIN=nightly-2020-07-08 ./.github/scripts/ci-test.sh
   openjdk-perf-compare:
     runs-on: [self-hosted, Linux, freq-scaling-off]
-    if: contains(github.event.pull_request.labels.*.name, 'PR-approved') || contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+    if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
         uses: qinsoon/comment-env-vars@1.0.1

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -7,6 +7,40 @@ on:
       - master
 
 jobs:
+  v8-binding-test:
+    runs-on: [self-hosted, linux, freq-scaling-on]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v2
+        with:
+          path: mmtk-core
+      - name: Check Binding Revision
+        uses: qinsoon/comment-env-vars@1.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          default_env: 'V8_BINDING_REF=master'
+      - name: Checkout V8 Binding
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/mmtk-v8
+          token: ${{ secrets.CI_ACCESS_TOKEN }}
+          path: mmtk-v8
+          ref: ${{ env.V8_BINDING_REF }}
+        - name: Overwrite MMTk core in V8 binding
+        run: |
+          cp -r mmtk-core mmtk-v8/repos
+      - name: Setup
+        run: |
+          cd mmtk-v8
+          RUSTUP_TOOLCHAIN=nightly-2020-07-08 ./.github/scripts/ci-setup.sh
+          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
+          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
+      - name: Test
+        run: |
+          cd mmtk-v8
+          RUSTUP_TOOLCHAIN=nightly-2020-07-08 V8_ROOT=repos/ .github/scripts/ci-test.sh
+
   # JikesRVM
   jikesrvm-binding-test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -33,14 +33,12 @@ jobs:
           rm -rf mmtk-v8/repos/*
           mkdir -p mmtk-v8/repos/mmtk-core
           cp -r mmtk-core/* mmtk-v8/repos/mmtk-core
-          ls mmtk-v8/repos/mmtk-core
       - name: Setup
         run: |
           cd mmtk-v8
           RUSTUP_TOOLCHAIN=nightly-2020-07-08 ./.github/scripts/ci-setup.sh
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
-          cat mmtk/Cargo.toml
       - name: Test
         run: |
           cd mmtk-v8


### PR DESCRIPTION
* Add tests for V8 binding.
* Now binding tests are triggered by the `PR-testing` label, and benchmarks are triggered by the `PR-benchmarking` label. Previously `PR-approved` and `PR-benchmarking` triggers both.