### PR TITLE
Fix SFT map bugs

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -25,6 +25,9 @@ pub struct CopySpace<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> SFT for CopySpace<VM> {
+    fn name(&self) -> &str {
+        self.get_name()
+    }
     fn is_live(&self, object: ObjectReference) -> bool {
         !self.from_space() || ForwardingWord::is_forwarded::<VM>(object)
     }

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -62,6 +62,7 @@ impl<VM: VMBinding> Space<VM> for CopySpace<VM> {
         // Borrow-checker fighting so that we can have a cyclic reference
         let me = unsafe { &*(self as *const Self) };
         self.pr.bind_space(me);
+        self.common().init(self.as_sft());
     }
 
     fn release_multiple_pages(&mut self, _start: Address) {

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -27,6 +27,9 @@ const GC_MARK_BIT_MASK: u8 = 1;
 const META_DATA_PAGES_PER_REGION: usize = CARD_META_PAGES_PER_REGION;
 
 impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
+    fn name(&self) -> &str {
+        self.get_name()
+    }
     fn is_live(&self, _object: ObjectReference) -> bool {
         true
     }

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -71,6 +71,7 @@ impl<VM: VMBinding> Space<VM> for ImmortalSpace<VM> {
         // Borrow-checker fighting so that we can have a cyclic reference
         let me = unsafe { &*(self as *const Self) };
         self.pr.bind_space(me);
+        self.common().init(self.as_sft());
     }
     fn release_multiple_pages(&mut self, _start: Address) {
         panic!("immortalspace only releases pages enmasse")

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -36,6 +36,9 @@ pub struct LargeObjectSpace<VM: VMBinding> {
 unsafe impl<VM: VMBinding> Sync for LargeObjectSpace<VM> {}
 
 impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
+    fn name(&self) -> &str {
+        self.get_name()
+    }
     fn is_live(&self, object: ObjectReference) -> bool {
         self.test_mark_bit(object, self.mark_state)
     }

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -1,6 +1,8 @@
 use crate::policy::space::{CommonSpace, Space, SFT};
 use crate::util::address::Address;
 use crate::util::heap::PageResource;
+use crate::mmtk::SFT_MAP;
+use crate::util::conversions::bytes_to_chunks_up;
 
 use crate::util::ObjectReference;
 
@@ -90,6 +92,7 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
         self.limit = AVAILABLE_START + total_bytes;
         // Eagerly memory map the entire heap (also zero all the memory)
         crate::util::memory::dzmmap(AVAILABLE_START, total_bytes).unwrap();
+        SFT_MAP.update(self.as_sft(), AVAILABLE_START, bytes_to_chunks_up(total_bytes));
     }
 
     fn reserved_pages(&self) -> usize {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -1,8 +1,8 @@
+use crate::mmtk::SFT_MAP;
 use crate::policy::space::{CommonSpace, Space, SFT};
 use crate::util::address::Address;
-use crate::util::heap::PageResource;
-use crate::mmtk::SFT_MAP;
 use crate::util::conversions::bytes_to_chunks_up;
+use crate::util::heap::PageResource;
 
 use crate::util::ObjectReference;
 
@@ -92,7 +92,11 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
         self.limit = AVAILABLE_START + total_bytes;
         // Eagerly memory map the entire heap (also zero all the memory)
         crate::util::memory::dzmmap(AVAILABLE_START, total_bytes).unwrap();
-        SFT_MAP.update(self.as_sft(), AVAILABLE_START, bytes_to_chunks_up(total_bytes));
+        SFT_MAP.update(
+            self.as_sft(),
+            AVAILABLE_START,
+            bytes_to_chunks_up(total_bytes),
+        );
     }
 
     fn reserved_pages(&self) -> usize {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -34,6 +34,9 @@ pub struct LockFreeImmortalSpace<VM: VMBinding> {
 unsafe impl<VM: VMBinding> Sync for LockFreeImmortalSpace<VM> {}
 
 impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
+    fn name(&self) -> &str {
+        self.get_name()
+    }
     fn is_live(&self, _object: ObjectReference) -> bool {
         unimplemented!()
     }

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -228,7 +228,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
      */
     fn grow_space(&self, start: Address, bytes: usize, new_chunk: bool) {
         if new_chunk {
-            let chunks = conversions::bytes_to_chunks_up(bytes);
+            let chunks = conversions::addr_range_to_chunks(start, start + bytes);
             SFT_MAP.update(self.as_sft() as *const (dyn SFT + Sync), start, chunks);
         }
     }

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -133,7 +133,28 @@ impl SFTMap {
         unsafe { &*res }
     }
 
-    fn trace_print_map(&self) {
+    // #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn log_update(&self, space: *const (dyn SFT + Sync), start: Address, chunks: usize) {
+        let first = start.chunk_index();
+        let end = start + (chunks << LOG_BYTES_IN_CHUNK);
+        debug!(
+            "Update SFT for [{}, {}) as {}",
+            start,
+            end,
+            unsafe { &(*space) }.name()
+        );
+        let start_chunk = chunk_index_to_address(first);
+        let end_chunk = chunk_index_to_address(first + chunks);
+        debug!(
+            "Update SFT for {} chunks of [{} #{}, {} #{})",
+            chunks,
+            start_chunk,
+            first,
+            end_chunk,
+            first + chunks
+        );
+
+        // print the entire SFT map
         const SPACE_PER_LINE: usize = 10;
         for i in (0..self.sft.len()).step_by(SPACE_PER_LINE) {
             let max = if i + SPACE_PER_LINE > self.sft.len() {
@@ -156,24 +177,7 @@ impl SFTMap {
             self.set(chunk, space);
         }
         if DEBUG_SFT {
-            let end = start + (chunks << LOG_BYTES_IN_CHUNK);
-            debug!(
-                "Update SFT for [{}, {}) as {}",
-                start,
-                end,
-                unsafe { &(*space) }.name()
-            );
-            let start_chunk = chunk_index_to_address(first);
-            let end_chunk = chunk_index_to_address(first + chunks);
-            debug!(
-                "Update SFT for {} chunks of [{} #{}, {} #{})",
-                chunks,
-                start_chunk,
-                first,
-                end_chunk,
-                first + chunks
-            );
-            self.trace_print_map();
+            self.log_update(space, start, chunks);
         }
     }
 
@@ -193,9 +197,9 @@ impl SFTMap {
          */
         let self_mut: &mut Self = unsafe { self.mut_self() };
         // It is okay to set empty to valid, or set valid to empty. It is wrong if we overwrite a valid value with another valid value.
-        assert!(
-            (self_mut.sft[chunk] == (&EMPTY_SPACE_SFT) as *const _)
-                || (sft == (&EMPTY_SPACE_SFT) as *const _),
+        debug_assert!(
+            (unsafe { self_mut.sft[chunk].as_ref() }.unwrap().name() == "empty")
+                || (unsafe { sft.as_ref() }.unwrap().name() == "empty"),
             "attempt to overwrite a non-empty chunk in SFT map"
         );
         self_mut.sft[chunk] = sft;

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -534,6 +534,13 @@ impl<VM: VMBinding> CommonSpace<VM> {
         rtn
     }
 
+    pub fn init(&self, sft: *const (dyn SFT + Sync)) {
+        // For contiguous space, we eagerly initialize SFT map based on its address range.
+        if self.contiguous {
+            SFT_MAP.update(sft, self.start, bytes_to_chunks_up(self.extent));
+        }
+    }
+
     pub fn vm_map(&self) -> &'static VMMap {
         self.vm_map
     }

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -123,7 +123,12 @@ impl SFTMap {
     pub fn get(&self, address: Address) -> &'static dyn SFT {
         let res = self.sft[address.chunk_index()];
         if DEBUG_SFT {
-            trace!("Get SFT for {} #{} = {}", address, address.chunk_index(), unsafe { &(*res) }.name());
+            trace!(
+                "Get SFT for {} #{} = {}",
+                address,
+                address.chunk_index(),
+                unsafe { &(*res) }.name()
+            );
         }
         unsafe { &*res }
     }
@@ -135,10 +140,22 @@ impl SFTMap {
         }
         if DEBUG_SFT {
             let end = start + (chunks << LOG_BYTES_IN_CHUNK);
-            debug!("Update SFT for [{}, {}) as {}", start, end, unsafe { &(*space) }.name());
+            debug!(
+                "Update SFT for [{}, {}) as {}",
+                start,
+                end,
+                unsafe { &(*space) }.name()
+            );
             let start_chunk = chunk_index_to_address(first);
             let end_chunk = chunk_index_to_address(first + chunks);
-            debug!("Update SFT for {} chunks of [{} #{}, {} #{})", chunks, start_chunk, first, end_chunk, first + chunks);
+            debug!(
+                "Update SFT for {} chunks of [{} #{}, {} #{})",
+                chunks,
+                start_chunk,
+                first,
+                end_chunk,
+                first + chunks
+            );
             const SPACE_PER_LINE: usize = 10;
             for i in (0..self.sft.len()).step_by(SPACE_PER_LINE) {
                 let max = if i + SPACE_PER_LINE > self.sft.len() {
@@ -147,7 +164,10 @@ impl SFTMap {
                     i + SPACE_PER_LINE
                 };
                 let chunks: Vec<usize> = (i..max).collect();
-                let space_names: Vec<&str> = chunks.iter().map(|&x| unsafe {&*self.sft[x]}.name()).collect();
+                let space_names: Vec<&str> = chunks
+                    .iter()
+                    .map(|&x| unsafe { &*self.sft[x] }.name())
+                    .collect();
                 trace!("Chunk {}: {}", i, space_names.join(","));
             }
         }
@@ -169,7 +189,11 @@ impl SFTMap {
          */
         let self_mut: &mut Self = unsafe { self.mut_self() };
         // It is okay to set empty to valid, or set valid to empty. It is wrong if we overwrite a valid value with another valid value.
-        assert!((self_mut.sft[chunk] == (&EMPTY_SPACE_SFT) as *const _) || (sft == (&EMPTY_SPACE_SFT) as *const _), "attempt to overwrite a non-empty chunk in SFT map");
+        assert!(
+            (self_mut.sft[chunk] == (&EMPTY_SPACE_SFT) as *const _)
+                || (sft == (&EMPTY_SPACE_SFT) as *const _),
+            "attempt to overwrite a non-empty chunk in SFT map"
+        );
         self_mut.sft[chunk] = sft;
     }
 }
@@ -474,7 +498,13 @@ impl<VM: VMBinding> CommonSpace<VM> {
         vm_map.insert(start, extent, rtn.descriptor);
 
         if DEBUG_SPACE {
-            println!("Created space {} [{}, {}) for {} bytes", rtn.name, start, start + extent, extent);
+            println!(
+                "Created space {} [{}, {}) for {} bytes",
+                rtn.name,
+                start,
+                start + extent,
+                extent
+            );
         }
 
         rtn

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -133,6 +133,23 @@ impl SFTMap {
         unsafe { &*res }
     }
 
+    fn trace_print_map(&self) {
+        const SPACE_PER_LINE: usize = 10;
+        for i in (0..self.sft.len()).step_by(SPACE_PER_LINE) {
+            let max = if i + SPACE_PER_LINE > self.sft.len() {
+                self.sft.len()
+            } else {
+                i + SPACE_PER_LINE
+            };
+            let chunks: Vec<usize> = (i..max).collect();
+            let space_names: Vec<&str> = chunks
+                .iter()
+                .map(|&x| unsafe { &*self.sft[x] }.name())
+                .collect();
+            trace!("Chunk {}: {}", i, space_names.join(","));
+        }
+    }
+
     pub fn update(&self, space: *const (dyn SFT + Sync), start: Address, chunks: usize) {
         let first = start.chunk_index();
         for chunk in first..(first + chunks) {
@@ -156,20 +173,7 @@ impl SFTMap {
                 end_chunk,
                 first + chunks
             );
-            const SPACE_PER_LINE: usize = 10;
-            for i in (0..self.sft.len()).step_by(SPACE_PER_LINE) {
-                let max = if i + SPACE_PER_LINE > self.sft.len() {
-                    self.sft.len()
-                } else {
-                    i + SPACE_PER_LINE
-                };
-                let chunks: Vec<usize> = (i..max).collect();
-                let space_names: Vec<&str> = chunks
-                    .iter()
-                    .map(|&x| unsafe { &*self.sft[x] }.name())
-                    .collect();
-                trace!("Chunk {}: {}", i, space_names.join(","));
-            }
+            self.trace_print_map();
         }
     }
 

--- a/src/util/conversions.rs
+++ b/src/util/conversions.rs
@@ -42,6 +42,10 @@ pub fn address_to_chunk_index(addr: Address) -> usize {
     addr >> LOG_BYTES_IN_CHUNK
 }
 
+pub fn addr_range_to_chunks(start: Address, end: Address) -> usize {
+    address_to_chunk_index(end) - address_to_chunk_index(start) + 1
+}
+
 pub const fn raw_align_up(val: usize, align: usize) -> usize {
     // See https://github.com/rust-lang/rust/blob/e620d0f337d0643c757bab791fc7d88d63217704/src/libcore/alloc.rs#L192
     val.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1)

--- a/src/util/conversions.rs
+++ b/src/util/conversions.rs
@@ -42,6 +42,10 @@ pub fn address_to_chunk_index(addr: Address) -> usize {
     addr >> LOG_BYTES_IN_CHUNK
 }
 
+pub fn chunk_index_to_address(chunk: usize) -> Address {
+    unsafe { Address::from_usize(chunk << LOG_BYTES_IN_CHUNK) }
+}
+
 pub fn addr_range_to_chunks(start: Address, end: Address) -> usize {
     address_to_chunk_index(end) - address_to_chunk_index(start) + 1
 }

--- a/src/util/conversions.rs
+++ b/src/util/conversions.rs
@@ -46,10 +46,6 @@ pub fn chunk_index_to_address(chunk: usize) -> Address {
     unsafe { Address::from_usize(chunk << LOG_BYTES_IN_CHUNK) }
 }
 
-pub fn addr_range_to_chunks(start: Address, end: Address) -> usize {
-    address_to_chunk_index(end) - address_to_chunk_index(start) + 1
-}
-
 pub const fn raw_align_up(val: usize, align: usize) -> usize {
     // See https://github.com/rust-lang/rust/blob/e620d0f337d0643c757bab791fc7d88d63217704/src/libcore/alloc.rs#L192
     val.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1)

--- a/src/util/heap/monotonepageresource.rs
+++ b/src/util/heap/monotonepageresource.rs
@@ -67,12 +67,18 @@ impl<VM: VMBinding> PageResource<VM> for MonotonePageResource<VM> {
         zeroed: bool,
         tls: OpaquePointer,
     ) -> Address {
-        debug!("In MonotonePageResource, reserved_pages = {}, required_pages = {}", reserved_pages, immut_required_pages);
+        debug!(
+            "In MonotonePageResource, reserved_pages = {}, required_pages = {}",
+            reserved_pages, immut_required_pages
+        );
         let mut required_pages = immut_required_pages;
         let mut new_chunk = false;
         let mut sync = self.sync.lock().unwrap();
         let mut rtn = sync.cursor;
-        debug!("cursor = {}, sentinel = {}, current_chunk = {}", sync.cursor, sync.sentinel, sync.current_chunk);
+        debug!(
+            "cursor = {}, sentinel = {}, current_chunk = {}",
+            sync.cursor, sync.sentinel, sync.current_chunk
+        );
 
         if cfg!(debug = "true") {
             /*

--- a/src/util/heap/monotonepageresource.rs
+++ b/src/util/heap/monotonepageresource.rs
@@ -67,10 +67,12 @@ impl<VM: VMBinding> PageResource<VM> for MonotonePageResource<VM> {
         zeroed: bool,
         tls: OpaquePointer,
     ) -> Address {
+        debug!("In MonotonePageResource, reserved_pages = {}, required_pages = {}", reserved_pages, immut_required_pages);
         let mut required_pages = immut_required_pages;
         let mut new_chunk = false;
         let mut sync = self.sync.lock().unwrap();
         let mut rtn = sync.cursor;
+        debug!("cursor = {}, sentinel = {}, current_chunk = {}", sync.cursor, sync.sentinel, sync.current_chunk);
 
         if cfg!(debug = "true") {
             /*
@@ -97,23 +99,16 @@ impl<VM: VMBinding> PageResource<VM> for MonotonePageResource<VM> {
             let region_start = Self::get_region_start(sync.cursor + pages_to_bytes(required_pages));
             let region_delta = region_start.get_offset(sync.cursor);
             if region_delta >= 0 {
-                new_chunk = true;
                 /* start new region, so adjust pages and return address accordingly */
                 required_pages +=
                     bytes_to_pages(region_delta as usize) + self.meta_data_pages_per_region;
                 rtn = region_start + pages_to_bytes(self.meta_data_pages_per_region);
             }
-        } else {
-            let region_start = Self::get_region_start(sync.cursor + pages_to_bytes(required_pages));
-            let region_delta = region_start.get_offset(sync.cursor);
-            if region_delta >= 0 {
-                new_chunk = true;
-            }
         }
         let bytes = pages_to_bytes(required_pages);
-        trace!("bytes={}", bytes);
+        debug!("bytes={}", bytes);
         let mut tmp = sync.cursor + bytes;
-        trace!("tmp={:?}", tmp);
+        debug!("tmp={:?}", tmp);
 
         if !self.common().contiguous && tmp > sync.sentinel {
             /* we're out of virtual memory within our discontiguous region, so ask for more */
@@ -145,6 +140,7 @@ impl<VM: VMBinding> PageResource<VM> for MonotonePageResource<VM> {
             //debug!("tmp={:?} <= sync.sentinel={:?}", tmp, sync.sentinel);
             let old = sync.cursor;
             sync.cursor = tmp;
+            debug!("update cursor = {}", tmp);
 
             /* In a contiguous space we can bump along into the next chunk, so preserve the currentChunk invariant */
             if self.common().contiguous && chunk_align_down(sync.cursor) != sync.current_chunk {


### PR DESCRIPTION
This PR fixes two issues for SFT map.
1. Previously there were cases where we overwrote entries in SFT map to a different value. 
2. Previously, for contiguous spaces, we relied on `grow_space()` to set SFT map. However, we should not 'grow space' for contiguous space, as its address range is known at creation.

This PR:
* Adds some debug logging for SFT map (guarded by `DEBUG_SFT_MAP`).
* Adds some assertions for SFT map
  * We only allow these transitions for entries in SFT map: from empty to a valid value (when we grow space to the chunks), from a valid value to empty (when clearing the chunks), or from a valid value to the same valid value (when we have initialized the map, but `ensuer_mapped()` is called)
  * `grow_space()` should only be called when the `start` is chunk aligned. Otherwise, we may overwrite entries in SFT map.
* In `MonotonePageResource.alloc_pages()`, `new_chunk` is only set to true when a space is discontiguous and we used up the current chunk, in which case, we actually acquire new chunks. 
* For contiguous spaces, we initialise SFT map at init time, as its address range is known at creation time. 