### PR TITLE
Use mmapper for side metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ extern crate num_cpus;
 extern crate downcast_rs;
 
 mod mmtk;
+pub(crate) use mmtk::MMAPPER;
 pub use mmtk::MMTK;
 pub(crate) use mmtk::VM_MAP;
 

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -160,7 +160,10 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
             self.fromspace().release();
         }
 
-        self.next_gc_full_heap.store(self.get_pages_avail() < (NURSERY_SIZE >> LOG_BYTES_IN_PAGE), Ordering::SeqCst);
+        self.next_gc_full_heap.store(
+            self.get_pages_avail() < (NURSERY_SIZE >> LOG_BYTES_IN_PAGE),
+            Ordering::SeqCst,
+        );
     }
 
     fn get_collection_reserve(&self) -> usize {
@@ -260,14 +263,21 @@ impl<VM: VMBinding> GenCopy<VM> {
     }
 
     fn request_full_heap_collection(&self) -> bool {
-        debug!("full heap GC? attempt = {}, total = {}, reserved = {}", self.base().cur_collection_attempts.load(Ordering::SeqCst), self.get_total_pages(), self.get_pages_reserved());
+        debug!(
+            "full heap GC? attempt = {}, total = {}, reserved = {}",
+            self.base().cur_collection_attempts.load(Ordering::SeqCst),
+            self.get_total_pages(),
+            self.get_pages_reserved()
+        );
 
         // For barrier overhead measurements, we always do full gc in nursery collections.
         if super::FULL_NURSERY_GC {
             return true;
         }
 
-        if self.next_gc_full_heap.load(Ordering::SeqCst) || self.base().cur_collection_attempts.load(Ordering::SeqCst) > 1 {
+        if self.next_gc_full_heap.load(Ordering::SeqCst)
+            || self.base().cur_collection_attempts.load(Ordering::SeqCst) > 1
+        {
             return true;
         }
 

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -248,6 +248,11 @@ impl<VM: VMBinding> GenCopy<VM> {
         if super::FULL_NURSERY_GC {
             return true;
         }
+
+        if self.base().cur_collection_attempts.load(Ordering::SeqCst) > 1 {
+            return true;
+        }
+
         self.get_total_pages() <= self.get_pages_reserved()
     }
 

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -115,7 +115,6 @@ impl<VM: VMBinding> CopySpace<VM> {
         unsafe {
             self.pr.reset();
         }
-        self.common.metadata.reset();
         self.from_space.store(false, Ordering::SeqCst);
     }
 

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -115,6 +115,7 @@ impl<VM: VMBinding> CopySpace<VM> {
         unsafe {
             self.pr.reset();
         }
+        self.common.metadata.reset();
         self.from_space.store(false, Ordering::SeqCst);
     }
 

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -111,7 +111,9 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
 
     fn reserved_pages(&self) -> usize {
         let cursor = unsafe { Address::from_usize(self.cursor.load(Ordering::Relaxed)) };
-        conversions::bytes_to_pages_up(self.limit - cursor) + self.metadata.reserved_pages()
+        let data_pages = conversions::bytes_to_pages_up(self.limit - cursor);
+        let meta_pages = self.metadata.calculate_reserved_pages(data_pages);
+        data_pages + meta_pages
     }
 
     fn acquire(&self, _tls: VMThread, pages: usize) -> Address {

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -127,8 +127,9 @@ impl<VM: VMBinding> Space<VM> for MallocSpace<VM> {
     }
 
     fn reserved_pages(&self) -> usize {
-        conversions::bytes_to_pages_up(self.active_bytes.load(Ordering::SeqCst))
-            + self.metadata.reserved_pages()
+        let data_pages = conversions::bytes_to_pages_up(self.active_bytes.load(Ordering::SeqCst));
+        let meta_pages = self.metadata.calculate_reserved_pages(data_pages);
+        data_pages + meta_pages
     }
 
     fn verify_side_metadata_sanity(&self, side_metadata_sanity_checker: &mut SideMetadataSanity) {

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -377,7 +377,9 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
     }
 
     fn reserved_pages(&self) -> usize {
-        self.get_page_resource().reserved_pages() + self.common().metadata.reserved_pages()
+        let data_pages = self.get_page_resource().reserved_pages();
+        let meta_pages = self.common().metadata.calculate_reserved_pages(data_pages);
+        data_pages + meta_pages
     }
 
     fn get_name(&self) -> &'static str {

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -276,13 +276,18 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                     // adding a space lock here.
                     let bytes = conversions::pages_to_bytes(res.pages);
                     self.grow_space(res.start, bytes, res.new_chunk);
-                    // Mmap the pages and handle error. In case of any error,
+                    // Mmap the pages and the side metadata, and handle error. In case of any error,
                     // we will either call back to the VM for OOM, or simply panic.
-                    if let Err(mmap_error) = self.common().mmapper.ensure_mapped(
-                        res.start,
-                        res.pages,
-                        &self.common().metadata,
-                    ) {
+                    if let Err(mmap_error) = self
+                        .common()
+                        .mmapper
+                        .ensure_mapped(res.start, res.pages)
+                        .and(
+                            self.common()
+                                .metadata
+                                .try_map_metadata_space(res.start, bytes),
+                        )
+                    {
                         memory::handle_mmap_error::<VM>(mmap_error, tls);
                     }
 

--- a/src/util/heap/layout/byte_map_mmapper.rs
+++ b/src/util/heap/layout/byte_map_mmapper.rs
@@ -68,26 +68,26 @@ impl Mmapper for ByteMapMmapper {
         Ok(())
     }
 
-    fn quarantine_address_range(&self, start: Address, pages: usize) -> Result<()> {
-        let start_chunk = Self::address_to_mmap_chunks_down(start);
-        let end_chunk = Self::address_to_mmap_chunks_up(start + pages_to_bytes(pages));
-        trace!(
-            "Calling ensure_mapped with start={:?} and {} pages, {}-{}",
-            start,
-            pages,
-            Self::mmap_chunks_to_address(start_chunk),
-            Self::mmap_chunks_to_address(end_chunk)
-        );
+    fn quarantine_address_range(&self, _start: Address, _pages: usize) -> Result<()> {
+        // let start_chunk = Self::address_to_mmap_chunks_down(start);
+        // let end_chunk = Self::address_to_mmap_chunks_up(start + pages_to_bytes(pages));
+        // trace!(
+        //     "Calling ensure_mapped with start={:?} and {} pages, {}-{}",
+        //     start,
+        //     pages,
+        //     Self::mmap_chunks_to_address(start_chunk),
+        //     Self::mmap_chunks_to_address(end_chunk)
+        // );
 
-        for chunk in start_chunk..end_chunk {
-            if self.mapped[chunk].load(Ordering::Relaxed) == MapState::Mapped {
-                continue;
-            }
+        // for chunk in start_chunk..end_chunk {
+        //     if self.mapped[chunk].load(Ordering::Relaxed) == MapState::Mapped {
+        //         continue;
+        //     }
 
-            let mmap_start = Self::mmap_chunks_to_address(chunk);
-            let _guard = self.lock.lock().unwrap();
-            MapState::transition_to_quarantined(&self.mapped[chunk], mmap_start).unwrap();
-        }
+        //     let mmap_start = Self::mmap_chunks_to_address(chunk);
+        //     let _guard = self.lock.lock().unwrap();
+        //     MapState::transition_to_quarantined(&self.mapped[chunk], mmap_start).unwrap();
+        // }
 
         Ok(())
     }

--- a/src/util/heap/layout/byte_map_mmapper.rs
+++ b/src/util/heap/layout/byte_map_mmapper.rs
@@ -68,26 +68,26 @@ impl Mmapper for ByteMapMmapper {
         Ok(())
     }
 
-    fn quarantine_address_range(&self, _start: Address, _pages: usize) -> Result<()> {
-        // let start_chunk = Self::address_to_mmap_chunks_down(start);
-        // let end_chunk = Self::address_to_mmap_chunks_up(start + pages_to_bytes(pages));
-        // trace!(
-        //     "Calling ensure_mapped with start={:?} and {} pages, {}-{}",
-        //     start,
-        //     pages,
-        //     Self::mmap_chunks_to_address(start_chunk),
-        //     Self::mmap_chunks_to_address(end_chunk)
-        // );
+    fn quarantine_address_range(&self, start: Address, pages: usize) -> Result<()> {
+        let start_chunk = Self::address_to_mmap_chunks_down(start);
+        let end_chunk = Self::address_to_mmap_chunks_up(start + pages_to_bytes(pages));
+        trace!(
+            "Calling ensure_mapped with start={:?} and {} pages, {}-{}",
+            start,
+            pages,
+            Self::mmap_chunks_to_address(start_chunk),
+            Self::mmap_chunks_to_address(end_chunk)
+        );
 
-        // for chunk in start_chunk..end_chunk {
-        //     if self.mapped[chunk].load(Ordering::Relaxed) == MapState::Mapped {
-        //         continue;
-        //     }
+        for chunk in start_chunk..end_chunk {
+            if self.mapped[chunk].load(Ordering::Relaxed) == MapState::Mapped {
+                continue;
+            }
 
-        //     let mmap_start = Self::mmap_chunks_to_address(chunk);
-        //     let _guard = self.lock.lock().unwrap();
-        //     MapState::transition_to_quarantined(&self.mapped[chunk], mmap_start).unwrap();
-        // }
+            let mmap_start = Self::mmap_chunks_to_address(chunk);
+            let _guard = self.lock.lock().unwrap();
+            MapState::transition_to_quarantined(&self.mapped[chunk], mmap_start).unwrap();
+        }
 
         Ok(())
     }

--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -124,6 +124,9 @@ impl Mmapper for FragmentedMapper {
                         let mmap_start = Self::chunk_index_to_address(base, chunk);
                         crate::util::memory::munprotect(mmap_start, MMAP_CHUNK_BYTES).unwrap();
                     }
+                    MapState::Quarantined => {
+                        unimplemented!()
+                    }
                     // might have become MAPPED here
                     MapState::Mapped => {}
                 }

--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -11,12 +11,16 @@ use std::sync::Mutex;
 
 const MMAP_NUM_CHUNKS: usize = 1 << (33 - LOG_MMAP_CHUNK_BYTES);
 
-const LOG_MAPPABLE_BYTES: usize = 36; // 128GB - physical memory larger than this is uncommon
-                                      /*
-                                       * Size of a slab.  The value 10 gives a slab size of 1GB, with 1024
-                                       * chunks per slab, ie a 1k slab map.  In a 64-bit address space, this
-                                       * will require 1M of slab maps.
-                                       */
+// 36 = 128G - physical memory larger than this is uncommon
+// 40 = 2T. Increased to 2T. Though we probably won't use this much memory, we allow quarantine memory range,
+// and that is usually used to quarantine a large amount of memory.
+const LOG_MAPPABLE_BYTES: usize = 40;
+
+/*
+ * Size of a slab.  The value 10 gives a slab size of 1GB, with 1024
+ * chunks per slab, ie a 1k slab map.  In a 64-bit address space, this
+ * will require 1M of slab maps.
+ */
 const LOG_MMAP_CHUNKS_PER_SLAB: usize = 8;
 const LOG_MMAP_SLAB_BYTES: usize = LOG_MMAP_CHUNKS_PER_SLAB + LOG_MMAP_CHUNK_BYTES;
 const MMAP_SLAB_EXTENT: usize = 1 << LOG_MMAP_SLAB_BYTES;
@@ -76,6 +80,38 @@ impl Mmapper for FragmentedMapper {
         }
     }
 
+    fn quarantine_address_range(&self, mut start: Address, pages: usize) -> Result<()> {
+        let end = start + conversions::pages_to_bytes(pages);
+        // Iterate over the slabs covered
+        while start < end {
+            let base = Self::slab_align_down(start);
+            let high = if end > Self::slab_limit(start) && !Self::slab_limit(start).is_zero() {
+                Self::slab_limit(start)
+            } else {
+                end
+            };
+
+            let slab = Self::slab_align_down(start);
+            let start_chunk = Self::chunk_index(slab, start);
+            let end_chunk = Self::chunk_index(slab, conversions::mmap_chunk_align_up(high));
+
+            let mapped = self.get_or_allocate_slab_table(start);
+
+            /* Iterate over the chunks within the slab */
+            for (chunk, entry) in mapped.iter().enumerate().take(end_chunk).skip(start_chunk) {
+                if matches!(entry.load(Ordering::Relaxed), MapState::Quarantined) {
+                    continue;
+                }
+
+                let mmap_start = Self::chunk_index_to_address(base, chunk);
+                let _guard = self.lock.lock().unwrap();
+                MapState::transition_to_quarantined(entry, mmap_start).unwrap();
+            }
+            start = high;
+        }
+        Ok(())
+    }
+
     fn ensure_mapped(&self, mut start: Address, pages: usize) -> Result<()> {
         let end = start + conversions::pages_to_bytes(pages);
         // Iterate over the slabs covered
@@ -101,7 +137,10 @@ impl Mmapper for FragmentedMapper {
 
                 let mmap_start = Self::chunk_index_to_address(base, chunk);
                 let _guard = self.lock.lock().unwrap();
-                MapState::transition_to_mapped(entry, mmap_start).unwrap();
+                let res = MapState::transition_to_mapped(entry, mmap_start);
+                if res.is_err() {
+                    return res;
+                }
             }
             start = high;
         }

--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -1,4 +1,5 @@
 use super::Mmapper;
+use super::mmapper::MapState;
 use crate::util::heap::layout::vm_layout_constants::*;
 use crate::util::Address;
 use crate::util::{conversions, side_metadata::SideMetadata};
@@ -7,14 +8,6 @@ use std::fmt;
 use std::io::Result;
 use std::mem::transmute;
 use std::sync::Mutex;
-
-#[repr(u8)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-enum MapState {
-    Unmapped,
-    Mapped,
-    Protected,
-}
 
 const MMAP_NUM_CHUNKS: usize = 1 << (33 - LOG_MMAP_CHUNK_BYTES);
 

--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -14,7 +14,7 @@ const MMAP_NUM_CHUNKS: usize = 1 << (33 - LOG_MMAP_CHUNK_BYTES);
 // 36 = 128G - physical memory larger than this is uncommon
 // 40 = 2T. Increased to 2T. Though we probably won't use this much memory, we allow quarantine memory range,
 // and that is usually used to quarantine a large amount of memory.
-const LOG_MAPPABLE_BYTES: usize = 40;
+const LOG_MAPPABLE_BYTES: usize = 36;
 
 /*
  * Size of a slab.  The value 10 gives a slab size of 1GB, with 1024
@@ -80,35 +80,35 @@ impl Mmapper for FragmentedMapper {
         }
     }
 
-    fn quarantine_address_range(&self, mut start: Address, pages: usize) -> Result<()> {
-        let end = start + conversions::pages_to_bytes(pages);
-        // Iterate over the slabs covered
-        while start < end {
-            let base = Self::slab_align_down(start);
-            let high = if end > Self::slab_limit(start) && !Self::slab_limit(start).is_zero() {
-                Self::slab_limit(start)
-            } else {
-                end
-            };
+    fn quarantine_address_range(&self, mut _start: Address, _pages: usize) -> Result<()> {
+        // let end = start + conversions::pages_to_bytes(pages);
+        // // Iterate over the slabs covered
+        // while start < end {
+        //     let base = Self::slab_align_down(start);
+        //     let high = if end > Self::slab_limit(start) && !Self::slab_limit(start).is_zero() {
+        //         Self::slab_limit(start)
+        //     } else {
+        //         end
+        //     };
 
-            let slab = Self::slab_align_down(start);
-            let start_chunk = Self::chunk_index(slab, start);
-            let end_chunk = Self::chunk_index(slab, conversions::mmap_chunk_align_up(high));
+        //     let slab = Self::slab_align_down(start);
+        //     let start_chunk = Self::chunk_index(slab, start);
+        //     let end_chunk = Self::chunk_index(slab, conversions::mmap_chunk_align_up(high));
 
-            let mapped = self.get_or_allocate_slab_table(start);
+        //     let mapped = self.get_or_allocate_slab_table(start);
 
-            /* Iterate over the chunks within the slab */
-            for (chunk, entry) in mapped.iter().enumerate().take(end_chunk).skip(start_chunk) {
-                if matches!(entry.load(Ordering::Relaxed), MapState::Quarantined) {
-                    continue;
-                }
+        //     /* Iterate over the chunks within the slab */
+        //     for (chunk, entry) in mapped.iter().enumerate().take(end_chunk).skip(start_chunk) {
+        //         if matches!(entry.load(Ordering::Relaxed), MapState::Quarantined) {
+        //             continue;
+        //         }
 
-                let mmap_start = Self::chunk_index_to_address(base, chunk);
-                let _guard = self.lock.lock().unwrap();
-                MapState::transition_to_quarantined(entry, mmap_start).unwrap();
-            }
-            start = high;
-        }
+        //         let mmap_start = Self::chunk_index_to_address(base, chunk);
+        //         let _guard = self.lock.lock().unwrap();
+        //         MapState::transition_to_quarantined(entry, mmap_start).unwrap();
+        //     }
+        //     start = high;
+        // }
         Ok(())
     }
 

--- a/src/util/heap/layout/mmapper.rs
+++ b/src/util/heap/layout/mmapper.rs
@@ -64,6 +64,7 @@ pub trait Mmapper {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub(super) enum MapState {
     Unmapped,
+    Quarantined,
     Mapped,
     Protected,
 }

--- a/src/util/heap/layout/mmapper.rs
+++ b/src/util/heap/layout/mmapper.rs
@@ -59,3 +59,11 @@ pub trait Mmapper {
      */
     fn protect(&self, start: Address, pages: usize);
 }
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub(super) enum MapState {
+    Unmapped,
+    Mapped,
+    Protected,
+}

--- a/src/util/heap/layout/mmapper.rs
+++ b/src/util/heap/layout/mmapper.rs
@@ -4,57 +4,58 @@ use crate::util::Address;
 use atomic::{Atomic, Ordering};
 use std::io::Result;
 
+/// Generic mmap and protection functionality
 pub trait Mmapper {
-    /****************************************************************************
-     * Generic mmap and protection functionality
-     */
-
-    /**
-     * Given an address array describing the regions of virtual memory to be used
-     * by MMTk, demand zero map all of them if they are not already mapped.
-     *
-     * @param spaceMap An address array containing a pairs of start and end
-     * addresses for each of the regions to be mappe3d
-     */
+    /// Given an address array describing the regions of virtual memory to be used
+    /// by MMTk, demand zero map all of them if they are not already mapped.
+    ///
+    /// Arguments:
+    /// * `spaceMap`: An address array containing a pairs of start and end
+    ///   addresses for each of the regions to be mapped
     fn eagerly_mmap_all_spaces(&self, space_map: &[Address]);
 
-    /**
-     * Mark a number of pages as mapped, without making any
-     * request to the operating system.  Used to mark pages
-     * that the VM has already mapped.
-     * @param start Address of the first page to be mapped
-     * @param bytes Number of bytes to ensure mapped
-     */
+    /// Mark a number of pages as mapped, without making any
+    /// request to the operating system.  Used to mark pages
+    /// that the VM has already mapped.
+    ///
+    /// Arguments:
+    /// * `start`: Address of the first page to be mapped
+    /// * `bytes`: Number of bytes to ensure mapped
     fn mark_as_mapped(&self, start: Address, bytes: usize);
 
+    /// Quarantine/reserve address range. We mmap from the OS with no reserve and with PROT_NONE,
+    /// which should be little overhead. This ensures that we can reserve certain address range that
+    /// we can use if needed. Quarantined memory needs to be mapped before it can be used.
+    ///
+    /// Arguments:
+    /// * `start`: Address of the first page to be quarantined
+    /// * `bytes`: Number of bytes to quarantine from the start
     fn quarantine_address_range(&self, start: Address, pages: usize) -> Result<()>;
 
-    /**
-     * Ensure that a range of pages is mmapped (or equivalent).  If the
-     * pages are not yet mapped, demand-zero map them. Note that mapping
-     * occurs at chunk granularity, not page granularity.<p>
-     *
-     * NOTE: There is a monotonicity assumption so that only updates require lock
-     * acquisition.
-     * TODO: Fix the above to support unmapping.
-     *
-     * @param start The start of the range to be mapped.
-     * @param pages The size of the range to be mapped, in pages
-     */
+    /// Ensure that a range of pages is mmapped (or equivalent).  If the
+    /// pages are not yet mapped, demand-zero map them. Note that mapping
+    /// occurs at chunk granularity, not page granularity.<p>
+    ///
+    /// Argumetns:
+    /// `start`: The start of the range to be mapped.
+    /// `pages`: The size of the range to be mapped, in pages
+    // NOTE: There is a monotonicity assumption so that only updates require lock
+    // acquisition.
+    // TODO: Fix the above to support unmapping.
     fn ensure_mapped(&self, start: Address, pages: usize) -> Result<()>;
 
-    /**
-     * Is the page pointed to by this address mapped ?
-     * @param addr Address in question
-     * @return {@code true} if the page at the given address is mapped.
-     */
+    /// Is the page pointed to by this address mapped? Returns true if
+    /// the page at the given address is mapped.
+    ///
+    /// Arguments:
+    /// * `addr`: Address in question
     fn is_mapped_address(&self, addr: Address) -> bool;
 
-    /**
-     * Mark a number of pages as inaccessible.
-     * @param start Address of the first page to be protected
-     * @param pages Number of pages to be protected
-     */
+    /// Mark a number of pages as inaccessible.
+    ///
+    /// Arguments:
+    /// * `start`: Address of the first page to be protected
+    /// * `pages`: Number of pages to be protected
     fn protect(&self, start: Address, pages: usize);
 }
 

--- a/src/util/heap/layout/mmapper.rs
+++ b/src/util/heap/layout/mmapper.rs
@@ -1,4 +1,3 @@
-use super::vm_layout_constants::BYTES_IN_CHUNK;
 use crate::util::heap::layout::vm_layout_constants::*;
 use crate::util::memory::*;
 use crate::util::{side_metadata::SideMetadata, Address};
@@ -41,12 +40,6 @@ pub trait Mmapper {
      * @param pages The size of the range to be mapped, in pages
      */
     fn ensure_mapped(&self, start: Address, pages: usize, metadata: &SideMetadata) -> Result<()>;
-
-    /// Map metadata memory for a given chunk
-    #[allow(clippy::result_unit_err)]
-    fn map_metadata(&self, chunk: Address, metadata: &SideMetadata) -> Result<()> {
-        metadata.try_map_metadata_space(chunk, BYTES_IN_CHUNK)
-    }
 
     /**
      * Is the page pointed to by this address mapped ?

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -89,8 +89,18 @@ impl SideMetadata {
         &self.context.local
     }
 
-    pub fn reserved_pages(&self) -> usize {
-        self.accounting.get_reserved_pages()
+    // pub fn reserved_pages(&self) -> usize {
+    //     self.accounting.get_reserved_pages()
+    // }
+    pub fn calculate_reserved_pages(&self, data_pages: usize) -> usize {
+        let mut total = 0;
+        for spec in self.context.global.iter() {
+            total += data_pages >> (spec.log_min_obj_size + 3 - spec.log_num_of_bits);
+        }
+        for spec in self.context.local.iter() {
+            total += data_pages >> (spec.log_min_obj_size + 3 - spec.log_num_of_bits);
+        }
+        total
     }
 
     pub fn reset(&self) {

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -75,9 +75,7 @@ pub struct SideMetadata {
 
 impl SideMetadata {
     pub fn new(context: SideMetadataContext) -> SideMetadata {
-        Self {
-            context,
-        }
+        Self { context }
     }
 
     pub fn get_context(&self) -> &SideMetadataContext {
@@ -107,9 +105,7 @@ impl SideMetadata {
         total
     }
 
-    pub fn reset(&self) {
-
-    }
+    pub fn reset(&self) {}
 
     // ** NOTE: **
     //  Regardless of the number of bits in a metadata unit, we always represent its content as a word.
@@ -724,7 +720,7 @@ mod tests {
             context: SideMetadataContext {
                 global: vec![spec],
                 local: vec![],
-            }
+            },
         };
         assert_eq!(side_metadata.calculate_reserved_pages(0), 0);
         assert_eq!(side_metadata.calculate_reserved_pages(63), 1);
@@ -753,7 +749,7 @@ mod tests {
             context: SideMetadataContext {
                 global: vec![gspec],
                 local: vec![lspec],
-            }
+            },
         };
         assert_eq!(side_metadata.calculate_reserved_pages(1024), 16 + 1);
     }

--- a/src/util/side_metadata/global.rs
+++ b/src/util/side_metadata/global.rs
@@ -93,6 +93,10 @@ impl SideMetadata {
         self.accounting.get_reserved_pages()
     }
 
+    pub fn reset(&self) {
+        self.accounting.reset();
+    }
+
     // ** NOTE: **
     //  Regardless of the number of bits in a metadata unit, we always represent its content as a word.
 

--- a/src/util/side_metadata/helpers.rs
+++ b/src/util/side_metadata/helpers.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::heap::layout::Mmapper;
-use crate::util::memory;
 use crate::util::Address;
 use crate::util::{
     constants::{BITS_IN_WORD, BYTES_IN_PAGE, LOG_BITS_IN_BYTE},
@@ -33,7 +32,9 @@ pub(crate) fn address_to_contiguous_meta_address(
 }
 
 /// Unmaps the specified metadata range, or panics.
+#[cfg(test)]
 pub(super) fn ensure_munmap_metadata(start: Address, size: usize) {
+    use crate::util::memory;
     trace!("ensure_munmap_metadata({}, 0x{:x})", start, size);
 
     assert!(memory::munmap(start, size).is_ok())
@@ -41,6 +42,7 @@ pub(super) fn ensure_munmap_metadata(start: Address, size: usize) {
 
 /// Unmaps a metadata space (`spec`) for the specified data address range (`start` and `size`)
 /// Returns the size in bytes that get munmapped.
+#[cfg(test)]
 pub(super) fn ensure_munmap_contiguos_metadata_space(
     start: Address,
     size: usize,
@@ -75,43 +77,15 @@ pub(super) fn try_mmap_contiguous_metadata_space(
     let mmap_size =
         address_to_meta_address(*spec, start + size).align_up(BYTES_IN_PAGE) - mmap_start;
     if mmap_size > 0 {
-        // FIXME - This assumes that we never mmap a metadata page twice.
-        // While this never happens in our current use-cases where the minimum data mmap size is a chunk and the metadata ratio is larger than 1/64, it could happen if (min_data_mmap_size * metadata_ratio) is smaller than a page.
-        // E.g. the current implementation detects such a case as an overlap and returns false.
         if !no_reserve {
             MMAPPER.ensure_mapped(mmap_start, mmap_size >> LOG_BYTES_IN_PAGE)
-            // try_mmap_metadata(mmap_start, mmap_size)
         } else {
             MMAPPER.quarantine_address_range(mmap_start, mmap_size >> LOG_BYTES_IN_PAGE)
-            // try_mmap_metadata_address_range(mmap_start, mmap_size)
         }
         .map(|_| mmap_size)
     } else {
         Ok(0)
     }
-}
-
-/// Tries to map the specified metadata address range (`start` and `size`), without reserving swap-space for it.
-pub(super) fn try_mmap_metadata_address_range(start: Address, size: usize) -> Result<()> {
-    let res = memory::mmap_noreserve(start, size);
-    trace!(
-        "try_mmap_metadata_address_range({}, 0x{:x}) -> {:#?}",
-        start,
-        size,
-        res
-    );
-    res
-}
-
-/// Tries to map the specified metadata space (`start` and `size`), including reservation of swap-space/physical memory.
-/// This function should only be called if we have called try_mmap_metadata_address_range() first.
-pub(super) fn try_mmap_metadata(start: Address, size: usize) -> Result<()> {
-    debug_assert!(size > 0 && size % BYTES_IN_PAGE == 0);
-
-    // It is safe to call dzmmap here as we have reserved the address range.
-    let res = unsafe { memory::dzmmap(start, size) };
-    trace!("try_mmap_metadata({}, 0x{:x}) -> {:#?}", start, size, res);
-    res
 }
 
 /// Performs the translation of data address (`data_addr`) to metadata address for the specified metadata (`metadata_spec`).
@@ -143,7 +117,7 @@ pub(crate) fn address_to_meta_address(
     res
 }
 
-const fn addr_rshift(metadata_spec: SideMetadataSpec) -> i32 {
+pub(super) const fn addr_rshift(metadata_spec: &SideMetadataSpec) -> i32 {
     ((LOG_BITS_IN_BYTE as usize) + metadata_spec.log_min_obj_size - metadata_spec.log_num_of_bits)
         as i32
 }
@@ -151,7 +125,7 @@ const fn addr_rshift(metadata_spec: SideMetadataSpec) -> i32 {
 #[allow(dead_code)]
 #[inline(always)]
 pub(crate) const fn metadata_address_range_size(metadata_spec: SideMetadataSpec) -> usize {
-    1usize << (LOG_ADDRESS_SPACE - addr_rshift(metadata_spec) as usize)
+    1usize << (LOG_ADDRESS_SPACE - addr_rshift(&metadata_spec) as usize)
 }
 
 #[inline(always)]

--- a/src/util/side_metadata/helpers_32.rs
+++ b/src/util/side_metadata/helpers_32.rs
@@ -5,13 +5,12 @@ use crate::util::{
 };
 use std::io::Result;
 
-use super::{
-    SideMetadataSpec, CHUNK_MASK,
-    LOCAL_SIDE_METADATA_BASE_ADDRESS, LOCAL_SIDE_METADATA_PER_CHUNK,
-    LOG_LOCAL_SIDE_METADATA_WORST_CASE_RATIO,
-};
 #[cfg(test)]
 use super::ensure_munmap_metadata;
+use super::{
+    SideMetadataSpec, CHUNK_MASK, LOCAL_SIDE_METADATA_BASE_ADDRESS, LOCAL_SIDE_METADATA_PER_CHUNK,
+    LOG_LOCAL_SIDE_METADATA_WORST_CASE_RATIO,
+};
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::heap::layout::Mmapper;
 use crate::MMAPPER;
@@ -45,8 +44,8 @@ pub(super) fn ensure_munmap_chunked_metadata_space(
     size: usize,
     spec: &SideMetadataSpec,
 ) -> usize {
-    use crate::util::constants::BYTES_IN_PAGE;
     use super::address_to_meta_address;
+    use crate::util::constants::BYTES_IN_PAGE;
     let meta_start = address_to_meta_address(*spec, start).align_down(BYTES_IN_PAGE);
     // per chunk policy-specific metadata for 32-bits targets
     let chunk_num = ((start + size - 1usize).align_down(BYTES_IN_CHUNK)

--- a/src/util/side_metadata/helpers_32.rs
+++ b/src/util/side_metadata/helpers_32.rs
@@ -1,15 +1,17 @@
 use crate::util::{
-    constants::{self, BYTES_IN_PAGE, LOG_BITS_IN_BYTE},
+    constants::{self, LOG_BITS_IN_BYTE},
     heap::layout::vm_layout_constants::{BYTES_IN_CHUNK, LOG_BYTES_IN_CHUNK},
     memory, Address,
 };
 use std::io::Result;
 
 use super::{
-    address_to_meta_address, ensure_munmap_metadata, SideMetadataSpec, CHUNK_MASK,
+    SideMetadataSpec, CHUNK_MASK,
     LOCAL_SIDE_METADATA_BASE_ADDRESS, LOCAL_SIDE_METADATA_PER_CHUNK,
     LOG_LOCAL_SIDE_METADATA_WORST_CASE_RATIO,
 };
+#[cfg(test)]
+use super::ensure_munmap_metadata;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::heap::layout::Mmapper;
 use crate::MMAPPER;
@@ -37,11 +39,14 @@ pub(super) fn address_to_chunked_meta_address(
 }
 
 /// Returns the size in bytes that gets munmapped.
+#[cfg(test)]
 pub(super) fn ensure_munmap_chunked_metadata_space(
     start: Address,
     size: usize,
     spec: &SideMetadataSpec,
 ) -> usize {
+    use crate::util::constants::BYTES_IN_PAGE;
+    use super::address_to_meta_address;
     let meta_start = address_to_meta_address(*spec, start).align_down(BYTES_IN_PAGE);
     // per chunk policy-specific metadata for 32-bits targets
     let chunk_num = ((start + size - 1usize).align_down(BYTES_IN_CHUNK)
@@ -94,6 +99,7 @@ pub(crate) const fn meta_bytes_per_chunk(log_min_obj_size: usize, log_num_of_bit
 }
 
 /// Unmaps the metadata for a single chunk starting at `start`
+#[cfg(test)]
 pub fn ensure_munmap_metadata_chunk(start: Address, local_per_chunk: usize) {
     if local_per_chunk != 0 {
         let policy_meta_start = address_to_meta_chunk_addr(start);
@@ -127,8 +133,13 @@ pub fn try_map_per_chunk_metadata_space(
                 };
                 // Failure: munmap what has been mmapped before
                 while munmap_start < aligned_start {
-                    ensure_munmap_metadata_chunk(munmap_start, local_per_chunk);
+                    // Commented out the following as we do not have unmap in Mmapper.
+                    // And we cannot guarantee that the memory to be munmapped does not include any useful data.
+                    // However, as we cannot map the address we need for sidemetadata, it is a fatal error
+                    // anyway, we do not need to munmap or anything as we cannot recover from it.
+                    // ensure_munmap_metadata_chunk(munmap_start, local_per_chunk);
                     munmap_start += LOCAL_SIDE_METADATA_PER_CHUNK;
+                    panic!("We have failed mmap");
                 }
             }
             trace!(
@@ -169,9 +180,7 @@ pub fn try_mmap_metadata_chunk(
     if !no_reserve {
         // We have reserved the memory
         MMAPPER.ensure_mapped(policy_meta_start, local_per_chunk >> LOG_BYTES_IN_PAGE)
-        // unsafe { memory::dzmmap(policy_meta_start, local_per_chunk) }
     } else {
         MMAPPER.quarantine_address_range(policy_meta_start, local_per_chunk >> LOG_BYTES_IN_PAGE)
-        // memory::mmap_noreserve(policy_meta_start, local_per_chunk)
     }
 }

--- a/src/util/side_metadata/helpers_32.rs
+++ b/src/util/side_metadata/helpers_32.rs
@@ -10,6 +10,9 @@ use super::{
     LOCAL_SIDE_METADATA_BASE_ADDRESS, LOCAL_SIDE_METADATA_PER_CHUNK,
     LOG_LOCAL_SIDE_METADATA_WORST_CASE_RATIO,
 };
+use crate::util::constants::LOG_BYTES_IN_PAGE;
+use crate::util::heap::layout::Mmapper;
+use crate::MMAPPER;
 
 #[inline(always)]
 pub(super) fn address_to_chunked_meta_address(
@@ -165,8 +168,10 @@ pub fn try_mmap_metadata_chunk(
     let policy_meta_start = address_to_meta_chunk_addr(start);
     if !no_reserve {
         // We have reserved the memory
-        unsafe { memory::dzmmap(policy_meta_start, local_per_chunk) }
+        MMAPPER.ensure_mapped(policy_meta_start, local_per_chunk >> LOG_BYTES_IN_PAGE)
+        // unsafe { memory::dzmmap(policy_meta_start, local_per_chunk) }
     } else {
-        memory::mmap_noreserve(policy_meta_start, local_per_chunk)
+        MMAPPER.quarantine_address_range(policy_meta_start, local_per_chunk >> LOG_BYTES_IN_PAGE)
+        // memory::mmap_noreserve(policy_meta_start, local_per_chunk)
     }
 }


### PR DESCRIPTION
This PR refactors the mmapper and uses mmapper to map memory for side metadata. This fixes the bug that our side metadata implementation may overwrite the its own memory mapping and cause data loss.

This PR:
* Moves the memory mapping of side metadata from within mmapper to `Space`. `Space` manages mapping its data memory and the side metadata memory.
* Changes mmapping for side metadata to use mmapper.
* Extracts `MapState`, and use it for both fragmented mmapper and byte map mmapper. `MapState` takes care of transition between states.
* Adds `MapState::Quarantined` and adds `quarantine_address_range()` to mmapper.
* Unmap is not supported. All unmap code in side metadata is either only used for test or is replaced with a panic (we should not unmap for those cases). 
* Increases `LOG_MAPPABLE_BYTES` in fragmented mapper from 36 (128G) to 40 (2T).
* No longer uses `PageAccounting` for side metadata. It was inaccurate to account side metadata at page granularity. Previously we mmapped side metadata at mmap chunk granularity (4M) and account side metadata at page granularity (4K), if the compression ratio is smaller than 1:1K, we may overcount our usage. Now we mmapped at page granularity, the overcount is more significant. Now we calculate side metadata usage based on the page usage of the data memory and the compression ratio.