### PR TITLE
Rename phase-based counters

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-jikesrvm-baseline.yml
+++ b/.github/workflows/perf-jikesrvm-baseline.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-openjdk-baseline.yml
+++ b/.github/workflows/perf-openjdk-baseline.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -98,7 +98,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -160,7 +160,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -266,7 +266,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.6.4"
+          ref: "0.6.5"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -211,7 +211,7 @@ impl Stats {
             if c.merge_phases() {
                 print!("{}\t", c.name());
             } else {
-                print!("{}.mu\t{}.gc\t", c.name(), c.name());
+                print!("{}.other\t{}.stw\t", c.name(), c.name());
             }
         }
         for name in scheduler_stat.keys() {


### PR DESCRIPTION
This PR renames the column names in statistics for phase-based (rather than work-packet-based) counters.
The reason is that `.mu` and `.gc` is misleading, especially for concurrent collectors.
`PERF_COUNT_HW_CPU_CYCLES.gc` and `PERF_COUNT_HW_CPU_CYCLES.mu` do not mean the CPU cycles of the GC and those of the mutators.
Instead, we are measuring the cycles spent during stop-the-world pauses and the cycles outside stop-the-world pauses.