### PR TITLE
move try_map_metadata_space next to SFT_MAP.update

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -62,7 +62,7 @@ impl<VM: VMBinding> Space<VM> for CopySpace<VM> {
         // Borrow-checker fighting so that we can have a cyclic reference
         let me = unsafe { &*(self as *const Self) };
         self.pr.bind_space(me);
-        self.common().init(self.as_sft());
+        self.common().init(self.as_space());
     }
 
     fn release_multiple_pages(&mut self, _start: Address) {

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -74,7 +74,7 @@ impl<VM: VMBinding> Space<VM> for ImmortalSpace<VM> {
         // Borrow-checker fighting so that we can have a cyclic reference
         let me = unsafe { &*(self as *const Self) };
         self.pr.bind_space(me);
-        self.common().init(self.as_sft());
+        self.common().init(self.as_space());
     }
     fn release_multiple_pages(&mut self, _start: Address) {
         panic!("immortalspace only releases pages enmasse")

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -266,15 +266,6 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                 unsafe { Address::zero() }
             } else {
                 debug!("Space.acquire(), returned = {}", rtn);
-                if !try_map_metadata_space(
-                    rtn,
-                    conversions::pages_to_bytes(pages),
-                    VM::VMActivePlan::global().global_side_metadata_per_chunk(),
-                    self.local_side_metadata_per_chunk(),
-                ) {
-                    // TODO(Javad): handle meta space allocation failure
-                    panic!("failed to mmap meta memory");
-                }
                 rtn
             }
         }
@@ -334,6 +325,15 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         if new_chunk {
             let chunks = conversions::bytes_to_chunks_up(bytes);
             SFT_MAP.update(self.as_sft() as *const (dyn SFT + Sync), start, chunks);
+            if !try_map_metadata_space(
+                start,
+                bytes,
+                VM::VMActivePlan::global().global_side_metadata_per_chunk(),
+                self.local_side_metadata_per_chunk(),
+            ) {
+                // TODO(Javad): handle meta space allocation failure
+                panic!("failed to mmap meta memory");
+            }
         }
     }
 

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -571,10 +571,19 @@ impl<VM: VMBinding> CommonSpace<VM> {
         rtn
     }
 
-    pub fn init(&self, sft: *const (dyn SFT + Sync)) {
+    pub fn init(&self, space: &dyn Space<VM>) {
         // For contiguous space, we eagerly initialize SFT map based on its address range.
         if self.contiguous {
-            SFT_MAP.update(sft, self.start, bytes_to_chunks_up(self.extent));
+            if !try_map_metadata_space(
+                self.start,
+                self.extent,
+                VM::VMActivePlan::global().global_side_metadata_per_chunk(),
+                space.local_side_metadata_per_chunk(),
+            ) {
+                // TODO(Javad): handle meta space allocation failure
+                panic!("failed to mmap meta memory");
+            }
+            SFT_MAP.update(space.as_sft(), self.start, bytes_to_chunks_up(self.extent));
         }
     }
 


### PR DESCRIPTION
This PR moves the main call to `try_map_metadata_space` deeper, next to the `SFT_MAP.update` call, potentially reducing the number of calls.