### PR TITLE
Remove an assertion in allocation

### DIFF
--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -94,7 +94,6 @@ pub fn get_maximum_aligned_size<VM: VMBinding>(
         known_alignment,
         VM::MIN_ALIGNMENT
     );
-    debug_assert!(size == size & !(known_alignment - 1));
     debug_assert!(known_alignment >= VM::MIN_ALIGNMENT);
 
     if VM::MAX_ALIGNMENT <= VM::MIN_ALIGNMENT || alignment <= known_alignment {


### PR DESCRIPTION
This PR removes an assertion in the allocation that checks if `size` is a multiple of `VM::MIN_ALIGNMENT`. This assertion would fail for cases like allocating an object of 12 bytes with `MIN_ALIGNMENT=8`, which is actually reasonable. This assertion is not necessary, and it is very possibly that the code is from Java MMTk and is Java specific.