### PR TITLE
Cleanup space descriptor, remove force_32bit_heap_layout

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -18,10 +18,7 @@ cargo build --features semispace,vm_space,code_space,ro_space
 cargo build --features nogc,sanity
 cargo build --features semispace,sanity
 
-# Build different implementations of heap layout
-cargo build --features nogc,force_32bit_heap_layout
 # For x86_64-linux, also see if we can build for i686
 if [[ $arch == "x86_64" && $os == "linux" ]]; then
     cargo build --target i686-unknown-linux-gnu --features nogc
-    cargo build --target i686-unknown-linux-gnu --features nogc,force_32bit_heap_layout
 fi

--- a/.github/scripts/ci-style.sh
+++ b/.github/scripts/ci-style.sh
@@ -23,12 +23,9 @@ cargo clippy --tests --features nogc
 cargo clippy --manifest-path=vmbindings/dummyvm/Cargo.toml --features nogc
 cargo clippy --manifest-path=vmbindings/dummyvm/Cargo.toml --features semispace
 
-# check for different implementations of heap layout
-cargo clippy --features nogc,force_32bit_heap_layout
 # For x86_64-linux, also check for i686
 if [[ $arch == "x86_64" && $os == "linux" ]]; then
     cargo clippy --target x86_64-unknown-linux-gnu --features nogc
-    cargo clippy --target x86_64-unknown-linux-gnu --features nogc,force_32bit_heap_layout
 fi 
 
 # check format

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -2,7 +2,13 @@ set -xe
 
 cargo test --features nogc
 cargo test --features semispace
-cargo test --features nogc,force_32bit_heap_layout
+
+# For x86_64-linux, also check for i686
+if [[ $arch == "x86_64" && $os == "linux" ]]; then
+    cargo test --features nogc --target i686-unknown-linux-gnu
+    cargo test --features semispace --target i686-unknown-linux-gnu
+fi
+
 python examples/build.py
 
 # Test with DummyVM (each test in a separate run)

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -2,6 +2,7 @@ set -xe
 
 cargo test --features nogc
 cargo test --features semispace
+cargo test --features nogc,force_32bit_heap_layout
 python examples/build.py
 
 # Test with DummyVM (each test in a separate run)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ largeobjectspace = []
 lockfreeimmortalspace = []
 
 sanity = []
-force_32bit_heap_layout = []
 nogc_lock_free = ["nogc", "lockfreeimmortalspace"]
 nogc_no_zeroing = ["nogc_lock_free"]
 

--- a/src/util/heap/freelistpageresource.rs
+++ b/src/util/heap/freelistpageresource.rs
@@ -3,7 +3,6 @@ use std::sync::{Mutex, MutexGuard};
 
 use super::layout::map::Map;
 use super::layout::Mmapper;
-use super::vmrequest::HEAP_LAYOUT_64BIT;
 use super::PageResource;
 use crate::policy::space::Space;
 use crate::util::address::Address;
@@ -30,9 +29,7 @@ impl CommonFreeListPageResource {
     }
 
     pub fn resize_freelist(&mut self, start_address: Address) {
-        // debug_assert!((HEAP_LAYOUT_64BIT || !contiguous) && !Plan.isInitialized());
         self.start = start_address.align_up(BYTES_IN_REGION);
-        // self.free_list.resize_freelist();
     }
 }
 
@@ -157,7 +154,7 @@ impl<VM: VMBinding> FreeListPageResource<VM> {
             );
             common_flpr
         };
