### PR TITLE
Allow longer timeout for pre review CI

### DIFF
--- a/.github/workflows/pre-review-ci.yml
+++ b/.github/workflows/pre-review-ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   pre-code-review-checks:
     runs-on: ubuntu-18.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly


### PR DESCRIPTION
This PR is to allow longer timeout for https://github.com/mmtk/mmtk-core/pull/217. Rough changes of build time for https://github.com/mmtk/mmtk-core/pull/217:
* build: 1m30s -> 3m
* test: 4m50 -> 7m40s