### PR TITLE
Fix Immix Defragmentation

### DIFF
--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -165,9 +165,6 @@ impl Block {
     /// Mark the block for defragmentation.
     #[inline(always)]
     pub fn set_as_defrag_source(&self, defrag: bool) {
-        if cfg!(debug_assertions) && defrag {
-            debug_assert!(!self.get_state().is_reusable());
-        }
         let byte = if defrag { Self::DEFRAG_SOURCE_STATE } else { 0 };
         side_metadata::store_atomic(
             &Self::DEFRAG_STATE_TABLE,


### PR DESCRIPTION
Recyclable immix blocks were not recognised as defrag sources for evacuation. When the number of (fragmented) recyclable blocks grows, those memory cannot be defragmented until the block is popped from the recyclable queue and get reused by some mutator or GC thread.

This PR fixes this problem by removing the constraints that "recyclable blocks cannot be defragmented".

Fixed #419 