### PR TITLE
Maintain the versions of dependencies in Cargo.toml when building docs

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -20,7 +20,7 @@ jobs:
           override: true
       - name: Append sha to crate version
         run: |
-          sed -i 's/version = "[0-9]\+.[0-9]\+.[0-9]\+/&-'${GITHUB_SHA}'/' Cargo.toml
+          sed -i 's/^version = "[0-9]\+.[0-9]\+.[0-9]\+/&-'${GITHUB_SHA}'/' Cargo.toml
       - name: Generate rustdoc
         run: ./.github/scripts/ci-doc.sh
       - name: Copy docs


### PR DESCRIPTION
The current workflow changes all the version numbers in `Cargo.toml` when building documentations, which can break the version specified for dependencies.