### PR TITLE
Bump version to v0.2

### DIFF
--- a/.github/scripts/ci-setup.sh
+++ b/.github/scripts/ci-setup.sh
@@ -1,4 +1,5 @@
 set -xe
 
 # Necessary libraries for 32bit mmtk build
+sudo apt-get update
 sudo apt-get install build-essential gcc-multilib -y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+0.2.0 (2020-12-18)
+===
+
+API
+---
+* Refactored the `ObjectModel` trait and it is clearer now that MMTk expects a GC byte from the VM.
+* Removed methods in the API that were marked as deprecated.
+* Minor changes to a few methods/traits in API.
+
+Misc
+---
+* Rewrote the implementation of GC byte and forwarding word due to the API change.
+* Calling `gc_init()` will not fail now if the binding has initialized its own logger.
+* Fixed a few bugs about incorrect entries in SFT map.
+* Fixed wrong allocator config for gencopy.
+* Fixed a bug that caused MMTk to panic with OOM in stress tests.
+* Fixed a bug that caused the first discontiguous space descriptor being considered as empty.
+
+0.1.0 (2020-11-04)
+===
+
+GC Plans
+---
+Added the following plans:
+* NoGC
+* SemiSpace
+* Generational Copying GC
+
+Allocators
+---
+Added the following allocators:
+* Bump Pointer Allocator
+* Large Object Allocator
+
+Policies
+---
+Added the following space policies:
+* Immortal (including variants)
+* Large object
+* Copy
+
+API
+---
+* Introduced bi-directional API between VM and MMTk
+
+Misc
+---
+* Implemented a scheduler, GC work packets and related statistics collecting mechanisms.
+* Implemented sanity checking.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmtk"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The MMTk Developers <>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ homepage = "https://www.mmtk.io"
 repository = "https://github.com/mmtk/mmtk-core"
 readme = "README.md"
 categories = ["memory-management"]
-keywords = ["gc", "allocation"]
+keywords = ["gc", "garbage", "collection", "garbage-collection", "allocation"]
 
 [lib]
 name = "mmtk"

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ $ cargo build --features <space separated features>
 ```
 
 You must specify a GC plan as a feature at build time.
-Currently, there are two different plans to choose from:
+You may choose from:
 
-* `--features nogc` for NoGC, and
-* `--features semispace` for SemiSpace.
+* `--features nogc` for NoGC (allocation only),
+* `--features semispace` for a semi space GC, or
+* `--features gencopy` for a generational copying GC.
 
-A full list of available features can be seen by examining [`Cargo.toml`](Cargo.toml).
+A full list of plans and other available features can be seen by examining [`Cargo.toml`](Cargo.toml).
 By passing the `--features` flag to the Rust compiler,
 we conditionally compile plan-specific code.
 You can optionally enable sanity checks by adding `sanity` to the set of features


### PR DESCRIPTION
* Bump version to 0.2.0
* Added keywords for garbage collection in `Cargo.toml`.
* Added missing description about the gencopy plan in `README.md`