### PR TITLE
Clear CopySpace side forwarding-status table

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -125,6 +125,9 @@ impl<VM: VMBinding> CopySpace<VM> {
 
     pub fn prepare(&self, from_space: bool) {
         self.from_space.store(from_space, Ordering::SeqCst);
+        // Clear the metadata if we are using side forwarding status table. Otherwise
+        // objects may inherit forwarding status from the previous GC.
+        // TODO: Fix performance.
         if let MetadataSpec::OnSide(side_forwarding_status_table) =
             *<VM::VMObjectModel as ObjectModel<VM>>::LOCAL_FORWARDING_BITS_SPEC
         {

--- a/src/util/heap/monotonepageresource.rs
+++ b/src/util/heap/monotonepageresource.rs
@@ -206,6 +206,11 @@ impl<VM: VMBinding> MonotonePageResource<VM> {
         }
     }
 
+    /// Get highwater mark of current monotone space.
+    pub fn cursor(&self) -> Address {
+        self.sync.lock().unwrap().cursor
+    }
+
     fn log_chunk_fields(&self, space_descriptor: SpaceDescriptor, site: &str) {
         let sync = self.sync.lock().unwrap();
         debug!(


### PR DESCRIPTION
Clear side forwarding status table before each GC, if CopySpace uses side metadata for forwarding bits.

This is required, otherwise, some unforwarded objects may have "forwarded" states inherited from the previous GC.