### PR TITLE
Use env-logger. Allow logger initialisation to fail.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ downcast-rs = "1.1.1"
 atomic-traits = "0.2.0"
 atomic = "0.4.6"
 spin = "0.5.2"
+env_logger = "0.8.2"
 
 [dev-dependencies]
 crossbeam = "0.7.3"

--- a/src/mm/memory_manager.rs
+++ b/src/mm/memory_manager.rs
@@ -43,13 +43,19 @@ pub fn start_control_collector<VM: VMBinding>(mmtk: &MMTK<VM>, tls: OpaquePointe
 }
 
 /// Initialize an MMTk instance. A VM should call this method after creating an [MMTK](../mmtk/struct.MMTK.html)
-/// instance but before using any of the methods provided in MMTk.
+/// instance but before using any of the methods provided in MMTk. This method will attempt to initialize a
+/// logger. If the VM would like to use its own logger, it should initialize the logger before calling this method.
 ///
 /// Arguments:
 /// * `mmtk`: A reference to an MMTk instance to initialize.
 /// * `heap_size`: The heap size for the MMTk instance in bytes.
 pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
-    crate::util::logger::init().unwrap();
+    match crate::util::logger::try_init() {
+        Ok(_) => debug!("MMTk initialized the logger."),
+        Err(_) => debug!(
+            "MMTk failed to initialize the logger. Possibly a logger has been initialized by user."
+        ),
+    }
     mmtk.plan.gc_init(heap_size, &mmtk.vm_map, &mmtk.scheduler);
 }
 

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -157,20 +157,23 @@ impl SFTMap {
     }
 
     fn trace_sft_map(&self) {
-        // print the entire SFT map
-        const SPACE_PER_LINE: usize = 10;
-        for i in (0..self.sft.len()).step_by(SPACE_PER_LINE) {
-            let max = if i + SPACE_PER_LINE > self.sft.len() {
-                self.sft.len()
-            } else {
-                i + SPACE_PER_LINE
-            };
-            let chunks: Vec<usize> = (i..max).collect();
-            let space_names: Vec<&str> = chunks
-                .iter()
-                .map(|&x| unsafe { &*self.sft[x] }.name())
-                .collect();
-            trace!("Chunk {}: {}", i, space_names.join(","));
+        // For large heaps, it takes long to iterate each chunk. So check log level first.
+        if log::log_enabled!(log::Level::Trace) {
+            // print the entire SFT map
+            const SPACE_PER_LINE: usize = 10;
+            for i in (0..self.sft.len()).step_by(SPACE_PER_LINE) {
+                let max = if i + SPACE_PER_LINE > self.sft.len() {
+                    self.sft.len()
+                } else {
+                    i + SPACE_PER_LINE
+                };
+                let chunks: Vec<usize> = (i..max).collect();
+                let space_names: Vec<&str> = chunks
+                    .iter()
+                    .map(|&x| unsafe { &*self.sft[x] }.name())
+                    .collect();
+                trace!("Chunk {}: {}", i, space_names.join(","));
+            }
         }
     }
 

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -1,47 +1,9 @@
-use log::{self, LevelFilter, Log, Metadata, Record, SetLoggerError};
-use std::env;
-use std::thread;
+use log::{self, SetLoggerError};
 
-/// Adapted from SimpleLogger in crate `log`
-struct MMTkLogger;
-
-impl Log for MMTkLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        // Cap it at compilation time
-        // If built with debug, can be tweaked using "RUST_LOG" env var.
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            println!(
-                "{:?}[{}:{}:{}] {}",
-                thread::current().id(),
-                record.level(),
-                record.file().unwrap(),
-                record.line().unwrap(),
-                record.args()
-            );
-        }
-    }
-
-    fn flush(&self) {}
-}
-
-static LOGGER: MMTkLogger = MMTkLogger;
-
-pub fn init() -> Result<(), SetLoggerError> {
-    match env::var("RUST_LOG") {
-        Ok(log_level) => match log_level.as_ref() {
-            "OFF" => log::set_max_level(LevelFilter::Off),
-            "ERROR" => log::set_max_level(LevelFilter::Error),
-            "WARN" => log::set_max_level(LevelFilter::Warn),
-            "INFO" => log::set_max_level(LevelFilter::Info),
-            "DEBUG" => log::set_max_level(LevelFilter::Debug),
-            "TRACE" => log::set_max_level(LevelFilter::Trace),
-            _ => log::set_max_level(LevelFilter::Info),
-        },
-        Err(_) => log::set_max_level(LevelFilter::Info),
-    }
-    log::set_logger(&LOGGER)
+/// Attempt to init a env_logger for MMTk.
+pub fn try_init() -> Result<(), SetLoggerError> {
+    env_logger::try_init_from_env(
+        // By default, use info level logging.
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    )
 }


### PR DESCRIPTION
This PR addresses https://github.com/mmtk/mmtk-core/issues/22 and https://github.com/mmtk/mmtk-core/issues/169.
* Replace the simple `MMTkLogger` implementation with `env-logger` (https://crates.io/crates/env_logger), which allows logging at different levels for different modules.
* Allow logger initialisation to fail. For a VM binding or a VM that uses their logger and has initialized the logger, previously calling `gc_init()` will cause a crash as MMTk cannot initialize MMTk's logger. Now calling `gc_init()` is fine. 
* Adds a log level check before iterating SFT map.

This This closes #22, closes #169.