### PR TITLE
Fix Gencopy full heap GC

### DIFF
--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -173,6 +173,12 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
             + self.common.get_pages_used()
     }
 
+    /// Return the number of pages avilable for allocation. Assuming all future allocations goes to nursery.
+    fn get_pages_avail(&self) -> usize {
+        // super.get_pages_avail() / 2 to reserve pages for copying
+        (self.get_total_pages() - self.get_pages_reserved()) >> 1
+    }
+
     fn base(&self) -> &BasePlan<VM> {
         &self.common.base
     }

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -158,7 +158,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         }
 
         self.next_gc_full_heap.store(
-            self.get_pages_avail() < self.base().options.min_nursery,
+            self.get_pages_avail() < conversions::bytes_to_pages_up(self.base().options.min_nursery),
             Ordering::SeqCst,
         );
     }

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -158,7 +158,8 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         }
 
         self.next_gc_full_heap.store(
-            self.get_pages_avail() < conversions::bytes_to_pages_up(self.base().options.min_nursery),
+            self.get_pages_avail()
+                < conversions::bytes_to_pages_up(self.base().options.min_nursery),
             Ordering::SeqCst,
         );
     }

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -185,7 +185,8 @@ pub trait Plan: 'static + Sync + Downcast {
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector>;
 
-    fn in_nursery(&self) -> bool {
+    /// Is current GC only collecting objects allocated since last GC?
+    fn is_current_gc_nursery(&self) -> bool {
         false
     }
 

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -499,7 +499,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ProcessModBuf<E> {
                 compare_exchange_atomic(self.meta, obj.to_address(), 0b0, 0b1);
             }
         }
-        if mmtk.plan.in_nursery() {
+        if mmtk.plan.is_current_gc_nursery() {
             if !self.modbuf.is_empty() {
                 let mut modbuf = vec![];
                 ::std::mem::swap(&mut modbuf, &mut self.modbuf);

--- a/src/util/finalizable_processor.rs
+++ b/src/util/finalizable_processor.rs
@@ -110,7 +110,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for Finalization<E> {
 
         let mut w = E::new(vec![], false, mmtk);
         w.set_worker(worker);
-        finalizable_processor.scan(worker.tls, &mut w, mmtk.plan.in_nursery());
+        finalizable_processor.scan(worker.tls, &mut w, mmtk.plan.is_current_gc_nursery());
         debug!(
             "Finished finalization, {} objects in candidates, {} objects ready to finalize",
             finalizable_processor.candidates.len(),
@@ -132,7 +132,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ForwardFinalization<E> {
         trace!("Forward finalization");
         let mut finalizable_processor = mmtk.finalizable_processor.lock().unwrap();
         let mut w = E::new(vec![], false, mmtk);
-        finalizable_processor.forward(&mut w, mmtk.plan.in_nursery());
+        finalizable_processor.forward(&mut w, mmtk.plan.is_current_gc_nursery());
         trace!("Finished forwarding finlizable");
     }
 }


### PR DESCRIPTION
This PR adds conditions to properly trigger full heap GC for GenCopy. Those conditions were missing when we first ported GenCopy from Java MMTk. This PR addresses https://github.com/mmtk/mmtk-core/issues/337.

In our current code base, there is only one condition to trigger a full heap GC: at the start of a GC, the number of reserved pages is more than total pages. Otherwise, we only do nursery GCs. However, this is incorrect, and it could result in a case where we  report OOM without attempting full heap GCs. For example, if the total pages are 5000, our tospace has 2499 pages. We would never do a nursery GC (2499x2 < 5000). But when we try to allocate more than 2 pages for nursery, the allocation failed (2499x2 +2 >= 5000). So a GC is triggered and the newly reserved pages will be cleared (reserved pages back to 2499x2), and no full heap GC will be triggered.

This PR ports back more conditions from Java MMTk to trigger full heap GCs
* Adds `next_gc_full_heap` so in some situations we may force the next GC to be full heap.
* Renames `in_nursery` and `Plan.in_nursery()` to `gc_full_heap` and `Plan.is_current_gc_full_heap()` to be consistent with Java MMTk.
* Adds conditions in `collection_required()` and `request_full_heap_collection()` to trigger full heap GCs.
* `get_pages_avail()` for generational plans should be 'half of (total - reserved)'.
* Adds `max_nursery`, `min_nursery` and `full_heap_system_gc` to command line options.
* Adds comments for command line options. Removes `verbose` and `vm_space` from command line options which are no longer used.