### PR TITLE
MallocSpace should map metadata for all the chunks for an allocated object

### DIFF
--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -286,7 +286,6 @@ impl<VM: VMBinding> MallocSpace<VM> {
         }
 
         // Update chunk_addr_max, basing on the end of the allocation: addr + size.
-        // chn
         {
             let max_chunk_start = conversions::chunk_align_down(addr + size);
             let max_chunk_usize = max_chunk_start.as_usize();


### PR DESCRIPTION
This PR fixes a bug that may cause the side metadata for an object in `MallocSpace` is not properly mapped. 

The bug is triggered when an object crosses the chunk boundary. The current code only maps the chunk for the object start, but it is possible that the `ObjectReference` for the object is in the next chunk. When we try set alloc bit for the object reference, we will see the alloc bit metadata is not yet mapped. 

This PR changes the mapping related code in `MallocSpace` so it maps all the chunks for the allocated object `[start, start + size)`.