### PR TITLE
Support for Side Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Cargo.lock
 /bench-exe
 /test_mmtk
 /test_mmtk_32
+**/.ccls-cache/**

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ Cargo.lock
 /bench-exe
 /test_mmtk
 /test_mmtk_32
-**/.ccls-cache/**

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -11,6 +11,7 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::constants::*;
 use crate::util::conversions::bytes_to_pages;
+use crate::util::gc_byte;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::layout::map::Map;
@@ -687,6 +688,11 @@ impl<VM: VMBinding> CommonPlan<VM> {
         vm_map: &'static VMMap,
         scheduler: &Arc<MMTkScheduler<VM>>,
     ) {
+        if !VM::VMObjectModel::HAS_GC_BYTE {
+            unsafe {
+                gc_byte::init_side_gcbyte();
+            }
+        }
         self.base.gc_init(heap_size, vm_map, scheduler);
         let unsync = unsafe { &mut *self.unsync.get() };
         unsync.immortal.init(vm_map);

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -688,11 +688,7 @@ impl<VM: VMBinding> CommonPlan<VM> {
         vm_map: &'static VMMap,
         scheduler: &Arc<MMTkScheduler<VM>>,
     ) {
-        if !VM::VMObjectModel::HAS_GC_BYTE {
-            unsafe {
-                gc_byte::init_side_gcbyte();
-            }
-        }
+        gc_byte::init_gcbyte::<VM>();
         self.base.gc_init(heap_size, vm_map, scheduler);
         let unsync = unsafe { &mut *self.unsync.get() };
         unsync.immortal.init(vm_map);

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -264,12 +264,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                 unsafe { Address::zero() }
             } else {
                 debug!("Space.acquire(), returned = {}", rtn);
-                if !VM::VMObjectModel::HAS_GC_BYTE
-                    && !gc_byte::ensure_gcbyte_space_is_mapped(
-                        rtn,
-                        conversions::pages_to_bytes(pages),
-                    )
-                {
+                if !gc_byte::try_map_gcbyte::<VM>(rtn, conversions::pages_to_bytes(pages)) {
                     // TODO(Javad): handle meta space allocation failure
                     panic!("failed to mmap meta memory");
                 }
@@ -341,9 +336,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
      */
     fn ensure_mapped(&self) {
         let chunks = conversions::bytes_to_chunks_up(self.common().extent);
-        if !VM::VMObjectModel::HAS_GC_BYTE
-            && !gc_byte::ensure_gcbyte_space_is_mapped(self.common().start, self.common().extent)
-        {
+        if !gc_byte::try_map_gcbyte::<VM>(self.common().start, self.common().extent) {
             // TODO(Javad): handle meta space allocation failure
             panic!("failed to mmap meta memory");
         }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -118,6 +118,14 @@ impl Shr<usize> for Address {
     }
 }
 
+/// Address << shift (get an index)
+impl Shl<usize> for Address {
+    type Output = usize;
+    fn shl(self, shift: usize) -> usize {
+        self.0 << shift
+    }
+}
+
 impl Address {
     pub const ZERO: Self = Address(0);
     pub const MAX: Self = Address(usize::max_value());

--- a/src/util/forwarding_word.rs
+++ b/src/util/forwarding_word.rs
@@ -58,9 +58,10 @@ pub fn spin_and_get_forwarded_object<VM: VMBinding>(
         }
     } else {
         panic!(
-            "Invalid header value 0x{:x} 0x{:x}",
+            "Invalid header value 0x{:x} 0x{:x} for object{}",
             gc_byte,
-            read_forwarding_word::<VM>(object)
+            read_forwarding_word::<VM>(object),
+            object
         )
     }
 }

