### PR TITLE
Fix race condition in FragmentedMmapper.ensure_mapped()

### DIFF
--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -127,7 +127,8 @@ impl Mmapper for FragmentedMapper {
                         let mmap_start = Self::chunk_index_to_address(base, chunk);
                         crate::util::memory::munprotect(mmap_start, MMAP_CHUNK_BYTES).unwrap();
                     }
-                    _ => {}
+                    // might have become MAPPED here
+                    MapState::Mapped => {}
                 }
 
                 entry.store(MapState::Mapped, Ordering::Relaxed);

--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -107,11 +107,14 @@ impl Mmapper for FragmentedMapper {
 
             /* Iterate over the chunks within the slab */
             for (chunk, entry) in mapped.iter().enumerate().take(end_chunk).skip(start_chunk) {
+                if matches!(entry.load(Ordering::Relaxed), MapState::Mapped) {
+                    continue;
+                }
+
+                let _guard = self.lock.lock().unwrap();
                 match entry.load(Ordering::Relaxed) {
-                    MapState::Mapped => continue,
                     MapState::Unmapped => {
                         let mmap_start = Self::chunk_index_to_address(base, chunk);
-                        let _guard = self.lock.lock().unwrap();
                         crate::util::memory::dzmmap(mmap_start, MMAP_CHUNK_BYTES).unwrap();
                         self.map_metadata(
                             mmap_start,
@@ -122,10 +125,11 @@ impl Mmapper for FragmentedMapper {
                     }
                     MapState::Protected => {
                         let mmap_start = Self::chunk_index_to_address(base, chunk);
-                        let _guard = self.lock.lock().unwrap();
                         crate::util::memory::munprotect(mmap_start, MMAP_CHUNK_BYTES).unwrap();
                     }
+                    _ => {}
                 }
+
                 entry.store(MapState::Mapped, Ordering::Relaxed);
             }
             start = high;


### PR DESCRIPTION
The `FragmentedMmapper` was ported from JikesRVM MMTk . The method `ensure_mapped` was not ported correctly (Java MMTk code: https://github.com/JikesRVM/JikesRVM/blob/master/MMTk/src/org/mmtk/utility/heap/layout/FragmentedMmapper.java#L382). The original implementation is thread safe, but the ported version is not. It is possible that multiple threads see a a chunk as `Unmapped` or `Protected` - one thread acquires the lock and mmap/zero the chunk and the other would wait for the lock and try to mmap the chunk (and zero it again - at this point, we may already have data in the chunk).

This did not cause any issue so far as we only use it behind a page resource lock (in both `MonotonePageResource` and `FreelistPageResource`). For example, for `MonotonePageResource`, we acquire a lock here,
https://github.com/mmtk/mmtk-core/blob/6cac4ff8f60e10922ad1aff37514a84392ea88f5/src/util/heap/monotonepageresource.rs#L74
then use `ensure_mapped()`.
https://github.com/mmtk/mmtk-core/blob/6cac4ff8f60e10922ad1aff37514a84392ea88f5/src/util/heap/monotonepageresource.rs#L159

In my refactoring of https://github.com/mmtk/mmtk-core/pull/275, the `ensure_mapped()` is moved from `PageResource` to `Space` and is no longer protected by a lock. And it starts to cause segfault.