### PR TITLE
Fix poll condition when enable_collection() is not called

### DIFF
--- a/src/mm/memory_manager.rs
+++ b/src/mm/memory_manager.rs
@@ -56,6 +56,7 @@ pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
             "MMTk failed to initialize the logger. Possibly a logger has been initialized by user."
         ),
     }
+    assert!(heap_size > 0, "Invalid heap size");
     mmtk.plan.gc_init(heap_size, &mmtk.vm_map, &mmtk.scheduler);
 }
 

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -243,7 +243,9 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
 
         trace!("Polling ..");
 
-        if unsafe { VM::VMActivePlan::is_mutator(tls) } && VM::VMActivePlan::global().poll(false, self.as_space()) {
+        if unsafe { VM::VMActivePlan::is_mutator(tls) }
+            && VM::VMActivePlan::global().poll(false, self.as_space())
+        {
             debug!("Collection required");
             if !VM::VMActivePlan::global().is_initialized() {
                 panic!("Collection is not enabled.");

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -232,22 +232,20 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
 
     fn acquire(&self, tls: OpaquePointer, pages: usize) -> Address {
         trace!("Space.acquire, tls={:?}", tls);
-        // debug_assert!(tls != 0);
-        let allow_poll = unsafe { VM::VMActivePlan::is_mutator(tls) }
-            && VM::VMActivePlan::global().is_initialized();
+        // Should we poll to attempt to GC? If tls is collector, we cant attempt a GC.
+        let should_poll = unsafe { VM::VMActivePlan::is_mutator(tls) };
+        // Is a GC allowed here? enable_collection() has to be called so we know GC is initialized.
+        let allow_poll = should_poll && VM::VMActivePlan::global().is_initialized();
 
         trace!("Reserving pages");
         let pr = self.get_page_resource();
         let pages_reserved = pr.reserve_pages(pages);
         trace!("Pages reserved");
-
         trace!("Polling ..");
 
-        if unsafe { VM::VMActivePlan::is_mutator(tls) }
-            && VM::VMActivePlan::global().poll(false, self.as_space())
-        {
+        if should_poll && VM::VMActivePlan::global().poll(false, self.as_space()) {
             debug!("Collection required");
-            if !VM::VMActivePlan::global().is_initialized() {
+            if !allow_poll {
                 panic!("Collection is not enabled.");
             }
             pr.clear_request(pages_reserved);
@@ -257,6 +255,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
             debug!("Collection not required");
             let rtn = pr.get_new_pages(pages_reserved, pages, self.common().zeroed, tls);
             if rtn.is_zero() {
+                // We thought we had memory to allocate, but somehow failed the allocation. Will force a GC.
                 if !allow_poll {
                     panic!("Physical allocation failed when polling not allowed!");
                 }


### PR DESCRIPTION
This PR fixes https://github.com/mmtk/mmtk-core/issues/214. We no longer allow allocating without checking budget if the user does not call `enable_collection()`. 