### PR TITLE
Add build and stylecheck for release build in ci-build and ci-style

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -8,8 +8,12 @@ cargo build
 # Build features
 for_all_features "cargo build"
 
+# Build release
+for_all_features "cargo build --release"
+
 # For x86_64-linux, also see if we can build for i686
 if [[ $arch == "x86_64" && $os == "linux" ]]; then
     cargo build --target i686-unknown-linux-gnu
     for_all_features "cargo build --target i686-unknown-linux-gnu"
+    for_all_features "cargo build --release --target i686-unknown-linux-gnu"
 fi

--- a/.github/scripts/ci-style.sh
+++ b/.github/scripts/ci-style.sh
@@ -6,6 +6,8 @@ export RUSTFLAGS="-D warnings"
 cargo clippy
 # check all features
 for_all_features "cargo clippy"
+# check release
+for_all_features "cargo clippy --release"
 # check for tests
 for_all_features "cargo clippy --tests"
 # check for dummyvm
@@ -14,6 +16,7 @@ cargo clippy --manifest-path=vmbindings/dummyvm/Cargo.toml
 # For x86_64-linux, also check for i686
 if [[ $arch == "x86_64" && $os == "linux" ]]; then
     for_all_features "cargo clippy --target i686-unknown-linux-gnu"
+    for_all_features "cargo clippy --release --target i686-unknown-linux-gnu"
 fi 
 
 # check format

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Test
         run: |
           cd mmtk-v8
-          V8_ROOT=$GITHUB_WORKSPACE/v8_deps .github/scripts/ci-test.sh
+          export V8_ROOT=$GITHUB_WORKSPACE/v8_deps
+          .github/scripts/ci-test.sh
+          .github/scripts/ci-style.sh
 
   # JikesRVM
   jikesrvm-binding-test:
@@ -84,6 +86,7 @@ jobs:
         run: |
           cd mmtk-jikesrvm
           ./.github/scripts/ci-test.sh
+          ./.github/scripts/ci-style.sh
   jikesrvm-perf-compare:
     runs-on: [self-hosted, Linux, freq-scaling-off]
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
@@ -212,6 +215,7 @@ jobs:
         run: |
           cd mmtk-openjdk
           ./.github/scripts/ci-test.sh
+          ./.github/scripts/ci-style.sh
   openjdk-perf-compare:
     runs-on: [self-hosted, Linux, freq-scaling-off]
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -535,8 +535,12 @@ impl<VM: VMBinding> BasePlan<VM> {
         }
     }
 
+    // Depends on what base spaces we use, unsync may be unused.
+    #[allow(unused_variables)]
     #[cfg(feature = "base_spaces")]
     pub fn get_pages_used(&self) -> usize {
+        // Depends on what base spaces we use, pages may be unchanged.
+        #[allow(unused_mut)]
         let mut pages = 0;
         let unsync = unsafe { &mut *self.unsync.get() };
 

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -81,6 +81,8 @@ impl<VM: VMBinding> Space<VM> for MallocSpace<VM> {
         unreachable!()
     }
 
+    // We have assertions in a debug build. We allow this pattern for the release build.
+    #[allow(clippy::let_and_return)]
     fn in_space(&self, object: ObjectReference) -> bool {
         let ret = is_alloced_by_malloc(object);
 

--- a/src/policy/mallocspace/metadata.rs
+++ b/src/policy/mallocspace/metadata.rs
@@ -3,6 +3,8 @@ use crate::util::constants;
 use crate::util::constants::BYTES_IN_WORD;
 use crate::util::conversions;
 use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
+#[cfg(debug_assertions)]
+use crate::util::side_metadata::address_to_meta_address;
 use crate::util::side_metadata::load_atomic;
 #[cfg(target_pointer_width = "32")]
 use crate::util::side_metadata::meta_bytes_per_chunk;
@@ -102,7 +104,6 @@ pub fn is_alloced(object: ObjectReference) -> bool {
 pub fn is_alloced_object(address: Address) -> bool {
     #[cfg(debug_assertions)]
     if ASSERT_METADATA {
-        use crate::util::side_metadata::address_to_meta_address;
         // Need to make sure we atomically access the side metadata and the map.
         let lock = ALLOC_MAP.read().unwrap();
         let check =
@@ -125,7 +126,6 @@ pub fn is_alloced_object(address: Address) -> bool {
 pub fn is_marked(object: ObjectReference) -> bool {
     #[cfg(debug_assertions)]
     if ASSERT_METADATA {
-        use crate::util::side_metadata::address_to_meta_address;
         // Need to make sure we atomically access the side metadata and the map.
         let lock = MARK_MAP.read().unwrap();
         let ret = load_atomic(MARKING_METADATA_SPEC, object.to_address()) == 1;

--- a/src/policy/mallocspace/metadata.rs
+++ b/src/policy/mallocspace/metadata.rs
@@ -3,7 +3,6 @@ use crate::util::constants;
 use crate::util::constants::BYTES_IN_WORD;
 use crate::util::conversions;
 use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
-use crate::util::side_metadata::address_to_meta_address;
 use crate::util::side_metadata::load_atomic;
 #[cfg(target_pointer_width = "32")]
 use crate::util::side_metadata::meta_bytes_per_chunk;
@@ -103,6 +102,7 @@ pub fn is_alloced(object: ObjectReference) -> bool {
 pub fn is_alloced_object(address: Address) -> bool {
     #[cfg(debug_assertions)]
     if ASSERT_METADATA {
+        use crate::util::side_metadata::address_to_meta_address;
         // Need to make sure we atomically access the side metadata and the map.
         let lock = ALLOC_MAP.read().unwrap();
         let check =
@@ -125,6 +125,7 @@ pub fn is_alloced_object(address: Address) -> bool {
 pub fn is_marked(object: ObjectReference) -> bool {
     #[cfg(debug_assertions)]
     if ASSERT_METADATA {
+        use crate::util::side_metadata::address_to_meta_address;
         // Need to make sure we atomically access the side metadata and the map.
         let lock = MARK_MAP.read().unwrap();
         let ret = load_atomic(MARKING_METADATA_SPEC, object.to_address()) == 1;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -18,7 +18,7 @@ pub type ByteOffset = isize;
 /// (memory wise and time wise). The idea is from the paper
 /// High-level Low-level Programming (VEE09) and JikesRVM.
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, Hash, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Eq, Hash, PartialOrd, Ord, PartialEq)]
 pub struct Address(usize);
 
 /// Address + ByteSize (positive)


### PR DESCRIPTION
This PR adds build and style check for the release build of mmtk-core. It also adds style check for the bindings, and will run the binding's style checks for mmtk-core. It closes https://github.com/mmtk/mmtk-core/issues/279.