### PR TITLE
Handle mmap failure properly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(associated_type_defaults)]
 #![feature(specialization)]
 #![feature(trait_alias)]
+#![feature(let_chains)]
 
 //! Memory Management ToolKit (MMTk) is a portable and high performance memory manager
 //! that includes various garbage collection algorithms and provides clean and efficient

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 #![feature(associated_type_defaults)]
 #![feature(specialization)]
 #![feature(trait_alias)]
-#![feature(let_chains)]
 
 //! Memory Management ToolKit (MMTk) is a portable and high performance memory manager
 //! that includes various garbage collection algorithms and provides clean and efficient

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -277,11 +277,15 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                     // adding a space lock here.
                     let bytes = conversions::pages_to_bytes(res.pages);
                     self.grow_space(res.start, bytes, res.new_chunk);
-                    self.common().mmapper.ensure_mapped(
+                    // Mmap the pages and handle error. In case of any error,
+                    // we will either call back to the VM for OOM, or simply panic.
+                    if let Err(mmap_error) = self.common().mmapper.ensure_mapped(
                         res.start,
                         res.pages,
                         &self.common().metadata,
-                    );
+                    ) {
+                        memory::handle_mmap_error::<VM>(mmap_error, tls);
+                    }
 
                     // TODO: Concurrent zeroing
                     if self.common().zeroed {

--- a/src/util/heap/layout/mmapper.rs
+++ b/src/util/heap/layout/mmapper.rs
@@ -1,6 +1,6 @@
-use crate::util::{side_metadata::SideMetadata, Address};
-
 use super::vm_layout_constants::BYTES_IN_CHUNK;
+use crate::util::{side_metadata::SideMetadata, Address};
+use std::io::Result;
 
 pub trait Mmapper {
     /****************************************************************************
@@ -37,19 +37,12 @@ pub trait Mmapper {
      * @param start The start of the range to be mapped.
      * @param pages The size of the range to be mapped, in pages
      */
-    fn ensure_mapped(&self, start: Address, pages: usize, metadata: &SideMetadata);
+    fn ensure_mapped(&self, start: Address, pages: usize, metadata: &SideMetadata) -> Result<()>;
 
     /// Map metadata memory for a given chunk
     #[allow(clippy::result_unit_err)]
-    fn map_metadata(&self, chunk: Address, metadata: &SideMetadata) -> Result<(), ()> {
-        if metadata
-            .try_map_metadata_space(chunk, BYTES_IN_CHUNK)
-            .is_err()
-        {
-            Err(())
-        } else {
-            Ok(())
-        }
+    fn map_metadata(&self, chunk: Address, metadata: &SideMetadata) -> Result<()> {
+        metadata.try_map_metadata_space(chunk, BYTES_IN_CHUNK)
     }
 
     /**

--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -55,6 +55,7 @@ pub trait Collection<VM: VMBinding> {
     );
 
     /// Inform the VM for an out-of-memory error. The VM can implement its own error routine for OOM.
+    /// Note the VM needs to fail in this call. We do not expect the VM to resume in any way.
     ///
     /// Arguments:
     /// * `tls`: The thread pointer for the mutator which failed the allocation and triggered the OOM.

--- a/vmbindings/dummyvm/src/tests/handle_mmap_conflict.rs
+++ b/vmbindings/dummyvm/src/tests/handle_mmap_conflict.rs
@@ -1,0 +1,24 @@
+use mmtk::util::Address;
+use mmtk::util::OpaquePointer;
+use mmtk::util::memory;
+use crate::DummyVM;
+
+#[test]
+pub fn test_handle_mmap_conflict() {
+    let start = unsafe { Address::from_usize(0x100_0000 )};
+    let one_megabyte = 1000000;
+    let mmap1_res = memory::dzmmap_noreplace(start, one_megabyte);
+    assert!(mmap1_res.is_ok());
+
+    let panic_res = std::panic::catch_unwind(|| {
+        let mmap2_res = memory::dzmmap_noreplace(start, one_megabyte);
+        assert!(mmap2_res.is_err());
+        memory::handle_mmap_error::<DummyVM>(mmap2_res.err().unwrap(), OpaquePointer::UNINITIALIZED);
+    });
+
+    // The error should match the error message in memory::handle_mmap_error()
+    assert!(panic_res.is_err());
+    let err = panic_res.err().unwrap();
+    assert!(err.is::<&str>());
+    assert_eq!(err.downcast_ref::<&str>().unwrap(), &"Failed to mmap, the address is already mapped. Should MMTk quanrantine the address range first?");
+}

--- a/vmbindings/dummyvm/src/tests/handle_mmap_oom.rs
+++ b/vmbindings/dummyvm/src/tests/handle_mmap_oom.rs
@@ -1,0 +1,23 @@
+use mmtk::util::Address;
+use mmtk::util::OpaquePointer;
+use mmtk::util::memory;
+use crate::DummyVM;
+
+#[test]
+pub fn test_handle_mmap_oom() {
+    let panic_res = std::panic::catch_unwind(move || {
+        let start = unsafe { Address::from_usize(0x100_0000 )};
+        let one_terabyte = 1000000000000;
+        // mmap 1 terabyte memory - we expect this will fail due to out of memory.
+        // If that's not the case, increase the size we mmap.
+        let mmap_res = memory::dzmmap_noreplace(start, one_terabyte);
+
+        memory::handle_mmap_error::<DummyVM>(mmap_res.err().unwrap(), OpaquePointer::UNINITIALIZED);
+    });
+    assert!(panic_res.is_err());
+
+    // The error should match the default implementation of Collection::out_of_memory()
+    let err = panic_res.err().unwrap();
+    assert!(err.is::<&str>());
+    assert_eq!(err.downcast_ref::<&str>().unwrap(), &"Out of memory!");
+}

--- a/vmbindings/dummyvm/src/tests/mod.rs
+++ b/vmbindings/dummyvm/src/tests/mod.rs
@@ -2,3 +2,5 @@
 // We should run each module in a separate test process, as we do not have proper
 // setup/teardown procedure for MMTk instances.
 mod issue139;
+mod handle_mmap_oom;
+mod handle_mmap_conflict;


### PR DESCRIPTION
This PR closes https://github.com/mmtk/mmtk-core/issues/221. 
* `Mmapper.ensure_mapped()` returns a `Result` to indicate whether the mmap succeeds.
* Adds a function `handle_mmap_error()`. Besides simply panicking, it deals with two types of errors differently: 1. For OOM, it calls `Collection::out_of_memory()` to inform the VM, 2. For conflicting with existing mapping, it prints a different error message.
* Add tests for `handle_mmap_error()` in DummyVM.