### PR TITLE
Run binding tests with extreme_assertions

### DIFF
--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -52,7 +52,7 @@ jobs:
   # JikesRVM
   jikesrvm-binding-test:
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: contains(github.event.pull_request.labels.*.name, 'PR-testing')
     steps:
       - name: Checkout MMTk Core
@@ -183,7 +183,7 @@ jobs:
   # OpenJDK
   openjdk-binding-test:
     runs-on: ubuntu-18.04
-    timeout-minutes: 120
+    timeout-minutes: 240
     if: contains(github.event.pull_request.labels.*.name, 'PR-testing')
     steps:
       - name: Checkout MMTk Core

--- a/docs/tutorial/code/mygc_semispace/global.rs
+++ b/docs/tutorial/code/mygc_semispace/global.rs
@@ -202,6 +202,8 @@ impl<VM: VMBinding> MyGC<VM> {
             common: CommonPlan::new(vm_map, mmapper, options, heap, &MYGC_CONSTRAINTS, global_metadata_specs.clone()),
         };
 
+        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
+        // side metadata in extreme_assertions.
         let mut side_metadata_sanity_checker = SideMetadataSanity::new();
         res.common.verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
         res.copyspace0.verify_side_metadata_sanity(&mut side_metadata_sanity_checker);

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -71,6 +71,8 @@ pub fn gc_init<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, heap_size: usize) {
     mmtk.plan
         .gc_init(heap_size, &crate::VM_MAP, &mmtk.scheduler);
     info!("Initialized MMTk with {:?}", mmtk.options.plan);
+    #[cfg(feature = "extreme_assertions")]
+    warn!("The feature 'extreme_assertions' is enabled. MMTk will run expensive run-time checks. Slow performance should be expected.");
 }
 
 /// Request MMTk to create a mutator for the given thread. For performance reasons, A VM should

--- a/src/plan/gencopy/global.rs
+++ b/src/plan/gencopy/global.rs
@@ -265,6 +265,8 @@ impl<VM: VMBinding> GenCopy<VM> {
             next_gc_full_heap: AtomicBool::new(false),
         };
 
+        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
+        // side metadata in extreme_assertions.
         {
             let mut side_metadata_sanity_checker = SideMetadataSanity::new();
             res.common

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -160,6 +160,17 @@ pub fn create_plan<VM: VMBinding>(
 ///
 /// The global instance defines and manages static resources
 /// (such as memory and virtual memory resources).
+///
+/// Constructor:
+///
+/// For the constructor of a new plan, there are a few things the constructor _must_ do
+/// (please check existing plans and see what they do in the constructor):
+/// 1. Create a HeapMeta, and use this HeapMeta to initialize all the spaces.
+/// 2. Create a vector of all the side metadata specs with `SideMetadataContext::new_global_specs()`,
+///    the parameter is a vector of global side metadata specs that are specific to the plan.
+/// 3. Initialize all the spaces the plan uses with the heap meta, and the global metadata specs vector.
+/// 4. Create a `SideMetadataSanity` object, and invoke verify_side_metadata_sanity() for each space (or
+///    invoke verify_side_metadata_sanity() in `CommonPlan`/`BasePlan` for the spaces in the common/base plan).
 pub trait Plan: 'static + Sync + Downcast {
     type VM: VMBinding;
 

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -151,6 +151,8 @@ impl<VM: VMBinding> MarkSweep<VM> {
             ),
         };
 
+        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
+        // side metadata in extreme_assertions.
         {
             let mut side_metadata_sanity_checker = SideMetadataSanity::new();
             res.common

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -40,6 +40,7 @@ pub const MS_CONSTRAINTS: PlanConstraints = PlanConstraints {
     gc_header_bits: 2,
     gc_header_words: 0,
     num_specialized_scans: 1,
+    may_trace_duplicate_edges: true,
     ..PlanConstraints::default()
 };
 

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -139,6 +139,8 @@ impl<VM: VMBinding> NoGC<VM> {
             ),
         };
 
+        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
+        // side metadata in extreme_assertions.
         let mut side_metadata_sanity_checker = SideMetadataSanity::new();
         res.base
             .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -170,6 +170,8 @@ impl<VM: VMBinding> PageProtect<VM> {
             ),
         };
 
