### PR TITLE
Remove Option for space in allocators

### DIFF
--- a/docs/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/tutorial/code/mygc_semispace/gc_work.rs
@@ -34,7 +34,7 @@ impl<VM: VMBinding> CopyContext for MyGCCopyContext<VM> {
     // ANCHOR_END: copycontext_constraints_init
     // ANCHOR: copycontext_prepare
     fn prepare(&mut self) {
-        self.mygc.rebind(Some(self.plan.tospace()));
+        self.mygc.rebind(self.plan.tospace());
     }
     // ANCHOR_END: copycontext_prepare
     fn release(&mut self) {
@@ -69,9 +69,10 @@ impl<VM: VMBinding> CopyContext for MyGCCopyContext<VM> {
 // ANCHOR: constructor_and_workerlocal
 impl<VM: VMBinding> MyGCCopyContext<VM> {
     pub fn new(mmtk: &'static MMTK<VM>) -> Self {
+        let plan = &mmtk.plan.downcast_ref::<MyGC<VM>>().unwrap();
         Self {
-            plan: &mmtk.plan.downcast_ref::<MyGC<VM>>().unwrap(),
-            mygc: BumpAllocator::new(OpaquePointer::UNINITIALIZED, None, &*mmtk.plan),
+            plan,
+            mygc: BumpAllocator::new(OpaquePointer::UNINITIALIZED, plan.tospace(), &*mmtk.plan),
         }
     }
 }

--- a/docs/tutorial/code/mygc_semispace/mutator.rs
+++ b/docs/tutorial/code/mygc_semispace/mutator.rs
@@ -36,13 +36,13 @@ pub fn mygc_mutator_release<VM: VMBinding>(
     }
     .downcast_mut::<BumpAllocator<VM>>()
     .unwrap();
-    bump_allocator.rebind(Some(
+    bump_allocator.rebind(
         mutator
             .plan
             .downcast_ref::<MyGC<VM>>()
             .unwrap()
             .tospace(),
-    ));
+    );
 }
 // ANCHOR_END: release
 

--- a/src/plan/gencopy/gc_work.rs
+++ b/src/plan/gencopy/gc_work.rs
@@ -27,7 +27,7 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
         self.ss.tls = tls;
     }
     fn prepare(&mut self) {
-        self.ss.rebind(Some(self.plan.tospace()));
+        self.ss.rebind(self.plan.tospace());
     }
     fn release(&mut self) {
         // self.ss.rebind(Some(self.plan.tospace()));
@@ -61,9 +61,11 @@ impl<VM: VMBinding> CopyContext for GenCopyCopyContext<VM> {
 
 impl<VM: VMBinding> GenCopyCopyContext<VM> {
     pub fn new(mmtk: &'static MMTK<VM>) -> Self {
+        let plan = &mmtk.plan.downcast_ref::<GenCopy<VM>>().unwrap();
         Self {
-            plan: &mmtk.plan.downcast_ref::<GenCopy<VM>>().unwrap(),
-            ss: BumpAllocator::new(OpaquePointer::UNINITIALIZED, None, &*mmtk.plan),
+            plan,
+            // it doesn't matter which space we bind with the copy allocator. We will rebind to a proper space in prepare().
+            ss: BumpAllocator::new(OpaquePointer::UNINITIALIZED, plan.tospace(), &*mmtk.plan),
         }
     }
 }

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -78,7 +78,6 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
                 .get_allocator_mut(self.config.allocator_mapping[allocator])
         }
         .get_space()
-        .unwrap()
         .initialize_header(refer, true)
     }
 

--- a/src/plan/semispace/gc_work.rs
+++ b/src/plan/semispace/gc_work.rs
@@ -26,7 +26,7 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
         self.ss.tls = tls;
     }
     fn prepare(&mut self) {
-        self.ss.rebind(Some(self.plan.tospace()));
+        self.ss.rebind(self.plan.tospace());
     }
     fn release(&mut self) {
         // self.ss.rebind(Some(self.plan.tospace()));
@@ -56,9 +56,11 @@ impl<VM: VMBinding> CopyContext for SSCopyContext<VM> {
 
 impl<VM: VMBinding> SSCopyContext<VM> {
     pub fn new(mmtk: &'static MMTK<VM>) -> Self {
+        let plan = &mmtk.plan.downcast_ref::<SemiSpace<VM>>().unwrap();
         Self {
-            plan: &mmtk.plan.downcast_ref::<SemiSpace<VM>>().unwrap(),
-            ss: BumpAllocator::new(OpaquePointer::UNINITIALIZED, None, &*mmtk.plan),
+            plan,
+            // it doesn't matter which space we bind with the copy allocator. We will rebind to a proper space in prepare().
+            ss: BumpAllocator::new(OpaquePointer::UNINITIALIZED, plan.tospace(), &*mmtk.plan),
         }
     }
 }

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -24,13 +24,13 @@ pub fn ss_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, _tls: Opaque
     }
     .downcast_mut::<BumpAllocator<VM>>()
     .unwrap();
-    bump_allocator.rebind(Some(
+    bump_allocator.rebind(
         mutator
             .plan
             .downcast_ref::<SemiSpace<VM>>()
             .unwrap()
             .tospace(),
-    ));
+    );
 }
 
 lazy_static! {

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -107,7 +107,7 @@ pub fn get_maximum_aligned_size<VM: VMBinding>(
 pub trait Allocator<VM: VMBinding>: Downcast {
     fn get_tls(&self) -> OpaquePointer;
 
-    fn get_space(&self) -> Option<&'static dyn Space<VM>>;
+    fn get_space(&self) -> &'static dyn Space<VM>;
     fn get_plan(&self) -> &'static dyn Plan<VM = VM>;
 
     fn alloc(&mut self, size: usize, align: usize, offset: isize) -> Address;

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -73,21 +73,21 @@ impl<VM: VMBinding> Allocators<VM> {
                 AllocatorSelector::BumpPointer(index) => {
                     ret.bump_pointer[index as usize].write(BumpAllocator::new(
                         mutator_tls,
-                        Some(space),
+                        space,
                         plan,
                     ));
                 }
                 AllocatorSelector::LargeObject(index) => {
                     ret.large_object[index as usize].write(LargeObjectAllocator::new(
                         mutator_tls,
-                        Some(space.downcast_ref::<LargeObjectSpace<VM>>().unwrap()),
+                        space.downcast_ref::<LargeObjectSpace<VM>>().unwrap(),
                         plan,
                     ));
                 }
                 AllocatorSelector::Malloc(index) => {
                     ret.malloc[index as usize].write(MallocAllocator::new(
                         mutator_tls,
-                        Some(space.downcast_ref::<MallocSpace<VM>>().unwrap()),
+                        space.downcast_ref::<MallocSpace<VM>>().unwrap(),
                         plan,
                     ));
                 }

--- a/src/util/alloc/malloc_allocator.rs
+++ b/src/util/alloc/malloc_allocator.rs
@@ -9,13 +9,13 @@ use crate::vm::VMBinding;
 #[repr(C)]
 pub struct MallocAllocator<VM: VMBinding> {
     pub tls: OpaquePointer,
-    space: Option<&'static MallocSpace<VM>>,
+    space: &'static MallocSpace<VM>,
     plan: &'static dyn Plan<VM = VM>,
 }
 
 impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
-    fn get_space(&self) -> Option<&'static dyn Space<VM>> {
-        self.space.map(|s| s as &'static dyn Space<VM>)
+    fn get_space(&self) -> &'static dyn Space<VM> {
+        self.space as &'static dyn Space<VM>
     }
     fn get_plan(&self) -> &'static dyn Plan<VM = VM> {
         self.plan
@@ -32,7 +32,7 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
         // TODO: We currently ignore the offset field. This is wrong.
         // assert!(offset == 0);
         assert!(align <= 16);
-        let ret = self.space.unwrap().alloc(self.tls, size);
+        let ret = self.space.alloc(self.tls, size);
         trace!(
             "MallocSpace.alloc size = {}, align = {}, offset = {}, res = {}",
             size,
@@ -47,7 +47,7 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
 impl<VM: VMBinding> MallocAllocator<VM> {
     pub fn new(
         tls: OpaquePointer,
-        space: Option<&'static MallocSpace<VM>>,
+        space: &'static MallocSpace<VM>,
         plan: &'static dyn Plan<VM = VM>,
     ) -> Self {
         MallocAllocator { tls, space, plan }


### PR DESCRIPTION
It is unnecessary to use `Option` for `space` in allocators. Also the `Allocator` trait now return a space reference from `get_space()` rather than an `Option`.