### PR TITLE
Update to ci-perf-kit 0.5.1

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.5.0"
+          ref: "0.5.1"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.5.0"
+          ref: "0.5.1"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -85,7 +85,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.5.0"
+          ref: "0.5.1"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -146,7 +146,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.5.0"
+          ref: "0.5.1"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.5.0"
+          ref: "0.5.1"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -259,7 +259,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.5.0"
+          ref: "0.5.1"
           path: ci-perf-kit
           submodules: true
       # setup


### PR DESCRIPTION
This PR updates our actions to use `ci-perf-kit` 0.5.1 (https://github.com/mmtk/ci-perf-kit/releases/tag/0.5.1). It fixed a typo in OpenJDK GenCopy regression runs.