+        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
+        // side metadata in extreme_assertions.
         {
             use crate::util::metadata::side_metadata::SideMetadataSanity;
             let mut side_metadata_sanity_checker = SideMetadataSanity::new();

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -148,7 +148,7 @@ impl<VM: VMBinding> PageProtect<VM> {
         let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
 
-        PageProtect {
+        let ret = PageProtect {
             space: LargeObjectSpace::new(
                 "los",
                 true,
@@ -168,6 +168,17 @@ impl<VM: VMBinding> PageProtect<VM> {
                 &CONSTRAINTS,
                 global_metadata_specs,
             ),
+        };
+
+        {
+            use crate::util::metadata::side_metadata::SideMetadataSanity;
+            let mut side_metadata_sanity_checker = SideMetadataSanity::new();
+            ret.common
+                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+            ret.space
+                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
         }
+
+        ret
     }
 }

--- a/src/plan/plan_constraints.rs
+++ b/src/plan/plan_constraints.rs
@@ -19,6 +19,10 @@ pub struct PlanConstraints {
     /// Size (in bytes) beyond which copied objects must be copied to the LOS.
     /// This depends on the copy allocator.
     pub max_non_los_copy_bytes: usize,
+    /// Some plans may allow benign race for testing mark bit, and this will lead to trace the same edges
+    /// multiple times. If a plan allows tracing duplicate edges, we will not run duplicate edge check
+    /// in extreme_assertions.
+    pub may_trace_duplicate_edges: bool,
     pub barrier: BarrierSelector,
     // the following seems unused for now
     pub needs_linear_scan: bool,
@@ -39,6 +43,7 @@ impl PlanConstraints {
             needs_linear_scan: SUPPORT_CARD_SCANNING || LAZY_SWEEP,
             needs_concurrent_workers: false,
             generate_gc_trace: false,
+            may_trace_duplicate_edges: false,
             needs_forward_after_liveness: false,
             barrier: BarrierSelector::NoBarrier,
         }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -187,6 +187,8 @@ impl<VM: VMBinding> SemiSpace<VM> {
             ),
         };
 
+        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
+        // side metadata in extreme_assertions.
         {
             let mut side_metadata_sanity_checker = SideMetadataSanity::new();
             res.common

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -239,8 +239,10 @@ impl<VM: VMBinding> GCWork<VM> for EndOfGC {
         info!("End of GC");
 
         #[cfg(feature = "extreme_assertions")]
-        // reset the logging info at the end of each GC
-        crate::util::edge_logger::reset();
+        if crate::util::edge_logger::should_check_duplicate_edges(&*mmtk.plan) {
+            // reset the logging info at the end of each GC
+            crate::util::edge_logger::reset();
+        }
 
         mmtk.plan.base().set_gc_status(GcStatus::NotInGC);
         <VM as VMBinding>::VMCollection::resume_mutators(worker.tls);
@@ -373,9 +375,11 @@ impl<E: ProcessEdgesWork> ProcessEdgesBase<E> {
     // at creation. This avoids overhead for dynamic dispatch or downcasting plan for each object traced.
     pub fn new(edges: Vec<Address>, mmtk: &'static MMTK<E::VM>) -> Self {
         #[cfg(feature = "extreme_assertions")]
-        for edge in &edges {
-            // log edge, panic if already logged
-            crate::util::edge_logger::log_edge(*edge);
+        if crate::util::edge_logger::should_check_duplicate_edges(&*mmtk.plan) {
+            for edge in &edges {
+                // log edge, panic if already logged
+                crate::util::edge_logger::log_edge(*edge);
+            }
         }
         Self {
             edges,

--- a/src/util/edge_logger.rs
+++ b/src/util/edge_logger.rs
@@ -4,13 +4,21 @@
 //! We currently only use this as part of the `extreme_assertions` feature.
 //!
 
-use super::Address;
+use crate::plan::Plan;
+use crate::util::Address;
+use crate::vm::VMBinding;
 use std::collections::HashSet;
 use std::sync::RwLock;
 
 lazy_static! {
     // A private hash-set to keep track of edges.
     static ref EDGE_LOG: RwLock<HashSet<Address>> = RwLock::new(HashSet::new());
+}
+
+/// Whether we should check duplicate edges. This depends on the actual plan.
+pub fn should_check_duplicate_edges<VM: VMBinding>(plan: &dyn Plan<VM=VM>) -> bool {
+    // If a plan allows tracing duplicate edges, we should not run this check.
+    !plan.constraints().may_trace_duplicate_edges
 }
 
 /// Logs an edge.

--- a/src/util/edge_logger.rs
+++ b/src/util/edge_logger.rs
@@ -16,7 +16,7 @@ lazy_static! {
 }
 
 /// Whether we should check duplicate edges. This depends on the actual plan.
-pub fn should_check_duplicate_edges<VM: VMBinding>(plan: &dyn Plan<VM=VM>) -> bool {
+pub fn should_check_duplicate_edges<VM: VMBinding>(plan: &dyn Plan<VM = VM>) -> bool {
     // If a plan allows tracing duplicate edges, we should not run this check.
     !plan.constraints().may_trace_duplicate_edges
 }


### PR DESCRIPTION
This PR adds workflows for running bindings with extreme_assertions.
* Add `may_trace_duplicate_edges` in plan constraints. Some plans may trace duplicate edges, and for those plan, we do not run duplicate edge check.
* Add the missing side metadata sanity check for PageProtect.
* Increase timeout for binding tests (as they now include tests with extreme_assertions).

Related PRs:
* https://github.com/mmtk/mmtk-openjdk/pull/95
* https://github.com/mmtk/mmtk-jikesrvm/pull/79