### PR TITLE
Dispatch mmtk-dev-env workflow

### DIFF
--- a/.github/workflows/mmtk-dev-env.yml
+++ b/.github/workflows/mmtk-dev-env.yml
@@ -1,0 +1,23 @@
+name: Check mmtk-dev-env
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-mmtk-dev-env:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.3.0
+        with:
+          owner: mmtk
+          repo: mmtk-dev-env
+          github_token: ${{ secrets.CI_ACCESS_TOKEN }}
+          workflow_file_name: ci.yml
+          ref: main
+          wait_interval: 10
+          inputs: '{}'
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true

--- a/.github/workflows/mmtk-dev-env.yml
+++ b/.github/workflows/mmtk-dev-env.yml
@@ -15,8 +15,8 @@ jobs:
           repo: mmtk-dev-env
           github_token: ${{ secrets.CI_ACCESS_TOKEN }}
           workflow_file_name: ci.yml
-          ref: update-rust-toolchain
-          wait_interval: 10
+          ref: main
+          wait_interval: 30
           inputs: '{}'
           propagate_failure: true
           trigger_workflow: true

--- a/.github/workflows/mmtk-dev-env.yml
+++ b/.github/workflows/mmtk-dev-env.yml
@@ -1,11 +1,13 @@
 name: Check mmtk-dev-env
 
+# Triggerred when a new commit is pushed to master
 on:
-  pull_request:
+  push:
     branches:
       - master
 
 jobs:
+  # Trigger ci.yml from mmtk/mmtk-dev-env to make sure mmtk-core can build with mmtk-dev-env.
   check-mmtk-dev-env:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/mmtk-dev-env.yml
+++ b/.github/workflows/mmtk-dev-env.yml
@@ -15,7 +15,7 @@ jobs:
           repo: mmtk-dev-env
           github_token: ${{ secrets.CI_ACCESS_TOKEN }}
           workflow_file_name: ci.yml
-          ref: main
+          ref: update-rust-toolchain
           wait_interval: 10
           inputs: '{}'
           propagate_failure: true


### PR DESCRIPTION
This PR adds a check: for each mmtk-core commit in `master`, we will run `ci.yml` from https://github.com/mmtk/mmtk-dev-env to make sure the core can be built on the dev env.