### PR TITLE
Gencopy allocator fix

### DIFF
--- a/src/plan/gencopy/mutator.rs
+++ b/src/plan/gencopy/mutator.rs
@@ -38,7 +38,6 @@ pub fn gencopy_mutator_release<VM: VMBinding>(
 lazy_static! {
     pub static ref ALLOCATOR_MAPPING: EnumMap<AllocationType, AllocatorSelector> = enum_map! {
         AllocationType::Default => AllocatorSelector::BumpPointer(0),
-        // TODO: JikesRVM support
         AllocationType::Immortal | AllocationType::Code | AllocationType::ReadOnly => AllocatorSelector::BumpPointer(1),
         AllocationType::Los => AllocatorSelector::LargeObject(0),
     };
@@ -52,8 +51,8 @@ pub fn create_gencopy_mutator<VM: VMBinding>(
         allocator_mapping: &*ALLOCATOR_MAPPING,
         space_mapping: box vec![
             (AllocatorSelector::BumpPointer(0), &mmtk.plan.nursery),
-            (AllocatorSelector::BumpPointer(1), mmtk.plan.fromspace()),
-            (AllocatorSelector::BumpPointer(2), mmtk.plan.tospace()),
+            (AllocatorSelector::BumpPointer(1), mmtk.plan.common.get_immortal()),
+            (AllocatorSelector::LargeObject(0), mmtk.plan.common.get_los()),
         ],
         prepare_func: &gencopy_mutator_prepare,
         release_func: &gencopy_mutator_release,

--- a/src/plan/gencopy/mutator.rs
+++ b/src/plan/gencopy/mutator.rs
@@ -51,8 +51,14 @@ pub fn create_gencopy_mutator<VM: VMBinding>(
         allocator_mapping: &*ALLOCATOR_MAPPING,
         space_mapping: box vec![
             (AllocatorSelector::BumpPointer(0), &mmtk.plan.nursery),
-            (AllocatorSelector::BumpPointer(1), mmtk.plan.common.get_immortal()),
-            (AllocatorSelector::LargeObject(0), mmtk.plan.common.get_los()),
+            (
+                AllocatorSelector::BumpPointer(1),
+                mmtk.plan.common.get_immortal(),
+            ),
+            (
+                AllocatorSelector::LargeObject(0),
+                mmtk.plan.common.get_los(),
+            ),
         ],
         prepare_func: &gencopy_mutator_prepare,
         release_func: &gencopy_mutator_release,

--- a/src/plan/gencopy/mutator.rs
+++ b/src/plan/gencopy/mutator.rs
@@ -24,7 +24,7 @@ pub fn gencopy_mutator_release<VM: VMBinding>(
     mutator: &mut Mutator<GenCopy<VM>>,
     _tls: OpaquePointer,
 ) {
-    // rebind the allocation bump pointer to the nursery space
+    // reset nursery allocator
     let bump_allocator = unsafe {
         mutator
             .allocators
@@ -32,7 +32,7 @@ pub fn gencopy_mutator_release<VM: VMBinding>(
     }
     .downcast_mut::<BumpAllocator<VM>>()
     .unwrap();
-    bump_allocator.rebind(Some(&mutator.plan.nursery));
+    bump_allocator.reset();
 }
 
 lazy_static! {

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -28,7 +28,7 @@ impl<VM: VMBinding> BumpAllocator<VM> {
         self.limit = limit;
     }
 
-    fn reset(&mut self) {
+    pub fn reset(&mut self) {
         self.cursor = unsafe { Address::zero() };
         self.limit = unsafe { Address::zero() };
     }


### PR DESCRIPTION
This PR fixes a few issues with gencopy. 
* Fixes the wrong allocator config for gencopy (as in https://github.com/mmtk/mmtk-core/issues/172)
   * We don't need allocators for mature spaces if we do not have pre-maturing.
   * Adds the allocator for large object space.
   * This should not affect OpenJDK, as it only uses the default allocator.
* We just need to reset nursery allocator rather than rebinding it to the same nursery space.