### PR TITLE
Fix deprecated set-env

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -12,7 +12,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.1
+        uses: qinsoon/comment-env-vars@1.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'OPENJDK_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,OPENJDK_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: mmtk-core
       - name: Check Binding Revision
-        uses: qinsoon/comment-env-vars@1.0.1
+        uses: qinsoon/comment-env-vars@1.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'V8_BINDING_REF=master'
@@ -55,7 +55,7 @@ jobs:
         with:
           path: mmtk-core
       - name: Check Binding Revision
-        uses: qinsoon/comment-env-vars@1.0.1
+        uses: qinsoon/comment-env-vars@1.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'JIKESRVM_BINDING_REF=master'
@@ -85,7 +85,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.1
+        uses: qinsoon/comment-env-vars@1.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'JIKESRVM_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,JIKESRVM_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'
@@ -179,7 +179,7 @@ jobs:
         with:
           path: mmtk-core
       - name: Check Binding Revision
-        uses: qinsoon/comment-env-vars@1.0.1
+        uses: qinsoon/comment-env-vars@1.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'OPENJDK_BINDING_REF=master'
@@ -208,7 +208,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.1
+        uses: qinsoon/comment-env-vars@1.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'OPENJDK_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,OPENJDK_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/stress-ci.yml
+++ b/.github/workflows/stress-ci.yml
@@ -35,7 +35,7 @@ jobs:
       # Set parameters
       - name: Set stress test parameters
         id: stress_test
-        run: echo "::set-env name=MMTK_STRESS_FACTOR::1"
+        run: echo "MMTK_STRESS_FACTOR=1" >> $GITHUB_ENV
       - name: antlr
         if: always()
         run:
@@ -110,8 +110,7 @@ jobs:
       # Set parameters
       - name: Set stress test parameters
         id: stress_test
-        run: |
-          echo "::set-env name=MMTK_STRESS_FACTOR::1"
+        run: echo "MMTK_STRESS_FACTOR=1" >> $GITHUB_ENV
       # Run
       - name: antlr
         if: always()


### PR DESCRIPTION
This fixes https://github.com/mmtk/mmtk-core/issues/145.
* Use comment-env-vars 1.0.2 (with the updated action-core of v1.2.6)
* Replace the use of set-env to env files.