### PR TITLE
Disable stress test for now

### DIFF
--- a/.github/workflows/stress-ci.yml
+++ b/.github/workflows/stress-ci.yml
@@ -2,8 +2,11 @@ name: Stress Test CI
 
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
+    # Disable our stress test for now. We will rework on the config: https://github.com/mmtk/mmtk-core/issues/328
+    branches-ignore:
+      - '**'
 
 jobs:
   jikesrvm-stress-test:


### PR DESCRIPTION
Our current stress tests in CI always fail due to timeout or other issues. We will need to rework on it: https://github.com/mmtk/mmtk-core/issues/328. For now, we disable stress test. So we can use the stress test machine to test our new configuration.