### PR TITLE
Fix an issue that we did not throw OOM for Immix plans if DEFRAG is set to false

### DIFF
--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -39,9 +39,9 @@ pub struct GenImmix<VM: VMBinding> {
     /// An immix space as the mature space.
     pub immix: ImmixSpace<VM>,
     /// Whether the last GC was a defrag GC for the immix space.
-    // This is not used. It should be used for last_collection_was_exhaustive.
-    // TODO: We need to fix this.
     pub last_gc_was_defrag: AtomicBool,
+    /// Whether the last GC was a full heap GC
+    pub last_gc_was_full_heap: AtomicBool,
 }
 
 pub const GENIMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
@@ -76,7 +76,10 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
     }
 
     fn last_collection_was_exhaustive(&self) -> bool {
-        self.last_gc_was_defrag.load(Ordering::Relaxed)
+        self.last_gc_was_full_heap.load(Ordering::Relaxed)
+            && ImmixSpace::<VM>::is_last_gc_exhaustive(
+                self.last_gc_was_defrag.load(Ordering::Relaxed),
+            )
     }
 
     fn force_full_heap_collection(&self) {
@@ -163,6 +166,8 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         } else {
             self.last_gc_was_defrag.store(false, Ordering::Relaxed);
         }
+        self.last_gc_was_full_heap
+            .store(full_heap, Ordering::Relaxed);
     }
 
     fn get_collection_reserve(&self) -> usize {
@@ -227,6 +232,7 @@ impl<VM: VMBinding> GenImmix<VM> {
             ),
             immix: immix_space,
             last_gc_was_defrag: AtomicBool::new(false),
+            last_gc_was_full_heap: AtomicBool::new(false),
         };
 
         // Use SideMetadataSanity to check if each spec is valid. This is also needed for check

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -50,7 +50,7 @@ impl<VM: VMBinding> Plan for Immix<VM> {
     }
 
     fn last_collection_was_exhaustive(&self) -> bool {
-        self.last_gc_was_defrag.load(Ordering::Relaxed)
+        ImmixSpace::<VM>::is_last_gc_exhaustive(self.last_gc_was_defrag.load(Ordering::Relaxed))
     }
 
     fn constraints(&self) -> &'static PlanConstraints {

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -499,6 +499,15 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             .all(|line| !line.is_marked(unavail_state) && !line.is_marked(current_state)));
         Some(start..end)
     }
+
+    pub fn is_last_gc_exhaustive(did_defrag_for_last_gc: bool) -> bool {
+        if super::DEFRAG {
+            did_defrag_for_last_gc
+        } else {
+            // If defrag is disabled, every GC is exhaustive.
+            true
+        }
+    }
 }
 
 /// A work packet to prepare each block for GC.


### PR DESCRIPTION
This PR fixes a bug that when `DEFRAG` is set to `false`, Immix plans would not consider any GC as an emergency GC so they did not throw OOM. Immix plans check if last GC was defrag to determine whether last GC was exhaustive. As `DEFRAG` is false, there would be no defrag GC, thus the plans wouldn't consider any GC was exhaustive. So in case of running out of memory, Immix plans would keep looping to do GCs with no end condition. This PR fixes this issue.