-        let growable = HEAP_LAYOUT_64BIT;
+        let growable = cfg!(target_pointer_width = "64");
         let mut flpr = FreeListPageResource {
             common: CommonPageResource::new(true, growable),
             common_flpr,

--- a/src/util/heap/layout/heap_layout.rs
+++ b/src/util/heap/layout/heap_layout.rs
@@ -1,19 +1,19 @@
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
+#[cfg(target_pointer_width = "32")]
 use crate::util::heap::layout::map32::Map32;
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
+#[cfg(target_pointer_width = "32")]
 use crate::util::heap::layout::ByteMapMmapper;
 
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
+#[cfg(target_pointer_width = "64")]
 use crate::util::heap::layout::map64::Map64;
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
+#[cfg(target_pointer_width = "64")]
 use crate::util::heap::layout::FragmentedMapper;
 
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
+#[cfg(target_pointer_width = "32")]
 pub type VMMap = Map32;
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
+#[cfg(target_pointer_width = "64")]
 pub type VMMap = Map64;
 
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
+#[cfg(target_pointer_width = "32")]
 pub type Mmapper = ByteMapMmapper;
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
+#[cfg(target_pointer_width = "64")]
 pub type Mmapper = FragmentedMapper;

--- a/src/util/heap/layout/mod.rs
+++ b/src/util/heap/layout/mod.rs
@@ -3,17 +3,17 @@ pub mod heap_parameters;
 pub mod vm_layout_constants;
 pub mod mmapper;
 pub use self::mmapper::Mmapper;
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
+#[cfg(target_pointer_width = "32")]
 mod byte_map_mmapper;
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
+#[cfg(target_pointer_width = "32")]
 pub use self::byte_map_mmapper::ByteMapMmapper;
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
+#[cfg(target_pointer_width = "64")]
 mod fragmented_mapper;
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
+#[cfg(target_pointer_width = "64")]
 pub use self::fragmented_mapper::FragmentedMapper;
 pub mod heap_layout;
 pub mod map;
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
+#[cfg(target_pointer_width = "32")]
 pub mod map32;
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
+#[cfg(target_pointer_width = "64")]
 pub mod map64;

--- a/src/util/heap/monotonepageresource.rs
+++ b/src/util/heap/monotonepageresource.rs
@@ -1,5 +1,4 @@
 use super::layout::vm_layout_constants::BYTES_IN_CHUNK;
-use super::vmrequest::HEAP_LAYOUT_64BIT;
 use crate::policy::space::required_chunks;
 use crate::util::address::Address;
 use crate::util::conversions::*;
@@ -202,7 +201,7 @@ impl<VM: VMBinding> MonotonePageResource<VM> {
         let sentinel = start + bytes;
 
         MonotonePageResource {
-            common: CommonPageResource::new(true, HEAP_LAYOUT_64BIT),
+            common: CommonPageResource::new(true, cfg!(target_pointer_width = "64")),
 
             meta_data_pages_per_region,
             sync: Mutex::new(MonotonePageResourceSync {

--- a/src/util/heap/space_descriptor.rs
+++ b/src/util/heap/space_descriptor.rs
@@ -1,6 +1,5 @@
 use super::vmrequest::HEAP_LAYOUT_64BIT;
 use crate::util::constants::*;
-#[cfg(target_pointer_width = "64")]
 use crate::util::heap::layout::heap_parameters;
 use crate::util::heap::layout::vm_layout_constants;
 use crate::util::Address;
@@ -17,7 +16,6 @@ const SIZE_BITS: usize = 10;
 const SIZE_MASK: usize = ((1 << SIZE_BITS) - 1) << SIZE_SHIFT;
 const EXPONENT_SHIFT: usize = SIZE_SHIFT + SIZE_BITS;
 const EXPONENT_BITS: usize = 5;
-#[cfg(target_pointer_width = "32")]
 const EXPONENT_MASK: usize = ((1 << EXPONENT_BITS) - 1) << EXPONENT_SHIFT;
 const MANTISSA_SHIFT: usize = EXPONENT_SHIFT + EXPONENT_BITS;
 const MANTISSA_BITS: usize = 14;
@@ -27,7 +25,7 @@ const BASE_EXPONENT: usize = BITS_IN_INT - MANTISSA_BITS;
 const INDEX_MASK: usize = !TYPE_MASK;
 const INDEX_SHIFT: usize = TYPE_BITS;
 
-static DISCONTIGUOUS_SPACE_INDEX: AtomicUsize = AtomicUsize::new(0);
+static DISCONTIGUOUS_SPACE_INDEX: AtomicUsize = AtomicUsize::new(DISCONTIG_INDEX_INCREMENT);
 const DISCONTIG_INDEX_INCREMENT: usize = 1 << TYPE_BITS;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -54,15 +52,7 @@ impl SpaceDescriptor {
             );
         }
         let chunks = (end - start) >> vm_layout_constants::LOG_BYTES_IN_CHUNK;
-        if cfg!(debug) {
-            // if (!start.isZero() && (chunks <= 0 || chunks >= (1 << SIZE_BITS))) {
-            //   Log.write("SpaceDescriptor.createDescriptor(", start);
-            //   Log.write(",", end);
-            //   Log.writeln(")");
-            //   Log.writeln("chunks = ", chunks);
-            // }
-            debug_assert!(!start.is_zero() && chunks > 0 && chunks < (1 << SIZE_BITS));
-        }
+        debug_assert!(!start.is_zero() && chunks > 0 && chunks < (1 << SIZE_BITS));
         let mut tmp = start >> BASE_EXPONENT;
         let mut exponent = 0;
         while (tmp != 0) && ((tmp & 1) == 0) {
@@ -103,19 +93,21 @@ impl SpaceDescriptor {
         (self.0 & TYPE_MASK) == TYPE_CONTIGUOUS_HI
     }
 
-    #[cfg(target_pointer_width = "64")]
     pub fn get_start(self) -> Address {
-        unsafe { Address::from_usize(self.get_index() << heap_parameters::LOG_SPACE_SIZE_64) }
-    }
+        if HEAP_LAYOUT_64BIT {
+            // This should not be called for 32 bits. So its fine, it won't overflow in 64bit.
+            #[allow(arithmetic_overflow)]
+            unsafe {
+                Address::from_usize(self.get_index() << heap_parameters::LOG_SPACE_SIZE_64)
+            }
+        } else {
+            debug_assert!(self.is_contiguous());
 
-    #[cfg(target_pointer_width = "32")]
-    pub fn get_start(self) -> Address {
-        debug_assert!(self.is_contiguous());
-
-        let descriptor = self.0;
-        let mantissa = descriptor >> MANTISSA_SHIFT;
-        let exponent = (descriptor & EXPONENT_MASK) >> EXPONENT_SHIFT;
-        unsafe { Address::from_usize(mantissa << (BASE_EXPONENT + exponent)) }
+            let descriptor = self.0;
+            let mantissa = descriptor >> MANTISSA_SHIFT;
+            let exponent = (descriptor & EXPONENT_MASK) >> EXPONENT_SHIFT;
+            unsafe { Address::from_usize(mantissa << (BASE_EXPONENT + exponent)) }
+        }
     }
 
     pub fn get_extent(self) -> usize {
@@ -134,5 +126,79 @@ impl SpaceDescriptor {
     pub fn get_index(self) -> usize {
         debug_assert!(HEAP_LAYOUT_64BIT);
         (self.0 & INDEX_MASK) >> INDEX_SHIFT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::heap::layout::vm_layout_constants::*;
+
+    #[test]
+    fn create_discontiguous_descriptor() {
+        let d1 = SpaceDescriptor::create_descriptor();
+        assert!(!d1.is_empty());
+        assert!(!d1.is_contiguous());
+        assert!(!d1.is_contiguous_hi());
+
+        let d2 = SpaceDescriptor::create_descriptor();
+        assert!(!d2.is_empty());
+        assert!(!d2.is_contiguous());
+        assert!(!d2.is_contiguous_hi());
+    }
+
+    const TEST_SPACE_SIZE: usize = BYTES_IN_CHUNK * 10;
+
+    #[test]
+    fn create_contiguous_descriptor_at_heap_start() {
+        let d = SpaceDescriptor::create_descriptor_from_heap_range(
+            HEAP_START,
+            HEAP_START + TEST_SPACE_SIZE,
+        );
+        assert!(!d.is_empty());
+        assert!(d.is_contiguous());
+        assert!(!d.is_contiguous_hi());
+        assert_eq!(d.get_start(), HEAP_START);
+        if HEAP_LAYOUT_64BIT {
+            assert_eq!(d.get_extent(), SPACE_SIZE_64);
+        } else {
+            assert_eq!(d.get_extent(), TEST_SPACE_SIZE);
+        }
+    }
+
+    #[test]
+    fn create_contiguous_descriptor_in_heap() {
+        let d = SpaceDescriptor::create_descriptor_from_heap_range(
+            HEAP_START + TEST_SPACE_SIZE,
+            HEAP_START + TEST_SPACE_SIZE * 2,
+        );
+        assert!(!d.is_empty());
+        assert!(d.is_contiguous());
+        assert!(!d.is_contiguous_hi());
+        if HEAP_LAYOUT_64BIT {
+            assert_eq!(d.get_start(), HEAP_START);
+            assert_eq!(d.get_extent(), SPACE_SIZE_64);
+        } else {
+            assert_eq!(d.get_start(), HEAP_START + TEST_SPACE_SIZE);
+            assert_eq!(d.get_extent(), TEST_SPACE_SIZE);
+        }
+    }
+
+    #[test]
+    fn create_contiguous_descriptor_at_heap_end() {
+        let d = SpaceDescriptor::create_descriptor_from_heap_range(
+            HEAP_END - TEST_SPACE_SIZE,
+            HEAP_END,
+        );
+        assert!(!d.is_empty());
+        assert!(d.is_contiguous());
+        assert!(d.is_contiguous_hi());
+        if HEAP_LAYOUT_64BIT {
+            assert_eq!(d.get_start(), HEAP_END - SPACE_SIZE_64);
+            assert_eq!(d.get_extent(), SPACE_SIZE_64);
+        } else {
+            assert_eq!(d.get_start(), HEAP_END - TEST_SPACE_SIZE);
+            assert_eq!(d.get_extent(), TEST_SPACE_SIZE);
+        }
     }
 }

--- a/src/util/heap/space_descriptor.rs
+++ b/src/util/heap/space_descriptor.rs
@@ -99,7 +99,7 @@ impl SpaceDescriptor {
         unsafe { Address::from_usize(self.get_index() << heap_parameters::LOG_SPACE_SIZE_64) }
     }
 
-    #[cfg(taget_pointer_width = "32")]
+    #[cfg(target_pointer_width = "32")]
     pub fn get_start(self) -> Address {
         debug_assert!(self.is_contiguous());
 

--- a/src/util/heap/vmrequest.rs
+++ b/src/util/heap/vmrequest.rs
@@ -2,13 +2,6 @@ use super::layout::vm_layout_constants::*;
 use crate::util::constants::*;
 use crate::util::Address;
 
-////////// FIXME //////////////
-#[cfg(any(target_pointer_width = "32", feature = "force_32bit_heap_layout"))]
-pub const HEAP_LAYOUT_32BIT: bool = true;
-#[cfg(all(target_pointer_width = "64", not(feature = "force_32bit_heap_layout")))]
-pub const HEAP_LAYOUT_32BIT: bool = false; // FIXME SERIOUSLY
-pub const HEAP_LAYOUT_64BIT: bool = !HEAP_LAYOUT_32BIT;
-
 #[derive(Clone, Copy, Debug)]
 pub enum VMRequest {
     RequestDiscontiguous,
@@ -43,14 +36,14 @@ impl VMRequest {
     }
 
     pub fn discontiguous() -> Self {
-        if HEAP_LAYOUT_64BIT {
+        if cfg!(target_pointer_width = "64") {
             return Self::common64bit(false);
         }
         VMRequest::RequestDiscontiguous
     }
 
     pub fn fixed_size(mb: usize) -> Self {
-        if HEAP_LAYOUT_64BIT {
+        if cfg!(target_pointer_width = "64") {
             return Self::common64bit(false);
         }
         VMRequest::RequestExtent {
@@ -60,14 +53,14 @@ impl VMRequest {
     }
 
     pub fn fraction(frac: f32) -> Self {
-        if HEAP_LAYOUT_64BIT {
+        if cfg!(target_pointer_width = "64") {
             return Self::common64bit(false);
         }
         VMRequest::RequestFraction { frac, top: false }
     }
 
     pub fn high_fixed_size(mb: usize) -> Self {
-        if HEAP_LAYOUT_64BIT {
+        if cfg!(target_pointer_width = "64") {
             return Self::common64bit(true);
         }
         VMRequest::RequestExtent {
@@ -77,7 +70,7 @@ impl VMRequest {
     }
 
     pub fn fixed_extent(extent: usize, top: bool) -> Self {
-        if HEAP_LAYOUT_64BIT {
+        if cfg!(target_pointer_width = "64") {
             return Self::common64bit(top);
         }
         VMRequest::RequestExtent { extent, top }


### PR DESCRIPTION
This PR
* Adds unit tests for space descriptor.
* Fixes https://github.com/mmtk/mmtk-core/issues/71 so that the first descriptor for discontiguous space will not be considered as empty.
* Removes the `force_32bit_heap_layout` feature. Whether we use 32bit heap or 64bit depends on the compilation target.