### PR TITLE
Support measuring process-wide perf events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ atomic-traits = "0.2.0"
 atomic = "0.4.6"
 spin = "0.5.2"
 env_logger = "0.8.2"
-pfm = {version = "0.0.7", optional = true}
+pfm = {version = "0.0.7", path="/home/zixianc/pfm", optional = true}
 
 [dev-dependencies]
 crossbeam = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ atomic-traits = "0.2.0"
 atomic = "0.4.6"
 spin = "0.5.2"
 env_logger = "0.8.2"
-pfm = {version = "0.0.7", path="/home/zixianc/pfm", optional = true}
+pfm = {version = "0.0.8", optional = true}
 
 [dev-dependencies]
 crossbeam = "0.7.3"

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -25,8 +25,6 @@ use crate::util::opaque_pointer::*;
 use crate::util::{Address, ObjectReference};
 use crate::vm::Collection;
 use crate::vm::VMBinding;
-use std::fs::File;
-use std::io::Read;
 use std::sync::atomic::Ordering;
 
 /// Run the main loop for the GC controller thread. This method does not return.
@@ -48,6 +46,8 @@ pub fn start_control_collector<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMWorkerThre
 pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
     #[cfg(feature = "perf_counter")]
     {
+        use std::fs::File;
+        use std::io::Read;
         let mut status = File::open("/proc/self/status").unwrap();
         let mut contents = String::new();
         status.read_to_string(&mut contents).unwrap();

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -50,7 +50,7 @@ pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
             "MMTk failed to initialize the logger. Possibly a logger has been initialized by user."
         ),
     }
-    #[cfg(feature = "perf_counter")]
+    #[cfg(all(feature = "perf_counter", target_os = "linux"))]
     {
         use std::fs::File;
         use std::io::Read;

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -44,6 +44,12 @@ pub fn start_control_collector<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMWorkerThre
 /// * `mmtk`: A reference to an MMTk instance to initialize.
 /// * `heap_size`: The heap size for the MMTk instance in bytes.
 pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
+    match crate::util::logger::try_init() {
+        Ok(_) => debug!("MMTk initialized the logger."),
+        Err(_) => debug!(
+            "MMTk failed to initialize the logger. Possibly a logger has been initialized by user."
+        ),
+    }
     #[cfg(feature = "perf_counter")]
     {
         use std::fs::File;
@@ -59,13 +65,6 @@ pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
                     warn!("Current process has {} threads, process-wide perf event measurement will only include child threads spawned from this threadas", threads);
                 }
             }
-        }
-    }
-    match crate::util::logger::try_init() {
-        Ok(_) => debug!("MMTk initialized the logger."),
-        Err(_) => debug!(
-            "MMTk failed to initialize the logger. Possibly a logger has been initialized by user."
-        ),
     }
     assert!(heap_size > 0, "Invalid heap size");
     mmtk.plan

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -65,6 +65,7 @@ pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
                     warn!("Current process has {} threads, process-wide perf event measurement will only include child threads spawned from this threadas", threads);
                 }
             }
