### PR TITLE
Allow PRs to add new features without modifying CI scripts

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -1,5 +1,3 @@
-set -xe
-
 . $(dirname "$0")/ci-common.sh
 
 # Execute this script under the root folder of this repo. Otherwise it will fail.

--- a/.github/scripts/ci-common.sh
+++ b/.github/scripts/ci-common.sh
@@ -1,12 +1,7 @@
 arch=`rustc --print cfg | grep target_arch | cut -f2 -d"\""`
 os=`rustc --print cfg | grep target_os | cut -f2 -d"\""`
 
-feature_list="vm_space,ro_space,code_space,sanity,nogc_lock_free,nogc_no_zeroing,single_worker"
-
-# non mutally exclusive features
-non_exclusive_features="vm_space,ro_space,code_space,sanity,nogc_lock_free,nogc_no_zeroing,single_worker"
-# mutally exclusive features ("name:option1,option2,..." - name doesnt matter, but opition needs to match features in Cargo.toml)
-exclusive_features=("malloc:malloc_mimalloc,malloc_jemalloc,malloc_hoard")
+cargo_toml=$(dirname "$0")/../../Cargo.toml
 
 # Repeat a command for all the features. Requires the command as one argument (with double quotes)
 for_all_features() {
@@ -34,3 +29,96 @@ for_all_features() {
         done
     done
 }
+
+# Get all non exclusive features
+init_non_exclusive_features() {
+    declare -a features=()
+    parse_features=false
+    i=0
+
+    while IFS= read -r line; do
+        # Only parse non mutally exclusive features
+        if [[ $line == *"-- Non mutally exclusive features --"* ]]; then
+            parse_features=true
+            continue
+        fi
+        if [[ $line == *"-- Mutally exclusive features --"* ]]; then
+            parse_features=false
+            continue
+        fi
+
+        # Skip other comment lines
+        if [[ $line == \#* ]]; then
+            continue
+        fi
+
+        if $parse_features ; then
+            # Get feature name before '='
+            IFS='='; feature=($line); unset IFS;
+            if [[ ! -z "$feature" ]]; then
+                # Trim whitespaces
+                features[i]=$(echo $feature)
+                let "i++"
+            fi
+        fi
+    done < $cargo_toml
+
+    non_exclusive_features=$(IFS=$','; echo "${features[*]}")
+}
+
+# Get exclusive features
+init_exclusive_features() {
+    parse_features=false
+    i=0
+    
+    # Current group
+    group=
+    # Group index
+    gi=0
+    # Features in the current group
+    declare -a features=()
+
+    while IFS= read -r line; do
+        # Only parse mutally exclusive features
+        if [[ $line == *"-- Mutally exclusive features --"* ]]; then
+            parse_features=true
+            continue
+        fi
+
+        # Start a new group
+        if [[ $line == *"Group:"* ]]; then
+            # Save current group, and clear current features
+            if [[ ! -z "$group" ]]; then
+                exclusive_features[gi]=$(echo $group:)$(IFS=$',';echo "${features[*]}")
+                let "gi++"
+                features=()
+            fi
+            # Extract group name
+            group=$(echo $line | cut -c9-)
+        fi
+
+        # Skip other comment lines
+        if [[ $line == \#* ]]; then
+            continue
+        fi
+
+        if $parse_features ; then
+            # Get feature name before '='
+            IFS='='; feature=($line); unset IFS;
+            if [[ ! -z "$feature" ]]; then
+                # Trim whitespaces
+                features[i]=$(echo $feature)
+                let "i++"
+            fi
+        fi
+    done < $cargo_toml
+}
+
+# non mutally exclusive features
+non_exclusive_features=
+init_non_exclusive_features
+# mutally exclusive features
+exclusive_features=()
+init_exclusive_features
+
+set -xe

--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -1,5 +1,3 @@
-set -xe
-
 . $(dirname "$0")/ci-common.sh
 
 cargo doc --features $non_exclusive_features --no-deps

--- a/.github/scripts/ci-style.sh
+++ b/.github/scripts/ci-style.sh
@@ -1,5 +1,3 @@
-set -xe
-
 . $(dirname "$0")/ci-common.sh
 
 export RUSTFLAGS="-D warnings"

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -4,9 +4,7 @@ for_all_features "cargo test"
 
 # For x86_64-linux, also check for i686
 if [[ $arch == "x86_64" && $os == "linux" ]]; then
-    # Skipping one test - see Issue #229. Remove the skip part when the bug is fixed.
-    # After the bug is fixed, change the following line to 'for_all_features "cargo test --target i686-unknown-linux-gnu"'
-    cargo test --target i686-unknown-linux-gnu -- --skip test_side_metadata_try_mmap_metadata_chunk
+    for_all_features "cargo test --target i686-unknown-linux-gnu"
 fi
 
 python examples/build.py

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -1,8 +1,12 @@
-cargo test
+. $(dirname "$0")/ci-common.sh
+
+for_all_features "cargo test"
 
 # For x86_64-linux, also check for i686
 if [[ $arch == "x86_64" && $os == "linux" ]]; then
-    cargo test --target i686-unknown-linux-gnu
+    # Skipping one test - see Issue #229. Remove the skip part when the bug is fixed.
+    # After the bug is fixed, change the following line to 'for_all_features "cargo test --target i686-unknown-linux-gnu"'
+    cargo test --target i686-unknown-linux-gnu -- --skip test_side_metadata_try_mmap_metadata_chunk
 fi
 
 python examples/build.py

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -1,5 +1,3 @@
-set -xe
-
 cargo test
 
 # For x86_64-linux, also check for i686

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,10 @@ rand = "0.7.3"
 [features]
 default = []
 
-# When adding any new feature, please add the new feature to .github/scripts/ci-common.sh 
-# so their builds are properly tested in the CI.
+# .github/scripts/ci-common.sh extracts features from the following part (including from comments).
+# So be careful when editing or adding stuff to the section below.
 
+# Do not modify the following line - ci-common.sh matches it
 # -- Non mutally exclusive features --
 
 # spaces
@@ -62,11 +63,17 @@ nogc_no_zeroing = ["nogc_lock_free"]
 # Q: Why do we need this as a compile time flat? We can always set the number of GC threads through options.
 single_worker = []
 
+# Do not modify the following line - ci-common.sh matches it
 # -- Mutally exclusive features --
+# Only one feature from each group can be provided. Otherwise build will fail.
 
-# malloc implementations
+# Name of the mutualy exclusive feature group. ci-common.sh matches lines like this one.
+# Group:malloc
 # only one of the following features should be enabled, or none to use the default malloc from libc
 # this does not replace the global Rust allocator, but provides these libraries for GC implementation
 malloc_mimalloc = []
 malloc_jemalloc = []
 malloc_hoard = []
+
+# If there are more groups, they should be inserted above this line
+# Group:end


### PR DESCRIPTION
We have features that are mutually exclusive, such as `malloc_jemalloc`, `malloc_mimalloc`, etc. Only one from each group should be allowed (though it is possible that none is chosen). 

However, cargo does not support mutually exclusive features, and we cannot use `--all-features` for running cargo command on all the features. Thus we have some scripts to run all features considering mutually exclusive ones. We rely on hard coded feature list in `ci-common.sh`. 

This PR removes the hard coded feature list, and instead extracts features from `Cargo.toml`.