### PR TITLE
Fix panic when using LockFreeImmortalSpace for NoGC

### DIFF
--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -144,8 +144,10 @@ impl<VM: VMBinding> NoGC<VM> {
         let mut side_metadata_sanity_checker = SideMetadataSanity::new();
         res.base
             .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        res.nogc_space
-            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+        if cfg!(not(feature = "nogc_lock_free")) {
+            res.nogc_space
+                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+        }
 
         res
     }

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -144,10 +144,8 @@ impl<VM: VMBinding> NoGC<VM> {
         let mut side_metadata_sanity_checker = SideMetadataSanity::new();
         res.base
             .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        if cfg!(not(feature = "nogc_lock_free")) {
-            res.nogc_space
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        }
+        res.nogc_space
+            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
 
         res
     }

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -139,7 +139,7 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
     }
 
     /// We have to override the default implementation because
-    /// LockFreeImmortalSpace doesn't use side metadata
+    /// LockFreeImmortalSpace doesn't put metadata in a common space
     fn verify_side_metadata_sanity(&self, side_metadata_sanity_checker: &mut SideMetadataSanity) {
         side_metadata_sanity_checker
             .verify_metadata_context(std::any::type_name::<Self>(), &self.metadata)

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -140,7 +140,10 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
 
     /// We have to override the default implementation because
     /// LockFreeImmortalSpace doesn't use side metadata
-    fn verify_side_metadata_sanity(&self, _: &mut SideMetadataSanity) {}
+    fn verify_side_metadata_sanity(&self, side_metadata_sanity_checker: &mut SideMetadataSanity) {
+        side_metadata_sanity_checker
+            .verify_metadata_context(std::any::type_name::<Self>(), &self.metadata)
+    }
 }
 
 impl<VM: VMBinding> LockFreeImmortalSpace<VM> {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -130,13 +130,12 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
     }
 
     /// Get the name of the space
-    /// 
+    ///
     /// We have to override the default implementation because
     /// LockFreeImmortalSpace doesn't have a common space
     fn get_name(&self) -> &'static str {
         "LockFreeImmortalSpace"
     }
-
 }
 
 impl<VM: VMBinding> LockFreeImmortalSpace<VM> {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -17,6 +17,7 @@ use crate::vm::VMBinding;
 use crate::vm::*;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use crate::util::metadata::side_metadata::SideMetadataSanity;
 
 /// This type implements a lock free version of the immortal collection
 /// policy. This is close to the OpenJDK's epsilon GC.
@@ -136,6 +137,10 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
     fn get_name(&self) -> &'static str {
         "LockFreeImmortalSpace"
     }
+
+    /// We have to override the default implementation because
+    /// LockFreeImmortalSpace doesn't use side metadata
+    fn verify_side_metadata_sanity(&self, _: &mut SideMetadataSanity) {}
 }
 
 impl<VM: VMBinding> LockFreeImmortalSpace<VM> {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -11,13 +11,13 @@ use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::layout::vm_layout_constants::{
     AVAILABLE_BYTES, AVAILABLE_END, AVAILABLE_START,
 };
+use crate::util::metadata::side_metadata::SideMetadataSanity;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSpec};
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
 use crate::vm::*;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use crate::util::metadata::side_metadata::SideMetadataSanity;
 
 /// This type implements a lock free version of the immortal collection
 /// policy. This is close to the OpenJDK's epsilon GC.

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -128,6 +128,15 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
         }
         start
     }
+
+    /// Get the name of the space
+    /// 
+    /// We have to override the default implementation because
+    /// LockFreeImmortalSpace doesn't have a common space
+    fn get_name(&self) -> &'static str {
+        "LockFreeImmortalSpace"
+    }
+
 }
 
 impl<VM: VMBinding> LockFreeImmortalSpace<VM> {


### PR DESCRIPTION
Closes #430 

LockFreeImmortalSpace doesn't have a common space, and various functions try to get the common space.
This PR overrides some of the default behaviours to avoid the runtime panic.