### PR TITLE
remove unused trait method: ActivePlan::worker

### DIFF
--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -32,15 +32,6 @@ pub trait ActivePlan<VM: VMBinding> {
     // Possibly we should remove the use of this function, and remove this function?
     fn global() -> &'static dyn Plan<VM = VM>;
 
-    /// Return a `GCWorker` reference for the thread.
-    ///
-    /// Arguments:
-    /// * `tls`: The thread to query.
-    ///
-    /// # Safety
-    /// The caller needs to make sure that the thread is a GC worker thread.
-    unsafe fn worker(tls: OpaquePointer) -> &'static mut GCWorker<VM>;
-
     /// Return whether there is a mutator created and associated with the thread.
     ///
     /// Arguments:

--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -1,6 +1,5 @@
 use crate::plan::Mutator;
 use crate::plan::Plan;
-use crate::scheduler::*;
 use crate::util::OpaquePointer;
 use crate::vm::VMBinding;
 use std::marker::PhantomData;

--- a/vmbindings/dummyvm/src/active_plan.rs
+++ b/vmbindings/dummyvm/src/active_plan.rs
@@ -1,7 +1,6 @@
 use mmtk::Plan;
 use mmtk::vm::ActivePlan;
 use mmtk::util::OpaquePointer;
-use mmtk::scheduler::*;
 use mmtk::Mutator;
 use DummyVM;
 use SINGLETON;

--- a/vmbindings/dummyvm/src/active_plan.rs
+++ b/vmbindings/dummyvm/src/active_plan.rs
@@ -13,10 +13,6 @@ impl ActivePlan<DummyVM> for VMActivePlan {
         &*SINGLETON.plan
     }
 
-    unsafe fn worker(_tls: OpaquePointer) -> &'static mut GCWorker<DummyVM> {
-        unimplemented!()
-    }
-
     fn number_of_mutators() -> usize {
         unimplemented!()
     }


### PR DESCRIPTION
This PR removes the unused trait method `ActivePlan::worker` and closes issue #237.