--- a/src/util/gc_byte.rs
+++ b/src/util/gc_byte.rs
@@ -27,7 +27,7 @@ pub(crate) unsafe fn init_side_gcbyte() {
 }
 
 pub fn ensure_gcbyte_space_is_mapped(start: Address, size: usize) -> bool {
-    unsafe { SideMetadata::ensure_meta_space_is_mapped(start, size, SIDE_GCBYTE_ID) }
+    unsafe { SideMetadata::map_meta_space(start, size, SIDE_GCBYTE_ID) }
 }
 
 // TODO: we probably need to add non-atomic versions of the read and write methods

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -23,11 +23,13 @@ pub fn dzmmap(start: Address, size: usize) -> Result<Address> {
         }
         Ok(addr)
     } else {
-        assert!(result as usize <= 127,
-                "mmap with MAP_FIXED has unexpected behavior: demand zero mmap with MAP_FIXED on {:?} returned some other address {:?}",
-                start, result
-        );
-        Err(Error::from_raw_os_error(result as _))
+        // assert!(result as usize <= 127,
+        //         "mmap with MAP_FIXED has unexpected behavior: demand zero mmap with MAP_FIXED on {:?} returned some other address {:?}",
+        //         start, result
+        // );
+        Err(Error::from_raw_os_error(
+            unsafe { *libc::__errno_location() } as _,
+        ))
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -21,6 +21,7 @@ pub mod raw_memory_freelist;
 pub mod reference_processor;
 #[cfg(feature = "sanity")]
 pub mod sanity;
+pub mod side_metadata;
 pub mod statistics;
 mod synchronized_counter;
 pub mod treadmill;

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -1,4 +1,4 @@
-use super::helpers::{*, self};
+use super::helpers::{self, *};
 use crate::util::{constants, memory, Address};
 use std::sync::atomic::{AtomicU16, AtomicU32, AtomicU8, Ordering};
 
@@ -309,16 +309,12 @@ impl SideMetadata {
     }
 
     /// Bulk-zero a metadata space.
-    /// 
+    ///
     /// Arguments:
     ///
     /// `start` is the starting address of the data whose metadata is being zeroed.
     /// `size` is the size (in bytes) of the source data.
-    pub fn bzero_meta_space(
-        start: Address,
-        size: usize,
-        metadata_id: SideMetadataID,
-    ) {
+    pub fn bzero_meta_space(start: Address, size: usize, metadata_id: SideMetadataID) {
         let meta_start = helpers::address_to_meta_address(start, metadata_id);
         let meta_end = helpers::address_to_meta_address(start + size, metadata_id);
         memory::zero(meta_start, meta_end.as_usize() - meta_start.as_usize());
@@ -403,12 +399,12 @@ mod tests {
             ))
             .unwrap()
         );
-        assert!(
-            !helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+        assert!(!helpers::meta_page_is_mapped(
+            helpers::address_to_meta_page_address(
                 vm_layout_constants::HEAP_START + space_size,
                 metadata_id
-            ) + helpers::META_SPACE_PAGE_SIZE)
-            .unwrap()
-        );
+            ) + helpers::META_SPACE_PAGE_SIZE
+        )
+        .unwrap());
     }
 }

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -130,21 +130,18 @@ impl SideMetadata {
 
     pub fn load_atomic(metadata_id: SideMetadataID, data_addr: Address) -> usize {
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
-        // if cfg!(debug_assertions) {
-        assert!(
+        debug_assert!(
             meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
             "load_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
         );
-        // }
-        let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
 
+        let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
         if bits_num_log <= 3 {
             let lshift = meta_byte_lshift(data_addr, metadata_id) as u8;
             let mask = (((1usize << (1usize << bits_num_log)) - 1) << lshift) as u8;
             let byte_val = unsafe { meta_addr.atomic_load::<AtomicU8>(Ordering::SeqCst) };
-            // info!("load_atomic({}).meta_addr({}).byte_val(0x{:x}).mask(0x{:x}).lshift(0x{:x})", data_addr, meta_addr, byte_val, mask, lshift);
 
             ((byte_val & mask) as usize) >> lshift
         } else if bits_num_log == 4 {
@@ -157,27 +154,21 @@ impl SideMetadata {
     }
 
     pub fn store_atomic(metadata_id: SideMetadataID, data_addr: Address, metadata: usize) {
-        // info!("store_atomic({}, {}, 0x{:x})", metadata_id.as_usize(), data_addr, metadata);
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
-
-        // if cfg!(debug_assertions) {
-        assert!(
+        debug_assert!(
             meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
             "store_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
         );
-        // }
 
         let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
-
         if bits_num_log < 3 {
             let lshift = meta_byte_lshift(data_addr, metadata_id);
             let mask = ((1 << (1 << bits_num_log)) - 1) << lshift;
 
             let mut old_val = unsafe { meta_addr.load::<u8>() };
             let mut new_val = (old_val & !mask) | ((metadata as u8) << lshift);
-            // info!("store_atomic({}).meta_addr({}).old_val(0x{:x}).new_val(0x{:x}).mask(0x{:x})", data_addr, meta_addr, old_val, new_val, mask);
 
             while unsafe {
                 meta_addr
@@ -191,7 +182,6 @@ impl SideMetadata {
             } {
                 old_val = unsafe { meta_addr.load::<u8>() };
                 new_val = (old_val & !mask) | ((metadata as u8) << lshift);
-                // info!("store_atomic({}).meta_addr({}).old_val(0x{:x}).new_val(0x{:x})", data_addr, meta_addr, old_val, new_val);
             }
         } else if bits_num_log == 3 {
             unsafe { meta_addr.atomic_store::<AtomicU8>(metadata as u8, Ordering::SeqCst) };
@@ -211,15 +201,12 @@ impl SideMetadata {
         new_metadata: usize,
     ) -> bool {
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
-
-        // if cfg!(debug_assertions) {
-        assert!(
+        debug_assert!(
             meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
             "cmpxng_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
         );
-        // }
 
         let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
 
@@ -230,8 +217,6 @@ impl SideMetadata {
             let real_old_byte = unsafe { meta_addr.atomic_load::<AtomicU8>(Ordering::SeqCst) };
             let expected_old_byte = (real_old_byte & !mask) | ((old_metadata as u8) << lshift);
             let expected_new_byte = expected_old_byte | ((new_metadata as u8) << lshift);
-
-            // info!("SideMetadata::compare_exchange_atomic({}, 0x{:x}, 0x{:x})..meta_addr({}).real_old_byte(0x{:x}).exp_old_byte(0x{:x}).mask(0x{:x})", data_addr, old_metadata, new_metadata, meta_addr, real_old_byte, expected_new_byte, mask);
 
             unsafe {
                 meta_addr
@@ -321,5 +306,93 @@ impl SideMetadata {
         } else {
             todo!("side metadata > 32-bits is not supported yet!");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::constants;
+    use crate::util::heap::layout::vm_layout_constants;
+    use crate::util::side_metadata::helpers;
+    use crate::util::side_metadata::SideMetadata;
+
+    #[test]
+    fn test_side_metadata_request_meta_bits() {
+        for i in 0..5 {
+            SideMetadata::request_meta_bits(1 << i, constants::LOG_BYTES_IN_WORD as usize);
+        }
+    }
+
+    #[test]
+    fn test_ensure_meta_space_is_mapped_lt4kb() {
+        let number_of_bits = 1;
+        let number_of_bits_log = 0;
+        let align = constants::LOG_BYTES_IN_WORD as usize;
+        let space_size = 1;
+
+        let metadata_id = SideMetadata::request_meta_bits(number_of_bits, align);
+        assert!(SideMetadata::ensure_meta_space_is_mapped(
+            vm_layout_constants::HEAP_START,
+            space_size,
+            metadata_id
+        ));
+        assert!(
+            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+                vm_layout_constants::HEAP_START,
+                metadata_id
+            ))
+            .unwrap()
+        );
+        assert!(
+            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+                vm_layout_constants::HEAP_START + space_size,
+                metadata_id
+            ))
+            .unwrap()
+        );
+        assert!(
+            !helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+                vm_layout_constants::HEAP_START
+                    + (helpers::META_SPACE_PAGE_SIZE
+                        << (align + constants::LOG_BITS_IN_WORD - number_of_bits_log)),
+                metadata_id
+            ))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ensure_meta_space_is_mapped_gt4kb() {
+        let number_of_bits = 8;
+        let align = constants::LOG_BYTES_IN_WORD as usize;
+        let space_size = helpers::META_SPACE_PAGE_SIZE * 64 + 1;
+
+        let metadata_id = SideMetadata::request_meta_bits(number_of_bits, align);
+        assert!(SideMetadata::ensure_meta_space_is_mapped(
+            vm_layout_constants::HEAP_START,
+            space_size,
+            metadata_id
+        ));
+        assert!(
+            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+                vm_layout_constants::HEAP_START,
+                metadata_id
+            ))
+            .unwrap()
+        );
+        assert!(
+            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+                vm_layout_constants::HEAP_START + space_size,
+                metadata_id
+            ))
+            .unwrap()
+        );
+        assert!(
+            !helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+                vm_layout_constants::HEAP_START + space_size,
+                metadata_id
+            ) + helpers::META_SPACE_PAGE_SIZE)
+            .unwrap()
+        );
     }
 }

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -134,7 +134,8 @@ impl SideMetadata {
     pub fn load_atomic(metadata_id: SideMetadataID, data_addr: Address) -> usize {
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
         debug_assert!(
-            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            check_and_map_meta_page(address_to_meta_page_address(data_addr, metadata_id))
+                .is_mapped(),
             "load_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
@@ -174,7 +175,8 @@ impl SideMetadata {
     pub fn store_atomic(metadata_id: SideMetadataID, data_addr: Address, metadata: usize) {
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
         debug_assert!(
-            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            check_and_map_meta_page(address_to_meta_page_address(data_addr, metadata_id))
+                .is_mapped(),
             "store_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
@@ -235,7 +237,8 @@ impl SideMetadata {
     ) -> bool {
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
         debug_assert!(
-            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            check_and_map_meta_page(address_to_meta_page_address(data_addr, metadata_id))
+                .is_mapped(),
             "cmpxng_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
@@ -326,7 +329,8 @@ impl SideMetadata {
     pub fn fetch_add_atomic(metadata_id: SideMetadataID, data_addr: Address, val: usize) -> usize {
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
         debug_assert!(
-            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            check_and_map_meta_page(address_to_meta_page_address(data_addr, metadata_id))
+                .is_mapped(),
             "fetch_add_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
@@ -393,7 +397,8 @@ impl SideMetadata {
     pub fn fetch_sub_atomic(metadata_id: SideMetadataID, data_addr: Address, val: usize) -> usize {
         let meta_addr = address_to_meta_address(data_addr, metadata_id);
         debug_assert!(
-            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            check_and_map_meta_page(address_to_meta_page_address(data_addr, metadata_id))
+                .is_mapped(),
             "fetch_sub_atomic.metadata_addr({}) for data_addr({}) is not mapped",
             meta_addr,
             data_addr
@@ -588,27 +593,27 @@ mod tests {
             metadata_id
         ));
         assert!(
-            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+            helpers::check_and_map_meta_page(helpers::address_to_meta_page_address(
                 vm_layout_constants::HEAP_START,
                 metadata_id
             ))
-            .unwrap()
+            .is_mapped()
         );
         assert!(
-            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+            helpers::check_and_map_meta_page(helpers::address_to_meta_page_address(
                 vm_layout_constants::HEAP_START + space_size,
                 metadata_id
             ))
-            .unwrap()
+            .is_mapped()
         );
         assert!(
-            !helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+            !helpers::check_and_map_meta_page(helpers::address_to_meta_page_address(
                 vm_layout_constants::HEAP_START
                     + (helpers::META_SPACE_PAGE_SIZE
                         << (align + constants::LOG_BITS_IN_WORD - number_of_bits_log)),
                 metadata_id
             ))
-            .unwrap()
+            .is_mapped()
         );
     }
 
@@ -625,26 +630,26 @@ mod tests {
             metadata_id
         ));
         assert!(
-            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+            helpers::check_and_map_meta_page(helpers::address_to_meta_page_address(
                 vm_layout_constants::HEAP_START,
                 metadata_id
             ))
-            .unwrap()
+            .is_mapped()
         );
         assert!(
-            helpers::meta_page_is_mapped(helpers::address_to_meta_page_address(
+            helpers::check_and_map_meta_page(helpers::address_to_meta_page_address(
                 vm_layout_constants::HEAP_START + space_size,
                 metadata_id
             ))
-            .unwrap()
+            .is_mapped()
         );
-        assert!(!helpers::meta_page_is_mapped(
+        assert!(!helpers::check_and_map_meta_page(
             helpers::address_to_meta_page_address(
                 vm_layout_constants::HEAP_START + space_size,
                 metadata_id
             ) + helpers::META_SPACE_PAGE_SIZE
         )
-        .unwrap());
+        .is_mapped());
     }
 
     #[test]

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -1,0 +1,325 @@
+use super::helpers::*;
+use crate::util::{constants, Address};
+use std::sync::atomic::{AtomicU16, AtomicU32, AtomicU8, Ordering};
+
+// The following information about the target data is required:
+//     1. minimum data alignment (in #Bytes),
+//     2. global metadata size per data unit (in #bits),
+//     3. policy specific metadata size per data unit (in #bits)
+//
+// FACTS:
+// - Regardless of the number of bits in a metadata unit,
+// we always represent its content as a word.
+// - Policy-specific bits are required for all data units, so when a space
+// grows, all bits are grown as well.
+//
+
+pub(super) const INVALID_SIDEMETADATA_ID: SideMetadataID = SideMetadataID(MAX_METADATA_BITS + 1);
+
+// Starting from zero and increasing by one, this type works as a simple side metadata id
+#[derive(Copy, Clone)]
+pub struct SideMetadataID(usize);
+
+impl SideMetadataID {
+    pub const fn new() -> SideMetadataID {
+        INVALID_SIDEMETADATA_ID
+    }
+
+    pub fn as_usize(&self) -> usize {
+        self.0
+    }
+}
+
+// `align[metadata_id]` is the minimum alignment of the source data for `metadata_id`
+// `meta_bits_num_vec[metadata_id]` stores the number of bits requested for `metadata_id`
+// `meta_base_addr_vec[metadata_id]` stores the starting address of the memory to be mapped for the bits of `metadata_id`
+pub struct SideMetadata {
+    pub(super) align: Vec<usize>,
+    pub(super) meta_bits_num_log_vec: Vec<usize>,
+    pub(super) meta_base_addr_vec: Vec<Address>,
+}
+
+unsafe impl Sync for SideMetadata {}
+
+lazy_static! {
+    pub(super) static ref METADATA_SINGLETON: SideMetadata = SideMetadata {
+        align: Vec::with_capacity(MAX_METADATA_BITS),
+        meta_bits_num_log_vec: Vec::with_capacity(MAX_METADATA_BITS),
+        meta_base_addr_vec: Vec::with_capacity(MAX_METADATA_BITS),
+    };
+}
+
+impl SideMetadata {
+    // FIXME(Javad): check the possibility of a safe implementation.
+    #[allow(clippy::cast_ref_to_mut)]
+    #[allow(clippy::mut_from_ref)]
+    unsafe fn mut_self(&self) -> &mut Self {
+        &mut *(self as *const _ as *mut _)
+    }
+
+    // Adds the requested number of bits to the side metadata and returns an ID.
+    // This ID is used for the future references to these bits
+    // and allows choosing between bit sets (e.g. global and policy-specific bits, each have an ID).
+    //
+    // Arguments:
+    //
+    // `number_of_bits`: is the number of bits per source data unit (e.g. per object).
+    //   Currently, the maximum metadata size per data unit is a word (usize).
+    //
+    // `align`: is the minimum alignment of the source data.
+    //   The minimum data granularity is a word, which means the minimum value of this argument is 2 in 32-bits, and 3 in 64 bits systems.
+    pub fn request_meta_bits(number_of_bits: usize, align: usize) -> SideMetadataID {
+        assert!(
+            [1, 2, 4, 8, 16, 32].contains(&number_of_bits),
+            "number of metadata bits ({}) must be a power of two",
+            number_of_bits
+        );
+        assert!(
+            number_of_bits <= MAX_METADATA_BITS,
+            "Too many (>{}) metadata bits requested",
+            MAX_METADATA_BITS
+        );
+        assert!(
+            align >= (constants::LOG_BYTES_IN_WORD as usize),
+            "Alignment ({}) is less than minimum ({})",
+            align,
+            constants::LOG_BYTES_IN_WORD
+        );
+
+        let number_of_bits_log: usize = match number_of_bits {
+            1 => 0,
+            2 => 1,
+            4 => 2,
+            8 => 3,
+            16 => 4,
+            32 => 5,
+            _ => unreachable!(),
+        };
+        let next_id = SideMetadataID(METADATA_SINGLETON.meta_bits_num_log_vec.len());
+        unsafe {
+            METADATA_SINGLETON.mut_self().align.push(align);
+            METADATA_SINGLETON
+                .mut_self()
+                .meta_bits_num_log_vec
+                .push(number_of_bits_log);
+        }
+        let next_base_addr = if next_id.0 == 0 {
+            METADATA_BASE_ADDRESS
+        } else {
+            METADATA_SINGLETON.meta_base_addr_vec[next_id.0 - 1]
+                + meta_space_size(SideMetadataID(next_id.0 - 1))
+        };
+
+        unsafe {
+            METADATA_SINGLETON
+                .mut_self()
+                .meta_base_addr_vec
+                .push(next_base_addr);
+        }
+
+        next_id
+    }
+
+    pub fn ensure_meta_space_is_mapped(
+        start: Address,
+        size: usize,
+        metadata_id: SideMetadataID,
+    ) -> bool {
+        ensure_meta_is_mapped(start, size, metadata_id)
+    }
+
+    pub fn load_atomic(metadata_id: SideMetadataID, data_addr: Address) -> usize {
+        let meta_addr = address_to_meta_address(data_addr, metadata_id);
+        // if cfg!(debug_assertions) {
+        assert!(
+            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            "load_atomic.metadata_addr({}) for data_addr({}) is not mapped",
+            meta_addr,
+            data_addr
+        );
+        // }
+        let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
+
+        if bits_num_log <= 3 {
+            let lshift = meta_byte_lshift(data_addr, metadata_id) as u8;
+            let mask = (((1usize << (1usize << bits_num_log)) - 1) << lshift) as u8;
+            let byte_val = unsafe { meta_addr.atomic_load::<AtomicU8>(Ordering::SeqCst) };
+            // info!("load_atomic({}).meta_addr({}).byte_val(0x{:x}).mask(0x{:x}).lshift(0x{:x})", data_addr, meta_addr, byte_val, mask, lshift);
+
+            ((byte_val & mask) as usize) >> lshift
+        } else if bits_num_log == 4 {
+            unsafe { meta_addr.atomic_load::<AtomicU16>(Ordering::SeqCst) as usize }
+        } else if bits_num_log == 5 {
+            unsafe { meta_addr.atomic_load::<AtomicU32>(Ordering::SeqCst) as usize }
+        } else {
+            todo!("side metadata > 32-bits is not supported yet!")
+        }
+    }
+
+    pub fn store_atomic(metadata_id: SideMetadataID, data_addr: Address, metadata: usize) {
+        // info!("store_atomic({}, {}, 0x{:x})", metadata_id.as_usize(), data_addr, metadata);
+        let meta_addr = address_to_meta_address(data_addr, metadata_id);
+
+        // if cfg!(debug_assertions) {
+        assert!(
+            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            "store_atomic.metadata_addr({}) for data_addr({}) is not mapped",
+            meta_addr,
+            data_addr
+        );
+        // }
+
+        let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
+
+        if bits_num_log < 3 {
+            let lshift = meta_byte_lshift(data_addr, metadata_id);
+            let mask = ((1 << (1 << bits_num_log)) - 1) << lshift;
+
+            let mut old_val = unsafe { meta_addr.load::<u8>() };
+            let mut new_val = (old_val & !mask) | ((metadata as u8) << lshift);
+            // info!("store_atomic({}).meta_addr({}).old_val(0x{:x}).new_val(0x{:x}).mask(0x{:x})", data_addr, meta_addr, old_val, new_val, mask);
+
+            while unsafe {
+                meta_addr
+                    .compare_exchange::<AtomicU8>(
+                        old_val,
+                        new_val,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_err()
+            } {
+                old_val = unsafe { meta_addr.load::<u8>() };
+                new_val = (old_val & !mask) | ((metadata as u8) << lshift);
+                // info!("store_atomic({}).meta_addr({}).old_val(0x{:x}).new_val(0x{:x})", data_addr, meta_addr, old_val, new_val);
+            }
+        } else if bits_num_log == 3 {
+            unsafe { meta_addr.atomic_store::<AtomicU8>(metadata as u8, Ordering::SeqCst) };
+        } else if bits_num_log == 4 {
+            unsafe { meta_addr.atomic_store::<AtomicU16>(metadata as u16, Ordering::SeqCst) };
+        } else if bits_num_log == 5 {
+            unsafe { meta_addr.atomic_store::<AtomicU32>(metadata as u32, Ordering::SeqCst) };
+        } else {
+            todo!("side metadata > 32-bits is not supported yet!");
+        }
+    }
+
+    pub fn compare_exchange_atomic(
+        metadata_id: SideMetadataID,
+        data_addr: Address,
+        old_metadata: usize,
+        new_metadata: usize,
+    ) -> bool {
+        let meta_addr = address_to_meta_address(data_addr, metadata_id);
+
+        // if cfg!(debug_assertions) {
+        assert!(
+            meta_page_is_mapped(address_to_meta_page_address(data_addr, metadata_id)).unwrap(),
+            "cmpxng_atomic.metadata_addr({}) for data_addr({}) is not mapped",
+            meta_addr,
+            data_addr
+        );
+        // }
+
+        let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
+
+        if bits_num_log < 3 {
+            let lshift = meta_byte_lshift(data_addr, metadata_id);
+            let mask = ((1 << (1 << bits_num_log)) - 1) << lshift;
+
+            let real_old_byte = unsafe { meta_addr.atomic_load::<AtomicU8>(Ordering::SeqCst) };
+            let expected_old_byte = (real_old_byte & !mask) | ((old_metadata as u8) << lshift);
+            let expected_new_byte = expected_old_byte | ((new_metadata as u8) << lshift);
+
+            // info!("SideMetadata::compare_exchange_atomic({}, 0x{:x}, 0x{:x})..meta_addr({}).real_old_byte(0x{:x}).exp_old_byte(0x{:x}).mask(0x{:x})", data_addr, old_metadata, new_metadata, meta_addr, real_old_byte, expected_new_byte, mask);
+
+            unsafe {
+                meta_addr
+                    .compare_exchange::<AtomicU8>(
+                        expected_old_byte,
+                        expected_new_byte,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_ok()
+            }
+        } else if bits_num_log == 3 {
+            unsafe {
+                meta_addr
+                    .compare_exchange::<AtomicU8>(
+                        old_metadata as u8,
+                        new_metadata as u8,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_ok()
+            }
+        } else if bits_num_log == 4 {
+            unsafe {
+                meta_addr
+                    .compare_exchange::<AtomicU16>(
+                        old_metadata as u16,
+                        new_metadata as u16,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_ok()
+            }
+        } else if bits_num_log == 5 {
+            unsafe {
+                meta_addr
+                    .compare_exchange::<AtomicU32>(
+                        old_metadata as u32,
+                        new_metadata as u32,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_ok()
+            }
+        } else {
+            todo!("side metadata > 32-bits is not supported yet!")
+        }
+    }
+
+    pub fn load(metadata_id: SideMetadataID, data_addr: Address) -> usize {
+        let meta_addr = address_to_meta_address(data_addr, metadata_id);
+        let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
+
+        if bits_num_log <= 3 {
+            let lshift = meta_byte_lshift(data_addr, metadata_id);
+            let mask = ((1 << (1 << bits_num_log)) - 1) << lshift;
+            let byte_val = unsafe { meta_addr.load::<u8>() };
+
+            ((byte_val & mask) as usize) >> lshift
+        } else if bits_num_log == 4 {
+            unsafe { meta_addr.load::<u16>() as usize }
+        } else if bits_num_log == 5 {
+            unsafe { meta_addr.load::<u32>() as usize }
+        } else {
+            todo!("side metadata > 32-bits is not supported yet!")
+        }
+    }
+
+    pub fn store(metadata_id: SideMetadataID, data_addr: Address, metadata: usize) {
+        let meta_addr = address_to_meta_address(data_addr, metadata_id);
+        let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.0];
+
+        if bits_num_log < 3 {
+            let lshift = meta_byte_lshift(data_addr, metadata_id);
+            let mask = ((1 << (1 << bits_num_log)) - 1) << lshift;
+
+            let old_val = unsafe { meta_addr.load::<u8>() };
+            let new_val = (old_val & !mask) | ((metadata as u8) << lshift);
+
+            unsafe { meta_addr.store::<u8>(new_val) };
+        } else if bits_num_log == 3 {
+            unsafe { meta_addr.store::<u8>(metadata as u8) };
+        } else if bits_num_log == 4 {
+            unsafe { meta_addr.store::<u16>(metadata as u16) };
+        } else if bits_num_log == 5 {
+            unsafe { meta_addr.store::<u32>(metadata as u32) };
+        } else {
+            todo!("side metadata > 32-bits is not supported yet!");
+        }
+    }
+}

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -1,5 +1,5 @@
-use super::helpers::*;
-use crate::util::{constants, Address};
+use super::helpers::{*, self};
+use crate::util::{constants, memory, Address};
 use std::sync::atomic::{AtomicU16, AtomicU32, AtomicU8, Ordering};
 
 // The following information about the target data is required:
@@ -306,6 +306,22 @@ impl SideMetadata {
         } else {
             todo!("side metadata > 32-bits is not supported yet!");
         }
+    }
+
+    /// Bulk-zero a metadata space.
+    /// 
+    /// Arguments:
+    ///
+    /// `start` is the starting address of the data whose metadata is being zeroed.
+    /// `size` is the size (in bytes) of the source data.
+    pub fn bzero_meta_space(
+        start: Address,
+        size: usize,
+        metadata_id: SideMetadataID,
+    ) {
+        let meta_start = helpers::address_to_meta_address(start, metadata_id);
+        let meta_end = helpers::address_to_meta_address(start + size, metadata_id);
+        memory::zero(meta_start, meta_end.as_usize() - meta_start.as_usize());
     }
 }
 

--- a/src/util/side_metadata/helpers.rs
+++ b/src/util/side_metadata/helpers.rs
@@ -182,8 +182,17 @@ mod tests {
     #[test]
     fn test_side_metadata_helpers_round_up_to_page_size() {
         assert_eq!(round_up_to_page_size(1), META_SPACE_PAGE_SIZE);
-        assert_eq!(round_up_to_page_size(META_SPACE_PAGE_SIZE - 1), META_SPACE_PAGE_SIZE);
-        assert_eq!(round_up_to_page_size(META_SPACE_PAGE_SIZE), META_SPACE_PAGE_SIZE);
-        assert_eq!(round_up_to_page_size(META_SPACE_PAGE_SIZE + 1), META_SPACE_PAGE_SIZE << 1);
+        assert_eq!(
+            round_up_to_page_size(META_SPACE_PAGE_SIZE - 1),
+            META_SPACE_PAGE_SIZE
+        );
+        assert_eq!(
+            round_up_to_page_size(META_SPACE_PAGE_SIZE),
+            META_SPACE_PAGE_SIZE
+        );
+        assert_eq!(
+            round_up_to_page_size(META_SPACE_PAGE_SIZE + 1),
+            META_SPACE_PAGE_SIZE << 1
+        );
     }
 }

--- a/src/util/side_metadata/helpers.rs
+++ b/src/util/side_metadata/helpers.rs
@@ -1,0 +1,177 @@
+use crate::util::{constants, memory, Address};
+use memory::dzmmap;
+use std::io::{Error, Result};
+
+use super::global::METADATA_SINGLETON;
+use super::SideMetadataID;
+
+#[cfg(target_pointer_width = "32")]
+pub(super) const METADATA_BASE_ADDRESS: Address = unsafe { Address::from_usize(0) };
+#[cfg(target_pointer_width = "64")]
+pub(super) const METADATA_BASE_ADDRESS: Address =
+    unsafe { Address::from_usize(0x0000_0600_0000_0000) };
+
+#[cfg(target_pointer_width = "32")]
+pub(super) const MAX_HEAP_SIZE_LOG: usize = 32;
+// FIXME: This must be updated if the heap layout changes
+#[cfg(target_pointer_width = "64")]
+pub(super) const MAX_HEAP_SIZE_LOG: usize = 48;
+
+pub(super) const MAX_METADATA_BITS: usize = constants::BITS_IN_WORD;
+// const SPACE_PER_META_BIT: usize = 2 << (MAX_HEAP_SIZE_LOG - constants::LOG_BITS_IN_WORD);
+pub(super) const META_SPACE_PAGE_SIZE: usize = constants::BYTES_IN_PAGE;
+pub(super) const META_SPACE_PAGE_SIZE_LOG: usize = constants::LOG_BYTES_IN_PAGE as usize;
+
+#[inline(always)]
+pub(super) fn address_to_meta_address(addr: Address, metadata_id: SideMetadataID) -> Address {
+    let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.as_usize()];
+    // right shifts for `align` times, then
+    // if bits_num_log < 3, right shift a few more times to cover multi objects per metadata byte
+    // if bits_num_log = 3, metadata byte per object is 1
+    // for > 3, left shift, because more than 1 byte per object is required
+    let offset = (addr.as_usize() >> METADATA_SINGLETON.align[metadata_id.as_usize()])
+        >> ((constants::LOG_BITS_IN_BYTE as usize) - bits_num_log);
+
+    // info!("address_to_meta_address({}, {}).offset => 0x{:x}", addr, metadata_id.as_usize(), offset);
+    METADATA_SINGLETON.meta_base_addr_vec[metadata_id.as_usize()] + offset
+}
+
+// Gets the related meta address and clears the low order bits
+pub(super) fn address_to_meta_page_address(
+    data_addr: Address,
+    metadata_id: SideMetadataID,
+) -> Address {
+    let meta_addr = address_to_meta_address(data_addr, metadata_id);
+    unsafe {
+        Address::from_usize((meta_addr >> META_SPACE_PAGE_SIZE_LOG) << META_SPACE_PAGE_SIZE_LOG)
+    }
+}
+
+// Checks whether the meta page containing this address is already mapped.
+//
+// Returns Err if the address is not mappable by mmtk,
+// and Ok(is_mapped?) otherwise.
+//
+// NOTE: using incorrect (e.g. not properly aligned) page_addr is undefined behavior.
+pub(super) fn meta_page_is_mapped(page_addr: Address) -> Result<bool> {
+    let prot = libc::PROT_NONE;
+    // MAP_FIXED_NOREPLACE returns EEXIST if already mapped
+    let flags = libc::MAP_ANON | libc::MAP_PRIVATE | libc::MAP_FIXED_NOREPLACE;
+    let result: *mut libc::c_void = unsafe {
+        libc::mmap(
+            page_addr.to_mut_ptr(),
+            META_SPACE_PAGE_SIZE,
+            prot,
+            flags,
+            -1,
+            0,
+        )
+    };
+    if result == libc::MAP_FAILED {
+        let err = unsafe { *libc::__errno_location() };
+        if err == libc::EEXIST {
+            // mmtk already mapped it
+            Ok(true)
+        } else {
+            // mmtk can't map it
+            Err(Error::from_raw_os_error(err as _))
+        }
+    } else {
+        // mmtk can map it
+        // first, unmap the mapped memory
+        let result2 = unsafe { libc::munmap(page_addr.to_mut_ptr(), META_SPACE_PAGE_SIZE) };
+        assert_ne!(result2, libc::MAP_FAILED as _);
+        Ok(false)
+    }
+}
+
+fn find_middle_page(first_page: Address, last_page: Address) -> Address {
+    let total_page_num = (last_page.as_usize() + META_SPACE_PAGE_SIZE - first_page.as_usize())
+        / META_SPACE_PAGE_SIZE;
+    first_page + (META_SPACE_PAGE_SIZE * (total_page_num / 2))
+}
+
+pub(super) fn ensure_meta_is_mapped(
+    start: Address,
+    size: usize,
+    metadata_id: SideMetadataID,
+) -> bool {
+    let last_meta_page = address_to_meta_page_address(start + size - 1, metadata_id);
+    if meta_page_is_mapped(last_meta_page).unwrap() {
+        // all required pages are already mapped
+        return true;
+    }
+    let first_meta_page = address_to_meta_page_address(start, metadata_id);
+    if !meta_page_is_mapped(first_meta_page).unwrap() {
+        // map the whole area
+        if let Err(e) = dzmmap(
+            first_meta_page,
+            last_meta_page.as_usize() - first_meta_page.as_usize() + META_SPACE_PAGE_SIZE,
+        ) {
+            debug!(
+                "ensure_meta_is_mapped failed to map the required meta space with error: {}",
+                e
+            );
+            return false;
+        }
+        return true;
+    }
+    // find the first to be mapped page, and map from there onwards
+    //
+    // Here, we know the first_meta_page is mapped and the last is not.
+    // The following loop performs a binary search.
+    // At the end of the loop, both middle_page and last_page contain the result
+    let mut first_page = first_meta_page;
+    let mut last_page = last_meta_page;
+    let mut middle_page = find_middle_page(first_page, last_page);
+    while middle_page != last_page {
+        if meta_page_is_mapped(middle_page).unwrap() {
+            first_page = middle_page;
+        } else {
+            last_page = middle_page;
+        }
+        middle_page = find_middle_page(first_page, last_page);
+    }
+
+    if let Err(e) = dzmmap(
+        middle_page,
+        size - (middle_page.as_usize() - first_meta_page.as_usize()),
+    ) {
+        debug!(
+            "ensure_meta_is_mapped failed to map the required meta space with error: {}",
+            e
+        );
+        return false;
+    }
+
+    true
+}
+
+#[inline(always)]
+pub(super) fn meta_space_size(metadata_id: SideMetadataID) -> usize {
+    let actual_size = 1usize
+        << (MAX_HEAP_SIZE_LOG
+            - constants::LOG_BITS_IN_WORD
+            - METADATA_SINGLETON.align[metadata_id.as_usize()]
+            + METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.as_usize()]);
+    // final size is always a multiple of page size
+    round_up_to_page_size(actual_size)
+}
+
+#[inline(always)]
+pub(super) fn round_up_to_page_size(size: usize) -> usize {
+    if size % META_SPACE_PAGE_SIZE == 0 {
+        size
+    } else {
+        // round-up the size to page size
+        ((size >> constants::LOG_BYTES_IN_PAGE) + 1) << constants::LOG_BITS_IN_PAGE
+    }
+}
+
+#[inline(always)]
+pub(super) fn meta_byte_lshift(addr: Address, metadata_id: SideMetadataID) -> usize {
+    // I assume compilers are smart enough to optimize remainder to (2^n) operations
+    let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.as_usize()];
+    ((addr.as_usize() >> constants::LOG_BYTES_IN_WORD) % (constants::BITS_IN_BYTE >> bits_num_log))
+        << bits_num_log
+}

--- a/src/util/side_metadata/helpers.rs
+++ b/src/util/side_metadata/helpers.rs
@@ -32,7 +32,6 @@ pub(super) fn address_to_meta_address(addr: Address, metadata_id: SideMetadataID
     let offset = (addr.as_usize() >> METADATA_SINGLETON.align[metadata_id.as_usize()])
         >> ((constants::LOG_BITS_IN_BYTE as usize) - bits_num_log);
 
-    // info!("address_to_meta_address({}, {}).offset => 0x{:x}", addr, metadata_id.as_usize(), offset);
     METADATA_SINGLETON.meta_base_addr_vec[metadata_id.as_usize()] + offset
 }
 
@@ -174,4 +173,17 @@ pub(super) fn meta_byte_lshift(addr: Address, metadata_id: SideMetadataID) -> us
     let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.as_usize()];
     ((addr.as_usize() >> constants::LOG_BYTES_IN_WORD) % (constants::BITS_IN_BYTE >> bits_num_log))
         << bits_num_log
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::side_metadata::helpers::*;
+
+    #[test]
+    fn test_side_metadata_helpers_round_up_to_page_size() {
+        assert_eq!(round_up_to_page_size(1), META_SPACE_PAGE_SIZE);
+        assert_eq!(round_up_to_page_size(META_SPACE_PAGE_SIZE - 1), META_SPACE_PAGE_SIZE);
+        assert_eq!(round_up_to_page_size(META_SPACE_PAGE_SIZE), META_SPACE_PAGE_SIZE);
+        assert_eq!(round_up_to_page_size(META_SPACE_PAGE_SIZE + 1), META_SPACE_PAGE_SIZE << 1);
+    }
 }

--- a/src/util/side_metadata/helpers.rs
+++ b/src/util/side_metadata/helpers.rs
@@ -163,7 +163,7 @@ pub(super) fn round_up_to_page_size(size: usize) -> usize {
         size
     } else {
         // round-up the size to page size
-        ((size >> constants::LOG_BYTES_IN_PAGE) + 1) << constants::LOG_BITS_IN_PAGE
+        ((size >> constants::LOG_BYTES_IN_PAGE) + 1) << constants::LOG_BYTES_IN_PAGE
     }
 }
 

--- a/src/util/side_metadata/helpers.rs
+++ b/src/util/side_metadata/helpers.rs
@@ -1,4 +1,4 @@
-use crate::util::{constants, memory, Address};
+use crate::util::{constants, conversions, memory, Address};
 use memory::dzmmap;
 use std::io::{Error, Result};
 
@@ -12,39 +12,59 @@ pub(super) const METADATA_BASE_ADDRESS: Address =
     unsafe { Address::from_usize(0x0000_0600_0000_0000) };
 
 #[cfg(target_pointer_width = "32")]
-pub(super) const MAX_HEAP_SIZE_LOG: usize = 32;
+pub(super) const MAX_HEAP_SIZE_LOG: usize = 31;
 // FIXME: This must be updated if the heap layout changes
 #[cfg(target_pointer_width = "64")]
-pub(super) const MAX_HEAP_SIZE_LOG: usize = 48;
+pub(super) const MAX_HEAP_SIZE_LOG: usize = 46;
 
+// This is the maximum number of bits in a metadata bit-set
 pub(super) const MAX_METADATA_BITS: usize = constants::BITS_IN_WORD;
+// This is the maximum number of metadata bit-sets in an MMTk instance
+pub(super) const MAX_METADATA_ID: usize = constants::BITS_IN_WORD;
+
 // const SPACE_PER_META_BIT: usize = 2 << (MAX_HEAP_SIZE_LOG - constants::LOG_BITS_IN_WORD);
 pub(super) const META_SPACE_PAGE_SIZE: usize = constants::BYTES_IN_PAGE;
-pub(super) const META_SPACE_PAGE_SIZE_LOG: usize = constants::LOG_BYTES_IN_PAGE as usize;
 
 #[inline(always)]
 pub(super) fn address_to_meta_address(addr: Address, metadata_id: SideMetadataID) -> Address {
-    let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.as_usize()] as i32;
+    debug_assert!(
+        metadata_id.as_usize() < METADATA_SINGLETON.meta_bits_num_log_vec.len(),
+        "metadata_id ({}) out of range",
+        metadata_id.as_usize()
+    );
+    let bits_num_log = unsafe {
+        METADATA_SINGLETON
+            .meta_bits_num_log_vec
+            .get_unchecked(metadata_id.as_usize())
+    };
+    let bits_num_log = *bits_num_log as i32;
     // right shifts for `align` times, then
     // if bits_num_log < 3, right shift a few more times to cover multi objects per metadata byte
     // if bits_num_log = 3, metadata byte per object is 1
     // for > 3, left shift, because more than 1 byte per object is required
     let rshift = (constants::LOG_BITS_IN_BYTE as i32) - bits_num_log;
-    let offset = if rshift >= 0 {
-        addr.as_usize()
-            .checked_shr(METADATA_SINGLETON.align[metadata_id.as_usize()] as u32)
-            .unwrap()
-            .checked_shr(rshift as u32)
-            .unwrap()
-    } else {
-        addr.as_usize()
-            .checked_shr(METADATA_SINGLETON.align[metadata_id.as_usize()] as u32)
-            .unwrap()
-            .checked_shl(-rshift as u32)
-            .unwrap()
+    let offset = unsafe {
+        if rshift >= 0 {
+            addr.as_usize()
+                >> (*METADATA_SINGLETON
+                    .align
+                    .get_unchecked(metadata_id.as_usize()) as u32)
+                >> (rshift as u32)
+        } else {
+            addr.as_usize()
+                >> (*METADATA_SINGLETON
+                    .align
+                    .get_unchecked(metadata_id.as_usize()) as u32)
+                << (-rshift as u32)
+        }
     };
 
-    METADATA_SINGLETON.meta_base_addr_vec[metadata_id.as_usize()] + offset
+    unsafe {
+        *METADATA_SINGLETON
+            .meta_base_addr_vec
+            .get_unchecked(metadata_id.as_usize())
+            + offset
+    }
 }
 
 // Gets the related meta address and clears the low order bits
@@ -52,10 +72,7 @@ pub(super) fn address_to_meta_page_address(
     data_addr: Address,
     metadata_id: SideMetadataID,
 ) -> Address {
-    let meta_addr = address_to_meta_address(data_addr, metadata_id);
-    unsafe {
-        Address::from_usize((meta_addr >> META_SPACE_PAGE_SIZE_LOG) << META_SPACE_PAGE_SIZE_LOG)
-    }
+    conversions::page_align_down(address_to_meta_address(data_addr, metadata_id))
 }
 
 // Checks whether the meta page containing this address is already mapped.
@@ -96,60 +113,80 @@ pub(super) fn meta_page_is_mapped(page_addr: Address) -> Result<bool> {
     }
 }
 
-fn find_middle_page(first_page: Address, last_page: Address) -> Address {
-    let total_page_num = (last_page.as_usize() + META_SPACE_PAGE_SIZE - first_page.as_usize())
-        / META_SPACE_PAGE_SIZE;
-    first_page + (META_SPACE_PAGE_SIZE * (total_page_num / 2))
-}
-
-pub(super) fn ensure_meta_is_mapped(
-    start: Address,
-    size: usize,
-    metadata_id: SideMetadataID,
-) -> bool {
+pub(super) fn try_map_meta(start: Address, size: usize, metadata_id: SideMetadataID) -> bool {
     let last_meta_page = address_to_meta_page_address(start + size - 1, metadata_id);
-    if meta_page_is_mapped(last_meta_page).unwrap() {
-        // all required pages are already mapped
-        return true;
-    }
-    let first_meta_page = address_to_meta_page_address(start, metadata_id);
-    if !meta_page_is_mapped(first_meta_page).unwrap() {
-        // map the whole area
-        if let Err(e) = dzmmap(
-            first_meta_page,
-            last_meta_page.as_usize() - first_meta_page.as_usize() + META_SPACE_PAGE_SIZE,
-        ) {
-            debug!(
-                "ensure_meta_is_mapped failed to map the required meta space with error: {}",
-                e
-            );
+    match meta_page_is_mapped(last_meta_page) {
+        Ok(is_mapped) => {
+            if is_mapped {
+                // all required pages are already mapped -> success
+                return true;
+            }
+        }
+        Err(_) => {
+            // (at least) the last page is not mappable -> failure
             return false;
         }
-        return true;
     }
-    // find the first to be mapped page, and map from there onwards
-    //
-    // Here, we know the first_meta_page is mapped and the last is not.
-    // The following loop performs a binary search.
-    // At the end of the loop, both middle_page and last_page contain the result
-    let mut first_page = first_meta_page;
-    let mut last_page = last_meta_page;
-    let mut middle_page = find_middle_page(first_page, last_page);
-    while middle_page != last_page {
-        if meta_page_is_mapped(middle_page).unwrap() {
-            first_page = middle_page;
-        } else {
-            last_page = middle_page;
+    let first_meta_page = address_to_meta_page_address(start, metadata_id);
+    match meta_page_is_mapped(first_meta_page) {
+        Ok(is_mapped) => {
+            // first page is not mapped yet -> try mapping the whole area
+            if !is_mapped {
+                // map the whole area
+                if let Err(e) = dzmmap(
+                    first_meta_page,
+                    last_meta_page.as_usize() - first_meta_page.as_usize() + META_SPACE_PAGE_SIZE,
+                ) {
+                    debug!(
+                        "try_map_meta failed to map the required meta space with error: {}",
+                        e
+                    );
+                    return false;
+                }
+                return true;
+            }
+            // first page is already mapped and last page is not
         }
-        middle_page = find_middle_page(first_page, last_page);
+        Err(_) => {
+            // (at least) the first page is not mappable -> failure
+            return false;
+        }
     }
+    // // find the first to be mapped page, and map from there onwards
+    // //
+    // // Here, we know the first_meta_page is mapped and the last is not.
+    // // The following loop performs a binary search.
+    // // At the end of the loop, both middle_page and last_page contain the result
+    // let mut first_page = first_meta_page;
+    // let mut last_page = last_meta_page;
+    // let mut middle_page = find_middle_page(first_page, last_page);
+    // while middle_page != last_page {
+    //     match meta_page_is_mapped(middle_page) {
+    //         Ok(is_mapped) => {
+    //             if is_mapped {
+    //                 first_page = middle_page;
+    //             } else {
+    //                 last_page = middle_page;
+    //             }
+    //         }
+    //         Err(_) => {
+    //             // non-mappable page detected -> failure
+    //             return false;
+    //         }
+    //     }
+    //     middle_page = find_middle_page(first_page, last_page);
+    // }
 
+    // Considering that this function is only called on space growth,
+    // there is zero or one mapped meta page in the range.
+    // If we were to support space shrink, we needed a binary search,
+    // because there could be more than one mapped meta page.
     if let Err(e) = dzmmap(
-        middle_page,
-        size - (middle_page.as_usize() - first_meta_page.as_usize()),
+        first_meta_page + META_SPACE_PAGE_SIZE,
+        size - META_SPACE_PAGE_SIZE,
     ) {
         debug!(
-            "ensure_meta_is_mapped failed to map the required meta space with error: {}",
+            "try_map_meta failed to map the required meta space with error: {}",
             e
         );
         return false;
@@ -171,18 +208,22 @@ pub(super) fn meta_space_size(metadata_id: SideMetadataID) -> usize {
 
 #[inline(always)]
 pub(super) fn round_up_to_page_size(size: usize) -> usize {
-    if size % META_SPACE_PAGE_SIZE == 0 {
-        size
-    } else {
-        // round-up the size to page size
-        ((size >> constants::LOG_BYTES_IN_PAGE) + 1) << constants::LOG_BYTES_IN_PAGE
-    }
+    conversions::raw_align_up(size, META_SPACE_PAGE_SIZE)
 }
 
 #[inline(always)]
 pub(super) fn meta_byte_lshift(addr: Address, metadata_id: SideMetadataID) -> usize {
     // I assume compilers are smart enough to optimize remainder to (2^n) operations
-    let bits_num_log = METADATA_SINGLETON.meta_bits_num_log_vec[metadata_id.as_usize()];
+    debug_assert!(
+        metadata_id.as_usize() < METADATA_SINGLETON.meta_bits_num_log_vec.len(),
+        "metadata_id ({}) out of range",
+        metadata_id.as_usize()
+    );
+    let bits_num_log = unsafe {
+        METADATA_SINGLETON
+            .meta_bits_num_log_vec
+            .get_unchecked(metadata_id.as_usize())
+    };
     ((addr.as_usize() >> constants::LOG_BYTES_IN_WORD) % (constants::BITS_IN_BYTE >> bits_num_log))
         << bits_num_log
 }

--- a/src/util/side_metadata/mod.rs
+++ b/src/util/side_metadata/mod.rs
@@ -1,4 +1,64 @@
-//! A generic module to work with side metadata.
+//! This is a generic module to work with side metadata (vs. in-object metadata)
+//!
+//! This module enables the implementation of a wide range of GC algorithms for VMs which do not provide (any/sufficient) in-object space for GC-specific metadata (e.g. marking bits, etc.).
+//!
+//!
+//! # Design
+//!
+//! MMTk side metadata is designed to be **generic**, and **space-** and **time-** efficient.
+//!
+//! It aims to support two categories of side metadata:
+//!
+//! 1. **Global** metadata bits which are per-object metadata and are common to all policies, and
+//! 2. **Policy-specific** bits which are only used by certain policies and are not necessarily per-object.
+//!
+//! To support these categories, MMTk side metadata provides the following features:
+//!
+//! 1. The granularity of the source data is configurable to $2^n$ bytes, where $n >= 0$.
+//! 2. The number of metadata bits per source data unit is configurable to to $2^m$ bits, where $m >= 0$.
+//! 3. The total number of metadata bit-sets is only constrained by the amount of available memory.
+//! 4. For each metadata bit-set, the metadata space is only allocated for the range of heap addresses it chooses to cover.
+//! 5. Bulk-zeroing of metadata bits should be possible. For this, the memory space for each metadata bit-set is contiguous.
+//!
+//!
+//! # How to Use
+//!
+//! For each side metadata bit-set, first request the metadata bits by calling:
+//!
+//! ```
+//! SideMetadata::request_meta_bits(number_of_bits: usize, align: usize) -> SideMetadataID
+//! ```
+//!
+//! The returned ID is used for future references to this side metadata.
+//!
+//! Requesting the bits does not allocate any metadata space.
+//! So, the next step is to announce the data space you want the metadata to cover, by calling:
+//!
+//! ```
+//! SideMetadata::ensure_meta_space_is_mapped(
+//!     start: Address,
+//!     size: usize,
+//!     metadata_id: SideMetadataID
+//! ) -> bool
+//! ```
+//!
+//! On success, this function returns `true`.
+//!
+//! NOTE-1: A return value of `false` may mean you need to use a different memory space for your data)
+//!
+//! NOTE-2: As you allocate more memory, you may need to map more metadata space at runtime.
+//!
+//!
+//! After mapping the metadata space, the following operations can be performed on the metadata:
+//!
+//! 1. atomic load
+//! 2. atomic store
+//! 3. atomic compare-and-exchange
+//! 4. atomic fetch-and-add
+//! 5. atomic fetch-and-sub
+//! 6. load (non-atomic)
+//! 7. store (non-atomic)
+//! 8. bulk zeroing
 //!
 
 mod global;

--- a/src/util/side_metadata/mod.rs
+++ b/src/util/side_metadata/mod.rs
@@ -1,0 +1,8 @@
+//! A generic module to work with side metadata.
+//!
+
+mod global;
+mod helpers;
+
+pub use global::SideMetadata;
+pub use global::SideMetadataID;


### PR DESCRIPTION
This PR adds the support for side metadata (vs. in-object metadata) to MMTk and closes Issue #104.
Support for per-object GC-Byte on side is also added.

The goal of this PR is to enable the implementation of a wide range of GC algorithms for VMs which do not provide (any/sufficient) in-object space for GC-specific metadata (e.g. marking bits, etc.).

# Design

MMTk side metadata is designed to be **generic**, and **space-** and **time-** efficient.

Two categories of side metadata are considered in this PR:

1. **Global** metadata bits which are per-object metadata and are common to all policies, and
2. **Policy-specific** bits which are only used by certain policies and are not necessarily per-object.

To support these categories, MMTk side metadata provides the following features:

1. The granularity of the source data is configurable to $2^n$ bytes, where $n >= 0$.
2. The number of metadata bits per source data unit is configurable to to $2^m$ bits, where $m >= 0$.
3. The total number of metadata bit-sets is only constrained by the amount of available memory.
4. For each metadata bit-set, the metadata space is only allocated for the range of heap addresses it chooses to cover.
5. Bulk-zeroing of metadata bits should be possible. For this, the memory space for each metadata bit-set is contiguous.


# How to Use

For each side metadata bit-set, first request the metadata bits by calling:

```
SideMetadata::request_meta_bits(number_of_bits: usize, align: usize) -> SideMetadataID
```

The returned ID is used for future references to this side metadata.

Requesting the bits does not allocate any metadata space.
So, the next step is to announce the data space you want the metadata to cover, by calling:

```
SideMetadata::ensure_meta_space_is_mapped(
    start: Address,
    size: usize,
    metadata_id: SideMetadataID
) -> bool
```

On success, this function returns `true`.

NOTE-1: A return value of `false` may mean you need to use a different memory space for your data)

NOTE-2: As you allocate more memory, you may need to map more metadata space at runtime.


After mapping the metadata space, the following operations can be performed on the metadata:

1. atomic load
2. atomic store
3. atomic compare-and-exchange
4. atomic fetch-and-add
5. atomic fetch-and-sub
6. load (non-atomic)
7. store (non-atomic)
8. bulk zeroing