+        }
     }
     assert!(heap_size > 0, "Invalid heap size");
     mmtk.plan

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -411,7 +411,7 @@ impl<VM: VMBinding> BasePlan<VM> {
         constraints: &'static PlanConstraints,
         global_side_metadata_specs: Vec<SideMetadataSpec>,
     ) -> BasePlan<VM> {
-        let stats = Stats::new();
+        let stats = Stats::new(options.clone());
         // Initializing the analysis manager and routines
         #[cfg(feature = "analysis")]
         let analysis_manager = AnalysisManager::new(&stats);

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -411,7 +411,7 @@ impl<VM: VMBinding> BasePlan<VM> {
         constraints: &'static PlanConstraints,
         global_side_metadata_specs: Vec<SideMetadataSpec>,
     ) -> BasePlan<VM> {
-        let stats = Stats::new(options.clone());
+        let stats = Stats::new(&options);
         // Initializing the analysis manager and routines
         #[cfg(feature = "analysis")]
         let analysis_manager = AnalysisManager::new(&stats);

--- a/src/scheduler/stat.rs
+++ b/src/scheduler/stat.rs
@@ -242,7 +242,7 @@ impl<VM: VMBinding> HasCounterSet for MMTK<VM> {
     fn counter_set(mmtk: &'static Self) -> Vec<Box<dyn WorkCounter>> {
         let mut counters: Vec<Box<dyn WorkCounter>> = vec![Box::new(WorkDuration::new())];
         #[cfg(feature = "perf_counter")]
-        for e in &mmtk.options.perf_events.events {
+        for e in &mmtk.options.work_perf_events.events {
             counters.push(box WorkPerfEvent::new(&e.0, e.1, e.2));
         }
         counters

--- a/src/scheduler/work_counter.rs
+++ b/src/scheduler/work_counter.rs
@@ -163,7 +163,7 @@ mod perf_event {
         /// -1, 0 measures all threads on CPU 0
         /// -1, -1 is invalid
         pub fn new(name: &str, pid: pid_t, cpu: c_int) -> WorkPerfEvent {
-            let mut pe = PerfEvent::new(name)
+            let mut pe = PerfEvent::new(name, false)
                 .unwrap_or_else(|_| panic!("Failed to create perf event {}", name));
             pe.open(pid, cpu)
                 .unwrap_or_else(|_| panic!("Failed to open perf event {}", name));

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -317,7 +317,7 @@ mod tests {
     fn test_str_option_default() {
         serial_test(|| {
             let options = Options::default();
-            assert_eq!(&options.perf_events, &PerfEventOptions { events: vec![] });
+            assert_eq!(&options.work_perf_events, &PerfEventOptions { events: vec![] });
         })
     }
 
@@ -326,18 +326,18 @@ mod tests {
         serial_test(|| {
             with_cleanup(
                 || {
-                    std::env::set_var("MMTK_PERF_EVENTS", "PERF_COUNT_HW_CPU_CYCLES,0,-1");
+                    std::env::set_var("MMTK_WORK_PERF_EVENTS", "PERF_COUNT_HW_CPU_CYCLES,0,-1");
 
                     let options = Options::default();
                     assert_eq!(
-                        &options.perf_events,
+                        &options.work_perf_events,
                         &PerfEventOptions {
                             events: vec![("PERF_COUNT_HW_CPU_CYCLES".into(), 0, -1)]
                         }
                     );
                 },
                 || {
-                    std::env::remove_var("MMTK_PERF_EVENTS");
+                    std::env::remove_var("MMTK_WORK_PERF_EVENTS");
                 },
             )
         })
@@ -349,14 +349,14 @@ mod tests {
             with_cleanup(
                 || {
                     // The option needs to start with "hello", otherwise it is invalid.
-                    std::env::set_var("MMTK_PERF_EVENTS", "PERF_COUNT_HW_CPU_CYCLES");
+                    std::env::set_var("MMTK_WORK_PERF_EVENTS", "PERF_COUNT_HW_CPU_CYCLES");
 
                     let options = Options::default();
                     // invalid value from env var, use default.
-                    assert_eq!(&options.perf_events, &PerfEventOptions { events: vec![] });
+                    assert_eq!(&options.work_perf_events, &PerfEventOptions { events: vec![] });
                 },
                 || {
-                    std::env::remove_var("MMTK_PERF_EVENTS");
+                    std::env::remove_var("MMTK_WORK_PERF_EVENTS");
                 },
             )
         })

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -189,7 +189,8 @@ options! {
     // Perf events to measure
     // Semicolons are used to separate events
     // Each event is in the format of event_name,pid,cpu (see man perf_event_open for what pid and cpu mean)
-    perf_events:           PerfEventOptions     [always_valid] = PerfEventOptions {events: vec![]}
+    work_perf_events:       PerfEventOptions     [always_valid] = PerfEventOptions {events: vec![]},
+    perf_events:            PerfEventOptions     [always_valid] = PerfEventOptions {events: vec![]}
 }
 
 impl Options {

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -189,7 +189,7 @@ options! {
     // Perf events to measure
     // Semicolons are used to separate events
     // Each event is in the format of event_name,pid,cpu (see man perf_event_open for what pid and cpu mean)
-    // 
+    //
     // Measuring perf events for work packets
     work_perf_events:       PerfEventOptions     [always_valid] = PerfEventOptions {events: vec![]},
     // Measuring perf events for GC and mutators

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -189,8 +189,11 @@ options! {
     // Perf events to measure
     // Semicolons are used to separate events
     // Each event is in the format of event_name,pid,cpu (see man perf_event_open for what pid and cpu mean)
+    // 
+    // Measuring perf events for work packets
     work_perf_events:       PerfEventOptions     [always_valid] = PerfEventOptions {events: vec![]},
-    perf_events:            PerfEventOptions     [always_valid] = PerfEventOptions {events: vec![]}
+    // Measuring perf events for GC and mutators
+    phase_perf_events:      PerfEventOptions     [always_valid] = PerfEventOptions {events: vec![]}
 }
 
 impl Options {

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -317,7 +317,10 @@ mod tests {
     fn test_str_option_default() {
         serial_test(|| {
             let options = Options::default();
-            assert_eq!(&options.work_perf_events, &PerfEventOptions { events: vec![] });
+            assert_eq!(
+                &options.work_perf_events,
+                &PerfEventOptions { events: vec![] }
+            );
         })
     }
 
@@ -353,7 +356,10 @@ mod tests {
 
                     let options = Options::default();
                     // invalid value from env var, use default.
-                    assert_eq!(&options.work_perf_events, &PerfEventOptions { events: vec![] });
+                    assert_eq!(
+                        &options.work_perf_events,
+                        &PerfEventOptions { events: vec![] }
+                    );
                 },
                 || {
                     std::env::remove_var("MMTK_WORK_PERF_EVENTS");

--- a/src/util/statistics/counter/long_counter.rs
+++ b/src/util/statistics/counter/long_counter.rs
@@ -8,7 +8,7 @@ pub struct LongCounter<T: Diffable> {
     pub implicitly_start: bool,
     merge_phases: bool,
     count: Box<[u64; MAX_PHASES]>, // FIXME make this resizable
-    diffable: T, 
+    diffable: T,
     start_value: Option<T::Val>,
     total_count: u64,
     running: bool,
@@ -38,7 +38,9 @@ impl<T: Diffable> Counter for LongCounter<T> {
         debug_assert!(self.running);
         self.running = false;
         let current_value = self.diffable.current_value();
-        let delta = self.diffable.diff(&current_value, self.start_value.as_ref().unwrap());
+        let delta = self
+            .diffable
+            .diff(&current_value, self.start_value.as_ref().unwrap());
         self.count[self.stats.get_phase()] += delta;
         self.total_count += delta;
     }
@@ -127,7 +129,7 @@ impl<T: Diffable> LongCounter<T> {
         stats: Arc<SharedStats>,
         implicitly_start: bool,
         merge_phases: bool,
-        diffable: T
+        diffable: T,
     ) -> Self {
         LongCounter {
             name,

--- a/src/util/statistics/counter/long_counter.rs
+++ b/src/util/statistics/counter/long_counter.rs
@@ -38,9 +38,7 @@ impl<T: Diffable> Counter for LongCounter<T> {
         debug_assert!(self.running);
         self.running = false;
         let current_value = self.diffable.current_value();
-        let delta = self
-            .diffable
-            .diff(&current_value, self.start_value.as_ref().unwrap());
+        let delta = T::diff(&current_value, self.start_value.as_ref().unwrap());
         self.count[self.stats.get_phase()] += delta;
         self.total_count += delta;
     }
@@ -48,7 +46,7 @@ impl<T: Diffable> Counter for LongCounter<T> {
     fn phase_change(&mut self, old_phase: usize) {
         if self.running {
             let now = self.diffable.current_value();
-            let delta = self.diffable.diff(&now, self.start_value.as_ref().unwrap());
+            let delta = T::diff(&now, self.start_value.as_ref().unwrap());
             self.count[old_phase] += delta;
             self.total_count += delta;
             self.start_value = Some(now);

--- a/src/util/statistics/counter/mod.rs
+++ b/src/util/statistics/counter/mod.rs
@@ -2,13 +2,15 @@ use std::time::Instant;
 
 mod event_counter;
 mod long_counter;
-mod size_counter;
+#[cfg(feature = "perf_counter")]
 mod perf_event;
+mod size_counter;
 
 pub use self::event_counter::EventCounter;
 pub use self::long_counter::{LongCounter, Timer};
-pub use self::size_counter::SizeCounter;
+#[cfg(feature = "perf_counter")]
 pub use self::perf_event::PerfEventDiffable;
+pub use self::size_counter::SizeCounter;
 
 pub trait Counter {
     fn start(&mut self);
@@ -24,6 +26,8 @@ pub trait Counter {
     fn name(&self) -> &String;
 }
 
+/// A Diffable object could be stateless (e.g. a timer that reads the wall
+/// clock), or stateful (e.g. holds reference to a perf event fd)
 pub trait Diffable {
     type Val;
     fn current_value(&mut self) -> Self::Val;

--- a/src/util/statistics/counter/mod.rs
+++ b/src/util/statistics/counter/mod.rs
@@ -31,7 +31,7 @@ pub trait Counter {
 pub trait Diffable {
     type Val;
     fn current_value(&mut self) -> Self::Val;
-    fn diff(&mut self, current: &Self::Val, earlier: &Self::Val) -> u64;
+    fn diff(current: &Self::Val, earlier: &Self::Val) -> u64;
     fn print_diff(val: u64);
 }
 
@@ -44,7 +44,7 @@ impl Diffable for MonotoneNanoTime {
         Instant::now()
     }
 
-    fn diff(&mut self, current: &Instant, earlier: &Instant) -> u64 {
+    fn diff(current: &Instant, earlier: &Instant) -> u64 {
         let delta = current.duration_since(*earlier);
         delta.as_secs() * 1_000_000_000 + u64::from(delta.subsec_nanos())
     }

--- a/src/util/statistics/counter/mod.rs
+++ b/src/util/statistics/counter/mod.rs
@@ -3,10 +3,12 @@ use std::time::Instant;
 mod event_counter;
 mod long_counter;
 mod size_counter;
+mod perf_event;
 
 pub use self::event_counter::EventCounter;
 pub use self::long_counter::{LongCounter, Timer};
 pub use self::size_counter::SizeCounter;
+pub use self::perf_event::PerfEventDiffable;
 
 pub trait Counter {
     fn start(&mut self);
@@ -24,8 +26,8 @@ pub trait Counter {
 
 pub trait Diffable {
     type Val;
-    fn current_value() -> Self::Val;
-    fn diff(current: &Self::Val, earlier: &Self::Val) -> u64;
+    fn current_value(&mut self) -> Self::Val;
+    fn diff(&mut self, current: &Self::Val, earlier: &Self::Val) -> u64;
     fn print_diff(val: u64);
 }
 
@@ -34,11 +36,11 @@ pub struct MonotoneNanoTime;
 impl Diffable for MonotoneNanoTime {
     type Val = Instant;
 
-    fn current_value() -> Instant {
+    fn current_value(&mut self) -> Instant {
         Instant::now()
     }
 
-    fn diff(current: &Instant, earlier: &Instant) -> u64 {
+    fn diff(&mut self, current: &Instant, earlier: &Instant) -> u64 {
         let delta = current.duration_since(*earlier);
         delta.as_secs() * 1_000_000_000 + u64::from(delta.subsec_nanos())
     }

--- a/src/util/statistics/counter/perf_event.rs
+++ b/src/util/statistics/counter/perf_event.rs
@@ -1,0 +1,41 @@
+use super::Diffable;
+use pfm::{PerfEvent, PerfEventValue};
+
+/// A [`Diffable`] helper type for measuring overall perf events for mutators
+/// and GC
+/// This is the process-wide counterpart of [`crate::scheduler::work_counter::WorkPerfEvent`].
+pub struct PerfEventDiffable {
+    pe: PerfEvent,
+}
+
+impl PerfEventDiffable {
+    pub fn new(name: &str) -> Self {
+        let mut pe = PerfEvent::new(name, true)
+            .unwrap_or_else(|_| panic!("Failed to create perf event {}", name));
+        // measures the calling thread (and all child threads) on all CPUs
+        pe.open(0, -1)
+            .unwrap_or_else(|_| panic!("Failed to open perf event {}", name));
+        PerfEventDiffable { pe }
+    }
+}
+
+impl Diffable for PerfEventDiffable {
+    type Val = PerfEventValue;
+
+    fn current_value(&mut self) -> Self::Val {
+        let val = self.pe.read().unwrap();
+        self.pe.enable();
+        self.pe.reset();
+        val
+    }
+
+    fn diff(&mut self, current: &Self::Val, _earlier: &Self::Val) -> u64 {
+        // earlier value is not used as the counter is reset after each use
+        assert_eq!(current.time_enabled, current.time_running);
+        current.value as u64
+    }
+
+    fn print_diff(val: u64) {
+        print!("{}", val);
+    }
+}

--- a/src/util/statistics/counter/perf_event.rs
+++ b/src/util/statistics/counter/perf_event.rs
@@ -29,7 +29,7 @@ impl Diffable for PerfEventDiffable {
         val
     }
 
-    fn diff(&mut self, current: &Self::Val, _earlier: &Self::Val) -> u64 {
+    fn diff(current: &Self::Val, _earlier: &Self::Val) -> u64 {
         // earlier value is not used as the counter is reset after each use
         assert_eq!(current.time_enabled, current.time_running);
         current.value as u64

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -75,7 +75,6 @@ impl Stats {
         counters.push(t.clone());
         #[cfg(feature = "perf_counter")]
         for e in &options.perf_events.events {
-            println!("pushed {}", &e.0);
             counters.push(Arc::new(Mutex::new(LongCounter::new(
                 e.0.clone(),
                 shared.clone(),

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -74,7 +74,7 @@ impl Stats {
         )));
         counters.push(t.clone());
         #[cfg(feature = "perf_counter")]
-        for e in &options.perf_events.events {
+        for e in &options.phase_perf_events.events {
             counters.push(Arc::new(Mutex::new(LongCounter::new(
                 e.0.clone(),
                 shared.clone(),

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -1,5 +1,5 @@
 use crate::mmtk::MMTK;
-use crate::util::options::UnsafeOptionsWrapper;
+use crate::util::options::Options;
 use crate::util::statistics::counter::*;
 use crate::util::statistics::Timer;
 use crate::vm::VMBinding;
@@ -53,7 +53,7 @@ pub struct Stats {
 
 impl Stats {
     #[allow(unused)]
-    pub fn new(options: Arc<UnsafeOptionsWrapper>) -> Self {
+    pub fn new(options: &Options) -> Self {
         #[cfg(feature = "perf_counter")]
         let perfmon = {
             let mut perfmon: Perfmon = Default::default();

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -1,3 +1,4 @@
+use crate::util::options::UnsafeOptionsWrapper;
 use crate::mmtk::MMTK;
 use crate::util::statistics::counter::*;
 use crate::util::statistics::Timer;
@@ -51,29 +52,44 @@ pub struct Stats {
 }
 
 impl Stats {
-    pub fn new() -> Self {
+    pub fn new(options: Arc<UnsafeOptionsWrapper>) -> Self {
+        #[cfg(feature = "perf_counter")]
+        let perfmon = {
+            let mut perfmon: Perfmon = Default::default();
+            perfmon.initialize().expect("Perfmon failed to initialize");
+            perfmon
+        };
         let shared = Arc::new(SharedStats {
             phase: AtomicUsize::new(0),
             gathering_stats: AtomicBool::new(false),
         });
+        let mut counters: Vec<Arc<Mutex<dyn Counter + Send>>> = vec![];
         let t = Arc::new(Mutex::new(LongCounter::new(
             "time".to_string(),
             shared.clone(),
             true,
             false,
+            MonotoneNanoTime{}
         )));
+        counters.push(t.clone());
+        for e in &options.perf_events.events {
+            println!("pushed {}", &e.0);
+            counters.push(Arc::new(Mutex::new(LongCounter::new(
+                e.0.clone(),
+                shared.clone(),
+                true,
+                false,
+                PerfEventDiffable::new(&e.0)
+            ))));
+        }
         Stats {
             gc_count: AtomicUsize::new(0),
-            total_time: t.clone(),
+            total_time: t,
             #[cfg(feature = "perf_counter")]
-            perfmon: {
-                let mut perfmon: Perfmon = Default::default();
-                perfmon.initialize().expect("Perfmon failed to initialize");
-                perfmon
-            },
+            perfmon,
 
             shared,
-            counters: Mutex::new(vec![t]),
+            counters: Mutex::new(counters),
             exceeded_phase_limit: AtomicBool::new(false),
         }
     }
@@ -118,6 +134,7 @@ impl Stats {
             self.shared.clone(),
             implicit_start,
             merge_phases,
+            MonotoneNanoTime{}
         )));
         guard.push(counter.clone());
         counter
@@ -235,11 +252,5 @@ impl Stats {
 
     pub fn get_gathering_stats(&self) -> bool {
         self.shared.get_gathering_stats()
-    }
-}
-
-impl Default for Stats {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -1,5 +1,5 @@
-use crate::util::options::UnsafeOptionsWrapper;
 use crate::mmtk::MMTK;
+use crate::util::options::UnsafeOptionsWrapper;
 use crate::util::statistics::counter::*;
 use crate::util::statistics::Timer;
 use crate::vm::VMBinding;
@@ -52,6 +52,7 @@ pub struct Stats {
 }
 
 impl Stats {
+    #[allow(unused)]
     pub fn new(options: Arc<UnsafeOptionsWrapper>) -> Self {
         #[cfg(feature = "perf_counter")]
         let perfmon = {
@@ -69,9 +70,10 @@ impl Stats {
             shared.clone(),
             true,
             false,
-            MonotoneNanoTime{}
+            MonotoneNanoTime {},
         )));
         counters.push(t.clone());
+        #[cfg(feature = "perf_counter")]
         for e in &options.perf_events.events {
             println!("pushed {}", &e.0);
             counters.push(Arc::new(Mutex::new(LongCounter::new(
@@ -79,7 +81,7 @@ impl Stats {
                 shared.clone(),
                 true,
                 false,
-                PerfEventDiffable::new(&e.0)
+                PerfEventDiffable::new(&e.0),
             ))));
         }
         Stats {
@@ -134,7 +136,7 @@ impl Stats {
             self.shared.clone(),
             implicit_start,
             merge_phases,
-            MonotoneNanoTime{}
+            MonotoneNanoTime {},
         )));
         guard.push(counter.clone());
         counter


### PR DESCRIPTION
PR #315 added support for measuring perf events for work packets.
This PR support process-wide measurements of perf events, so we can know, say the total cycles, spent in mutators/GC.