### PR TITLE
GenCopy perf CI

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -10,7 +10,6 @@ jobs:
   openjdk-microbm:
     runs-on: [self-hosted, Linux, freq-scaling-off]
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
-    timeout-minutes: 600
     steps:
       - name: Check Revisions
         uses: qinsoon/comment-env-vars@1.0.2

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.4.3"
+          ref: "gencopy-perf"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -10,6 +10,7 @@ jobs:
   openjdk-microbm:
     runs-on: [self-hosted, Linux, freq-scaling-off]
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+    timeout-minutes: 600
     steps:
       - name: Check Revisions
         uses: qinsoon/comment-env-vars@1.0.2

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "gencopy-perf"
+          ref: "0.5.0"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.3"
+          ref: "0.5.0"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -85,7 +85,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.3"
+          ref: "0.5.0"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -146,7 +146,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.4.3"
+          ref: "0.5.0"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -84,96 +84,96 @@ jobs:
         run: |
           cd mmtk-jikesrvm
           ./.github/scripts/ci-test.sh
-  # jikesrvm-perf-compare:
-  #   runs-on: [self-hosted, Linux, freq-scaling-off]
-  #   if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
-  #   steps:
-  #     - name: Check Revisions
-  #       uses: qinsoon/comment-env-vars@1.0.2
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         default_env: 'JIKESRVM_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,JIKESRVM_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'
-  #     # Trunk
-  #     # - binding
-  #     - name: Checkout JikesRVM Binding Trunk
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: mmtk/mmtk-jikesrvm
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         path: mmtk-jikesrvm-trunk
-  #         submodules: true
-  #         ref: ${{ env.JIKESRVM_BINDING_TRUNK_REF }}
-  #     # - core
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v2
-  #       with:
-  #         ref: ${{ env.MMTK_CORE_TRUNK_REF }}
-  #         path: mmtk-core-trunk
-  #     # Branch
-  #     # - binding
-  #     - name: Checkout JikesRVM Binding Branch
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: mmtk/mmtk-jikesrvm
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         path: mmtk-jikesrvm-branch
-  #         submodules: true
-  #         ref: ${{ env.JIKESRVM_BINDING_BRANCH_REF }}
-  #     # - core
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v2
-  #       with:
-  #         ref: ${{ env.MMTK_CORE_BRANCH_REF }}
-  #         path: mmtk-core-branch
-  #     # Checkout perf-kit
-  #     - name: Checkout Perf Kit
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: mmtk/ci-perf-kit
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         ref: "0.4.3"
-  #         path: ci-perf-kit
-  #         submodules: true
-  #     # setup
-  #     # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)
-  #     - name: Setup Rust Toolchain
-  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
-  #     - name: Setup
-  #       run: |
-  #         mkdir -p ci-perf-kit/running/benchmarks/dacapo
-  #         cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo/
-  #     # run compare
-  #     - name: Compare Performance
-  #       id: run
-  #       run: |
-  #         JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm-trunk/ mmtk-core-trunk/ mmtk-jikesrvm-branch/ mmtk-core-branch/ jikesrvm-compare-report.md
-  #     # set report.md to output
-  #     - uses: pCYSl5EDgo/cat@master
-  #       id: cat
-  #       with:
-  #         path: jikesrvm-compare-report.md
-  #     # upload run results
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: jikesrvm-log
-  #         path: ci-perf-kit/running/results/log
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: jikesrvm-compare-report.md
-  #         path: jikesrvm-compare-report.md
-  #     # report
-  #     - name: Result
-  #       if: always()
-  #       uses: thollander/actions-comment-pull-request@master
-  #       with:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         message: ${{ steps.cat.outputs.text }}
-  #     # Cleanup logs (this is necessary for self-hosted runners)
-  #     - name: Clean up logs and reports
-  #       if: always()
-  #       run: |
-  #         rm -rf ci-perf-kit/running/results/log/*
-  #         rm jikesrvm-compare-report.md
+  jikesrvm-perf-compare:
+    runs-on: [self-hosted, Linux, freq-scaling-off]
+    if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+    steps:
+      - name: Check Revisions
+        uses: qinsoon/comment-env-vars@1.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          default_env: 'JIKESRVM_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,JIKESRVM_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'
+      # Trunk
+      # - binding
+      - name: Checkout JikesRVM Binding Trunk
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/mmtk-jikesrvm
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: mmtk-jikesrvm-trunk
+          submodules: true
+          ref: ${{ env.JIKESRVM_BINDING_TRUNK_REF }}
+      # - core
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.MMTK_CORE_TRUNK_REF }}
+          path: mmtk-core-trunk
+      # Branch
+      # - binding
+      - name: Checkout JikesRVM Binding Branch
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/mmtk-jikesrvm
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: mmtk-jikesrvm-branch
+          submodules: true
+          ref: ${{ env.JIKESRVM_BINDING_BRANCH_REF }}
+      # - core
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.MMTK_CORE_BRANCH_REF }}
+          path: mmtk-core-branch
+      # Checkout perf-kit
+      - name: Checkout Perf Kit
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/ci-perf-kit
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: "gencopy-perf"
+          path: ci-perf-kit
+          submodules: true
+      # setup
+      # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)
+      - name: Setup Rust Toolchain
+        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
+      - name: Setup
+        run: |
+          mkdir -p ci-perf-kit/running/benchmarks/dacapo
+          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo/
+      # run compare
+      - name: Compare Performance
+        id: run
+        run: |
+          JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm-trunk/ mmtk-core-trunk/ mmtk-jikesrvm-branch/ mmtk-core-branch/ jikesrvm-compare-report.md
+      # set report.md to output
+      - uses: pCYSl5EDgo/cat@master
+        id: cat
+        with:
+          path: jikesrvm-compare-report.md
+      # upload run results
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jikesrvm-log
+          path: ci-perf-kit/running/results/log
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jikesrvm-compare-report.md
+          path: jikesrvm-compare-report.md
+      # report
+      - name: Result
+        if: always()
+        uses: thollander/actions-comment-pull-request@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: ${{ steps.cat.outputs.text }}
+      # Cleanup logs (this is necessary for self-hosted runners)
+      - name: Clean up logs and reports
+        if: always()
+        run: |
+          rm -rf ci-perf-kit/running/results/log/*
+          rm jikesrvm-compare-report.md
 
   # OpenJDK
   openjdk-binding-test:

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -259,7 +259,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.4.3"
+          ref: "gencopy-perf"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -84,96 +84,96 @@ jobs:
         run: |
           cd mmtk-jikesrvm
           ./.github/scripts/ci-test.sh
-  jikesrvm-perf-compare:
-    runs-on: [self-hosted, Linux, freq-scaling-off]
-    if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
-    steps:
-      - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          default_env: 'JIKESRVM_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,JIKESRVM_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'
-      # Trunk
-      # - binding
-      - name: Checkout JikesRVM Binding Trunk
-        uses: actions/checkout@v2
-        with:
-          repository: mmtk/mmtk-jikesrvm
-          token: ${{ secrets.GITHUB_TOKEN }}
-          path: mmtk-jikesrvm-trunk
-          submodules: true
-          ref: ${{ env.JIKESRVM_BINDING_TRUNK_REF }}
-      # - core
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.MMTK_CORE_TRUNK_REF }}
-          path: mmtk-core-trunk
-      # Branch
-      # - binding
-      - name: Checkout JikesRVM Binding Branch
-        uses: actions/checkout@v2
-        with:
-          repository: mmtk/mmtk-jikesrvm
-          token: ${{ secrets.GITHUB_TOKEN }}
-          path: mmtk-jikesrvm-branch
-          submodules: true
-          ref: ${{ env.JIKESRVM_BINDING_BRANCH_REF }}
-      # - core
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.MMTK_CORE_BRANCH_REF }}
-          path: mmtk-core-branch
-      # Checkout perf-kit
-      - name: Checkout Perf Kit
-        uses: actions/checkout@v2
-        with:
-          repository: mmtk/ci-perf-kit
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.4.3"
-          path: ci-perf-kit
-          submodules: true
-      # setup
-      # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)
-      - name: Setup Rust Toolchain
-        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
-      - name: Setup
-        run: |
-          mkdir -p ci-perf-kit/running/benchmarks/dacapo
-          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo/
-      # run compare
-      - name: Compare Performance
-        id: run
-        run: |
-          JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm-trunk/ mmtk-core-trunk/ mmtk-jikesrvm-branch/ mmtk-core-branch/ jikesrvm-compare-report.md
-      # set report.md to output
-      - uses: pCYSl5EDgo/cat@master
-        id: cat
-        with:
-          path: jikesrvm-compare-report.md
-      # upload run results
-      - uses: actions/upload-artifact@v2
-        with:
-          name: jikesrvm-log
-          path: ci-perf-kit/running/results/log
-      - uses: actions/upload-artifact@v2
-        with:
-          name: jikesrvm-compare-report.md
-          path: jikesrvm-compare-report.md
-      # report
-      - name: Result
-        if: always()
-        uses: thollander/actions-comment-pull-request@master
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          message: ${{ steps.cat.outputs.text }}
-      # Cleanup logs (this is necessary for self-hosted runners)
-      - name: Clean up logs and reports
-        if: always()
-        run: |
-          rm -rf ci-perf-kit/running/results/log/*
-          rm jikesrvm-compare-report.md
+  # jikesrvm-perf-compare:
+  #   runs-on: [self-hosted, Linux, freq-scaling-off]
+  #   if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
+  #   steps:
+  #     - name: Check Revisions
+  #       uses: qinsoon/comment-env-vars@1.0.2
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         default_env: 'JIKESRVM_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,JIKESRVM_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'
+  #     # Trunk
+  #     # - binding
+  #     - name: Checkout JikesRVM Binding Trunk
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: mmtk/mmtk-jikesrvm
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         path: mmtk-jikesrvm-trunk
+  #         submodules: true
+  #         ref: ${{ env.JIKESRVM_BINDING_TRUNK_REF }}
+  #     # - core
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v2
+  #       with:
+  #         ref: ${{ env.MMTK_CORE_TRUNK_REF }}
+  #         path: mmtk-core-trunk
+  #     # Branch
+  #     # - binding
+  #     - name: Checkout JikesRVM Binding Branch
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: mmtk/mmtk-jikesrvm
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         path: mmtk-jikesrvm-branch
+  #         submodules: true
+  #         ref: ${{ env.JIKESRVM_BINDING_BRANCH_REF }}
+  #     # - core
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v2
+  #       with:
+  #         ref: ${{ env.MMTK_CORE_BRANCH_REF }}
+  #         path: mmtk-core-branch
+  #     # Checkout perf-kit
+  #     - name: Checkout Perf Kit
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: mmtk/ci-perf-kit
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         ref: "0.4.3"
+  #         path: ci-perf-kit
+  #         submodules: true
+  #     # setup
+  #     # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)
+  #     - name: Setup Rust Toolchain
+  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
+  #     - name: Setup
+  #       run: |
+  #         mkdir -p ci-perf-kit/running/benchmarks/dacapo
+  #         cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo/
+  #     # run compare
+  #     - name: Compare Performance
+  #       id: run
+  #       run: |
+  #         JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm-trunk/ mmtk-core-trunk/ mmtk-jikesrvm-branch/ mmtk-core-branch/ jikesrvm-compare-report.md
+  #     # set report.md to output
+  #     - uses: pCYSl5EDgo/cat@master
+  #       id: cat
+  #       with:
+  #         path: jikesrvm-compare-report.md
+  #     # upload run results
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: jikesrvm-log
+  #         path: ci-perf-kit/running/results/log
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: jikesrvm-compare-report.md
+  #         path: jikesrvm-compare-report.md
+  #     # report
+  #     - name: Result
+  #       if: always()
+  #       uses: thollander/actions-comment-pull-request@master
+  #       with:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         message: ${{ steps.cat.outputs.text }}
+  #     # Cleanup logs (this is necessary for self-hosted runners)
+  #     - name: Clean up logs and reports
+  #       if: always()
+  #       run: |
+  #         rm -rf ci-perf-kit/running/results/log/*
+  #         rm jikesrvm-compare-report.md
 
   # OpenJDK
   openjdk-binding-test:

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "gencopy-perf"
+          ref: "0.5.0"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -259,7 +259,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "gencopy-perf"
+          ref: "0.5.0"
           path: ci-perf-kit
           submodules: true
       # setup


### PR DESCRIPTION
Update `ci-perf-kit` to 0.5.0 (https://github.com/mmtk/ci-perf-kit/releases/tag/0.5.0), which has the following changes:
* Run performance comparison scripts for OpenJDK GenCopy
* Run performance regression scripts for OpenJDK GenCopy
* Use 40 invocations for performance regression runs (was 5 invocations)
* Fixed a bug for OpenJDK micro benchmarks (previously it wasn't testing MMTk at all - my bad).