### PR TITLE
Fix DummyVM mmtk.h interface to match recent changes

### DIFF
--- a/vmbindings/dummyvm/api/mmtk.h
+++ b/vmbindings/dummyvm/api/mmtk.h
@@ -18,9 +18,9 @@ extern MMTk_Mutator bind_mutator(void *tls);
 extern void destroy_mutator(MMTk_Mutator mutator);
 
 extern void* alloc(MMTk_Mutator mutator, size_t size,
-    size_t align, ssize_t offset, int allocator);
+    size_t align, size_t offset, int allocator);
 
-extern void post_alloc(MMTk_Mutator mutator, void* refer, void* type_refer,
+extern void post_alloc(MMTk_Mutator mutator, void* refer,
     int bytes, int allocator);
 
 extern bool is_live_object(void* ref);
@@ -52,7 +52,6 @@ extern void* trace_retain_referent(MMTk_TraceLocal trace_local, void* obj);
 extern void gc_init(size_t heap_size);
 extern bool will_never_move(void* object);
 extern bool process(char* name, char* value);
-extern void scan_region();
 extern void handle_user_collection_request(void *tls);
 
 extern void start_control_collector(void *tls);


### PR DESCRIPTION
[This commit](https://github.com/mmtk/mmtk-core/commit/f9ebe772b12ea4654dfbe31605b3fa8fc5b6893b#diff-25f32b23421651ab5171b50fda1c441c4ed86f74db168a3cdc656234de99e2c4) made some changes to the MMTk API provided by the DummyVM binding. However, the corresponding C/C++ header file has not been updated to match. This PR fixes this discrepancy. 

It also fixes a small syntactical typo.