### PR TITLE
add extreme_assertions feature, and duplicate edge check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ single_worker = []
 # To support VMs that do not provide in-header GC byte
 side_gc_header = []
 
+# To run expensive comprehensive runtime checks
+extreme_assertions = []
+
 # Do not modify the following line - ci-common.sh matches it
 # -- Mutally exclusive features --
 # Only one feature from each group can be provided. Otherwise build will fail.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ single_worker = []
 # To support VMs that do not provide in-header GC byte
 side_gc_header = []
 
-# To run expensive comprehensive runtime checks
+# To run expensive comprehensive runtime checks, such as checking duplicate edges
 extreme_assertions = []
 
 # Do not modify the following line - ci-common.sh matches it

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -178,6 +178,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for StopMutators<E> {
                 if !mmtk.plan.base().stacks_prepared() {
                     for mutator in <E::VM as VMBinding>::VMActivePlan::mutators() {
                         <E::VM as VMBinding>::VMCollection::prepare_mutator(
+                            worker.tls,
                             mutator.get_tls(),
                             mutator,
                         );
@@ -399,7 +400,11 @@ pub trait ProcessEdgesWork:
     #[inline]
     fn process_edge(&mut self, slot: Address) {
         #[cfg(feature = "extreme_assertions")]
-        assert!(crate::edge_logger::is_logged_edge(slot), "Unknown edge detected: ({})", slot);
+        assert!(
+            crate::edge_logger::is_logged_edge(slot),
+            "Unknown edge detected: ({})",
+            slot
+        );
         let object = unsafe { slot.load::<ObjectReference>() };
         let new_object = self.trace_object(object);
         if Self::OVERWRITE_REFERENCE {

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -398,6 +398,8 @@ pub trait ProcessEdgesWork:
 
     #[inline]
     fn process_edge(&mut self, slot: Address) {
+        #[cfg(feature = "extreme_assertions")]
+        assert!(crate::edge_logger::is_logged_edge(slot), "Unknown edge detected: ({})", slot);
         let object = unsafe { slot.load::<ObjectReference>() };
         let new_object = self.trace_object(object);
         if Self::OVERWRITE_REFERENCE {

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -401,7 +401,7 @@ pub trait ProcessEdgesWork:
     fn process_edge(&mut self, slot: Address) {
         #[cfg(feature = "extreme_assertions")]
         assert!(
-            crate::edge_logger::is_logged_edge(slot),
+            crate::util::edge_logger::is_logged_edge(slot),
             "Unknown edge detected: ({})",
             slot
         );

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -72,7 +72,9 @@ impl Sub<Address> for Address {
     fn sub(self, other: Address) -> ByteSize {
         debug_assert!(
             self.0 >= other.0,
-            "for (addr_a - addr_b), a needs to be larger than b"
+            "for (addr_a - addr_b), a({}) needs to be larger than b({})",
+            self,
+            other
         );
         self.0 - other.0
     }

--- a/src/util/edge_logger.rs
+++ b/src/util/edge_logger.rs
@@ -1,0 +1,24 @@
+use super::Address;
+use std::collections::HashSet;
+use std::sync::RwLock;
+
+lazy_static! {
+    static ref EDGE_LOG: RwLock<HashSet<Address>> = RwLock::new(HashSet::new());
+}
+
+pub fn log_edge(edge: Address) {
+    // println!("log_edge({})", edge);
+    let mut edge_log = EDGE_LOG.write().unwrap();
+    assert!(edge_log.insert(edge), "duplicate edge ({}) detected", edge);
+}
+
+pub fn is_logged_edge(edge: Address) -> bool {
+    let edge_log = EDGE_LOG.read().unwrap();
+    edge_log.contains(&edge)
+}
+
+pub fn reset() {
+    let mut edge_log = EDGE_LOG.write().unwrap();
+    edge_log.clear();
+    // println!("edge_logger::reset()");
+}

--- a/src/util/edge_logger.rs
+++ b/src/util/edge_logger.rs
@@ -26,18 +26,6 @@ pub fn log_edge(edge: Address) {
     assert!(edge_log.insert(edge), "duplicate edge ({}) detected", edge);
 }
 
-/// Checks whether an edge is already logged.
-/// Returns `true` if the edge is logged and `false` otherwise.
-///
-/// # Arguments
-///
-/// * `edge` - The edge to check.
-///
-pub fn is_logged_edge(edge: Address) -> bool {
-    let edge_log = EDGE_LOG.read().unwrap();
-    edge_log.contains(&edge)
-}
-
 /// Reset the edge logger by clearing the hash-set of edges.
 /// This function is called at the end of each GC iteration.
 ///

--- a/src/util/edge_logger.rs
+++ b/src/util/edge_logger.rs
@@ -1,24 +1,47 @@
+//! This is a simple module to log edges and check for duplicate edges.
+//!
+//! It uses a hash-set to keep track of edge, and is so very expensive.
+//! We currently only use this as part of the `extreme_assertions` feature.
+//!
+
 use super::Address;
 use std::collections::HashSet;
 use std::sync::RwLock;
 
 lazy_static! {
+    // A private hash-set to keep track of edges.
     static ref EDGE_LOG: RwLock<HashSet<Address>> = RwLock::new(HashSet::new());
 }
 
+/// Logs an edge.
+/// Panics if the edge was already logged.
+///
+/// # Arguments
+///
+/// * `edge` - The edge to log.
+///
 pub fn log_edge(edge: Address) {
-    // println!("log_edge({})", edge);
+    trace!("log_edge({})", edge);
     let mut edge_log = EDGE_LOG.write().unwrap();
     assert!(edge_log.insert(edge), "duplicate edge ({}) detected", edge);
 }
 
+/// Checks whether an edge is already logged.
+/// Returns `true` if the edge is logged and `false` otherwise.
+///
+/// # Arguments
+///
+/// * `edge` - The edge to check.
+///
 pub fn is_logged_edge(edge: Address) -> bool {
     let edge_log = EDGE_LOG.read().unwrap();
     edge_log.contains(&edge)
 }
 
+/// Reset the edge logger by clearing the hash-set of edges.
+/// This function is called at the end of each GC iteration.
+///
 pub fn reset() {
     let mut edge_log = EDGE_LOG.write().unwrap();
     edge_log.clear();
-    // println!("edge_logger::reset()");
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,6 +9,8 @@ pub mod alloc;
 #[cfg(feature = "analysis")]
 pub mod analysis;
 pub mod constants;
+#[cfg(feature = "extreme_assertions")]
+pub mod edge_logger;
 pub mod finalizable_processor;
 pub mod forwarding_word;
 pub mod gc_byte;

--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -45,9 +45,14 @@ pub trait Collection<VM: VMBinding> {
     /// Allow VM-specific behaviors for a mutator after all the mutators are stopped and before any actual GC work starts.
     ///
     /// Arguments:
-    /// * `tls`: The thread pointer for a mutator thread.
+    /// * `tls_worker`: The thread pointer for the worker thread performing this call.
+    /// * `tls_mutator`: The thread pointer for the target mutator thread.
     /// * `m`: The mutator context for the thread.
-    fn prepare_mutator<T: MutatorContext<VM>>(tls: OpaquePointer, m: &T);
+    fn prepare_mutator<T: MutatorContext<VM>>(
+        tls_worker: OpaquePointer,
+        tls_mutator: OpaquePointer,
+        m: &T,
+    );
 
     /// Inform the VM for an out-of-memory error. The VM can implement its own error routine for OOM.
     ///

--- a/vmbindings/dummyvm/src/collection.rs
+++ b/vmbindings/dummyvm/src/collection.rs
@@ -25,7 +25,7 @@ impl Collection<DummyVM> for VMCollection {
         unimplemented!();
     }
 
-    fn prepare_mutator<T: MutatorContext<DummyVM>>(_tls: OpaquePointer, _mutator: &T) {
+    fn prepare_mutator<T: MutatorContext<DummyVM>>(_tls_w: OpaquePointer, _tls_m: OpaquePointer, _mutator: &T) {
         unimplemented!()
     }
 }


### PR DESCRIPTION
This PR adds a feature (`extreme_assertions`) for when expensive runtime checks are required.
This feature can be used in both debug and release builds (but provides more useful info in the debug build).

This PR also adds checking for duplicate edges (guarded by the `extreme_assertions` feature) and closes issue #291.

It also adds an argument to `VMCollection::prepare_mutator` to fix issue 36 in `mmtk-jikesrvm`.