### PR TITLE
Update to comment-env-vars 1.0.3

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -12,7 +12,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.2
+        uses: qinsoon/comment-env-vars@1.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'OPENJDK_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,OPENJDK_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: mmtk-core
       - name: Check Binding Revision
-        uses: qinsoon/comment-env-vars@1.0.2
+        uses: qinsoon/comment-env-vars@1.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'V8_BINDING_REF=master'
@@ -57,7 +57,7 @@ jobs:
         with:
           path: mmtk-core
       - name: Check Binding Revision
-        uses: qinsoon/comment-env-vars@1.0.2
+        uses: qinsoon/comment-env-vars@1.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'JIKESRVM_BINDING_REF=master'
@@ -89,7 +89,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.2
+        uses: qinsoon/comment-env-vars@1.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'JIKESRVM_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,JIKESRVM_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'
@@ -186,7 +186,7 @@ jobs:
         with:
           path: mmtk-core
       - name: Check Binding Revision
-        uses: qinsoon/comment-env-vars@1.0.2
+        uses: qinsoon/comment-env-vars@1.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'OPENJDK_BINDING_REF=master'
@@ -217,7 +217,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.2
+        uses: qinsoon/comment-env-vars@1.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'OPENJDK_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,OPENJDK_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'


### PR DESCRIPTION
The action `comment-env-vars` extract values as Github aciton env vars from issue comments. We use this action to specify binding branches. Previosly 1.0.2 had a bug that only fetch the first 30 comments from an issue. Now it will properly fetch all the comments. 