### PR TITLE
Fix stop-the-world race.

### DIFF
--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -6,6 +6,15 @@ use crate::vm::VMBinding;
 
 /// VM-specific methods for garbage collection.
 pub trait Collection<VM: VMBinding> {
+    /// If true, only the coordinator thread can call stop_all_mutators and the resume_mutators methods.
+    /// If false, any GC thread can call these methods.
+    ///
+    /// This constant exists because some VMs require the thread that resumes a thread to be the same thread that
+    /// stopped it.  The MMTk Core will use the appropriate thread to stop or start the world according to the value of
+    /// this constant.  If a VM does not have such a requirement, the VM binding shall set this to false to reduce an
+    /// unnecessary context switch.
+    const COORDINATOR_ONLY_STW: bool = true;
+
     /// Stop all the mutator threads. MMTk calls this method when it requires all the mutator to yield for a GC.
     /// This method is called by a single thread in MMTk (the GC controller).
     /// This method should not return until all the threads are yielded.


### PR DESCRIPTION
With the associated commit in the mmtk-openjdk repository, stop-the-world and start-the-world requests no longer have to be made in the MMTk coordinator thread.

NOTE: This change will break the current `mmtk-openjdk` binding, because the VM will raise errors if the thread that starts the world is not the thread that stopped the world.  So `mmtk-openjdk` should only update its dependency to this revision at the same time it applied its corresponding PR for the stop-the-world race fix.