### PR TITLE
Fix the branch of CI action `actions-comment-pull-request`

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -82,7 +82,7 @@ jobs:
       # report
       - name: Result
         if: always()
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ steps.cat.outputs.text }}

--- a/.github/workflows/post-review-ci.yml
+++ b/.github/workflows/post-review-ci.yml
@@ -169,7 +169,7 @@ jobs:
       # report
       - name: Result
         if: always()
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ steps.cat.outputs.text }}
@@ -299,7 +299,7 @@ jobs:
       # report
       - name: Result
         if: always()
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ steps.cat.outputs.text }}


### PR DESCRIPTION
The [upstream](https://github.com/thollander/actions-comment-pull-request) renames the default branch from `master` to `main`.
See thollander/actions-comment-pull-request#25 and thollander/actions-comment-pull-request#24

This PR reflects that change. Fixes #436.


