### PR TITLE
Fix stress gc triggering in GenCopy

### DIFF
--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -5,8 +5,13 @@ cargo doc --features $non_exclusive_features --no-deps
 
 # Check tutorial code
 tutorial_code_dir=$project_root/docs/tutorial/code/mygc_semispace
+# Clear the dir and copy again
+rm -rf $project_root/src/plan/mygc
 cp -r $tutorial_code_dir $project_root/src/plan/mygc
-echo "pub mod mygc;" >> $project_root/src/plan/mod.rs
+# If we havent appended the mod line, append it
+if ! cat $project_root/src/plan/mod.rs | grep -q "pub mod mygc;"; then
+    echo "pub mod mygc;" >> $project_root/src/plan/mod.rs
+fi
 cargo build
 
 cargo install mdbook

--- a/docs/tutorial/code/mygc_semispace/global.rs
+++ b/docs/tutorial/code/mygc_semispace/global.rs
@@ -102,6 +102,12 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
     }
     // ANCHOR_END: schedule_collection
 
+    // ANCHOR: collection_required()
+    fn collection_required(&self, space_full: bool, space: &dyn Space<Self::VM>) -> bool {
+        self.base().collection_required(self, space_full, space)
+    }
+    // ANCHOR_END: collection_required()
+
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }

--- a/docs/tutorial/src/mygc/ss/alloc.md
+++ b/docs/tutorial/src/mygc/ss/alloc.md
@@ -109,6 +109,14 @@ base plan *through* the common plan.
 {{#include ../../../code/mygc_semispace/global.rs:plan_base}}
 ```
 
+The trait `Plan` requires `collection_required()` method to know when
+we should trigger a collection. We can just use the implementation
+in the `BasePlan`.
+
+```rust
+{{#include ../../../code/mygc_semispace/global.rs:collection_required}}
+```
+
 Find the method `get_pages_used`. Replace the current body with 
 `self.tospace().reserved_pages() + self.common.get_pages_used()`, to 
 correctly count the pages contained in the tospace and the common plan 

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -72,9 +72,13 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
     where
         Self: Sized,
     {
+        let stress_force_gc = self.stress_test_gc_required();
         let nursery_full = self.nursery.reserved_pages() >= (NURSERY_SIZE >> LOG_BYTES_IN_PAGE);
         let heap_full = self.get_pages_reserved() > self.get_total_pages();
-        space_full || nursery_full || heap_full
+
+        // TODO: Basically this is (nursery_full || super.collection_required()).
+        // We need to figure out a way to reuse the super code.
+        space_full || nursery_full || heap_full || stress_force_gc
     }
 
     fn gc_init(

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -68,17 +68,13 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         GCWorkerLocalPtr::new(c)
     }
 
-    fn collection_required(&self, space_full: bool, _space: &dyn Space<Self::VM>) -> bool
+    fn collection_required(&self, space_full: bool, space: &dyn Space<Self::VM>) -> bool
     where
         Self: Sized,
     {
-        let stress_force_gc = self.stress_test_gc_required();
         let nursery_full = self.nursery.reserved_pages() >= (NURSERY_SIZE >> LOG_BYTES_IN_PAGE);
-        let heap_full = self.get_pages_reserved() > self.get_total_pages();
 
-        // TODO: Basically this is (nursery_full || super.collection_required()).
-        // We need to figure out a way to reuse the super code.
-        space_full || nursery_full || heap_full || stress_force_gc
+        nursery_full || self.base().collection_required(self, space_full, space)
     }
 
     fn gc_init(

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -85,6 +85,10 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         unsafe { self.ms.release_all_chunks() };
     }
 
+    fn collection_required(&self, space_full: bool, space: &dyn Space<Self::VM>) -> bool {
+        self.base().collection_required(self, space_full, space)
+    }
+
     fn get_collection_reserve(&self) -> usize {
         0
     }

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -62,6 +62,10 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         self.nogc_space.init(&vm_map);
     }
 
+    fn collection_required(&self, space_full: bool, space: &dyn Space<Self::VM>) -> bool {
+        self.base.collection_required(self, space_full, space)
+    }
+
     fn base(&self) -> &BasePlan<VM> {
         &self.base
     }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -120,6 +120,10 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         self.fromspace().release();
     }
 
+    fn collection_required(&self, space_full: bool, space: &dyn Space<Self::VM>) -> bool {
+        self.base().collection_required(self, space_full, space)
+    }
+
     fn get_collection_reserve(&self) -> usize {
         self.tospace().reserved_pages()
     }


### PR DESCRIPTION
This PR refactors `collection_required()` from `Plan` to `BasePlan`, and allows each plan implementation to reuse `BasePlan.collection_required()`. This refactoring is along the line of the idea of 'composition over inheritance'. This fixes https://github.com/mmtk/mmtk-core/issues/209 where gencopy does not check stress test GC.
* Moved `collection_required()` and `stress_test_gc_required()` to `BasePlan`.
* Updated tutorial.
* Updated `ci-doc.sh` to allow re-execute the script (easier for developers to run ci-doc.sh in their dev environment)