### PR TITLE
Initial work on conservative scanning

### DIFF
--- a/src/plan/conservative/marksweep/gc_work.rs
+++ b/src/plan/conservative/marksweep/gc_work.rs
@@ -1,0 +1,132 @@
+use crate::plan::global::NoCopy;
+use crate::plan::global::Plan;
+use crate::policy::mallocspace::metadata::is_chunk_mapped;
+use crate::policy::mallocspace::metadata::is_chunk_marked_unsafe;
+use crate::policy::mallocspace::MallocSpace;
+use crate::policy::space::Space;
+use crate::scheduler::gc_work::*;
+use crate::scheduler::{GCWork, GCWorker, WorkBucketStage};
+use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
+use crate::util::Address;
+use crate::util::ObjectReference;
+use crate::vm::VMBinding;
+use crate::MMTK;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::Ordering;
+
+use super::ConservativeMarkSweep;
+
+pub struct MSProcessEdges<VM: VMBinding> {
+    plan: &'static ConservativeMarkSweep<VM>,
+    base: ProcessEdgesBase<MSProcessEdges<VM>>,
+}
+
+impl<VM: VMBinding> ProcessEdgesWork for MSProcessEdges<VM> {
+    type VM = VM;
+
+    const OVERWRITE_REFERENCE: bool = false;
+    fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
+        let base = ProcessEdgesBase::new(edges, roots, mmtk);
+        let plan = base
+            .plan()
+            .downcast_ref::<ConservativeMarkSweep<VM>>()
+            .unwrap();
+        Self { plan, base }
+    }
+
+    #[inline]
+    fn trace_object(&mut self, object: ObjectReference) -> ObjectReference {
+        if object.is_null() {
+            return object;
+        }
+        trace!("Tracing object {}", object);
+        if self.plan.ms_space().in_space(object) {
+            self.plan.ms_space().trace_object::<Self>(self, object)
+        } else {
+            self.plan
+                .common()
+                .trace_object::<Self, NoCopy<VM>>(self, object)
+        }
+    }
+}
+
+impl<VM: VMBinding> Deref for MSProcessEdges<VM> {
+    type Target = ProcessEdgesBase<Self>;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl<VM: VMBinding> DerefMut for MSProcessEdges<VM> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
+/// Simple work packet that just sweeps a single chunk
+pub struct MSSweepChunk<VM: VMBinding> {
+    ms: &'static MallocSpace<VM>,
+    // starting address of a chunk
+    chunk: Address,
+}
+
+impl<VM: VMBinding> GCWork<VM> for MSSweepChunk<VM> {
+    #[inline]
+    fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
+        self.ms.sweep_chunk(self.chunk);
+    }
+}
+
+/// Work packet that generates sweep jobs for gc workers. Each chunk is given its own work packet
+pub struct MSSweepChunks<VM: VMBinding> {
+    plan: &'static ConservativeMarkSweep<VM>,
+}
+
+impl<VM: VMBinding> MSSweepChunks<VM> {
+    pub fn new(plan: &'static ConservativeMarkSweep<VM>) -> Self {
+        Self { plan }
+    }
+}
+
+impl<VM: VMBinding> GCWork<VM> for MSSweepChunks<VM> {
+    #[inline]
+    fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
+        let ms = self.plan.ms_space();
+        let mut work_packets: Vec<Box<dyn GCWork<VM>>> = vec![];
+        let mut chunk = unsafe { Address::from_usize(ms.chunk_addr_min.load(Ordering::Relaxed)) }; // XXX: have to use AtomicUsize to represent an Address
+        let end = unsafe { Address::from_usize(ms.chunk_addr_max.load(Ordering::Relaxed)) }
+            + BYTES_IN_CHUNK;
+
+        // Since only a single thread generates the sweep work packets as well as it is a Stop-the-World collector,
+        // we can assume that the chunk mark metadata is not being accessed by anything else and hence we use
+        // non-atomic accesses
+        while chunk < end {
+            if is_chunk_mapped(chunk) && unsafe { is_chunk_marked_unsafe(chunk) } {
+                work_packets.push(box MSSweepChunk { ms, chunk });
+            }
+
+            chunk += BYTES_IN_CHUNK;
+        }
+
+        debug!("Generated {} sweep work packets", work_packets.len());
+        #[cfg(debug_assertions)]
+        {
+            ms.total_work_packets
+                .store(work_packets.len() as u32, Ordering::SeqCst);
+            ms.completed_work_packets.store(0, Ordering::SeqCst);
+            ms.work_live_bytes.store(0, Ordering::SeqCst);
+        }
+
+        mmtk.scheduler.work_buckets[WorkBucketStage::Release].bulk_add(work_packets);
+    }
+}
+
+pub struct MSGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::scheduler::GCWorkContext for MSGCWorkContext<VM> {
+    type VM = VM;
+    type PlanType = ConservativeMarkSweep<VM>;
+    type CopyContextType = NoCopy<VM>;
+    type ProcessEdgesWorkType = MSProcessEdges<VM>;
+}

--- a/src/plan/conservative/marksweep/global.rs
+++ b/src/plan/conservative/marksweep/global.rs
@@ -1,0 +1,160 @@
+use crate::mmtk::MMTK;
+use crate::plan::conservative::marksweep::gc_work::{MSGCWorkContext, MSSweepChunks};
+use crate::plan::conservative::marksweep::mutator::ALLOCATOR_MAPPING;
+use crate::plan::global::BasePlan;
+use crate::plan::global::CommonPlan;
+use crate::plan::global::GcStatus;
+use crate::plan::global::NoCopy;
+use crate::plan::AllocationSemantics;
+use crate::plan::Plan;
+use crate::plan::PlanConstraints;
+use crate::policy::mallocspace::metadata::ACTIVE_CHUNK_METADATA_SPEC;
+use crate::policy::mallocspace::MallocSpace;
+use crate::policy::space::Space;
+use crate::scheduler::*;
+use crate::util::alloc::allocators::AllocatorSelector;
+#[cfg(not(feature = "global_alloc_bit"))]
+use crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC;
+use crate::util::heap::layout::heap_layout::Mmapper;
+use crate::util::heap::layout::heap_layout::VMMap;
+use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
+use crate::util::heap::HeapMeta;
+use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
+use crate::util::options::UnsafeOptionsWrapper;
+use crate::util::VMWorkerThread;
+use crate::vm::VMBinding;
+use std::sync::Arc;
+
+use enum_map::EnumMap;
+
+pub struct ConservativeMarkSweep<VM: VMBinding> {
+    common: CommonPlan<VM>,
+    ms: MallocSpace<VM>,
+}
+
+pub const CONSERVATIVE_MS_CONSTRAINTS: PlanConstraints = PlanConstraints {
+    moves_objects: false,
+    gc_header_bits: 2,
+    gc_header_words: 0,
+    num_specialized_scans: 1,
+    may_trace_duplicate_edges: true,
+    ..PlanConstraints::default()
+};
+
+impl<VM: VMBinding> Plan for ConservativeMarkSweep<VM> {
+    type VM = VM;
+
+    fn gc_init(
+        &mut self,
+        heap_size: usize,
+        vm_map: &'static VMMap,
+        scheduler: &Arc<GCWorkScheduler<VM>>,
+    ) {
+        self.common.gc_init(heap_size, vm_map, scheduler);
+    }
+
+    fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
+        self.base().set_collection_kind::<Self>(self);
+        self.base().set_gc_status(GcStatus::GcPrepare);
+        scheduler.schedule_common_work::<MSGCWorkContext<VM>>(self);
+        scheduler.work_buckets[WorkBucketStage::Prepare].add(MSSweepChunks::<VM>::new(self));
+    }
+
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
+        &*ALLOCATOR_MAPPING
+    }
+
+    fn prepare(&mut self, tls: VMWorkerThread) {
+        self.common.prepare(tls, true);
+        // Dont need to prepare for MallocSpace
+    }
+
+    fn release(&mut self, tls: VMWorkerThread) {
+        trace!("Marksweep: Release");
+        self.common.release(tls, true);
+    }
+
+    fn collection_required(&self, space_full: bool, space: &dyn Space<Self::VM>) -> bool {
+        self.base().collection_required(self, space_full, space)
+    }
+
+    fn get_collection_reserve(&self) -> usize {
+        0
+    }
+
+    fn get_pages_used(&self) -> usize {
+        self.common.get_pages_used() + self.ms.reserved_pages()
+    }
+
+    fn base(&self) -> &BasePlan<VM> {
+        &self.common.base
+    }
+
+    fn common(&self) -> &CommonPlan<VM> {
+        &self.common
+    }
+
+    fn constraints(&self) -> &'static PlanConstraints {
+        &CONSERVATIVE_MS_CONSTRAINTS
+    }
+
+    fn create_worker_local(
+        &self,
+        tls: VMWorkerThread,
+        mmtk: &'static MMTK<Self::VM>,
+    ) -> GCWorkerLocalPtr {
+        let mut c = NoCopy::new(mmtk);
+        c.init(tls);
+        GCWorkerLocalPtr::new(c)
+    }
+}
+
+impl<VM: VMBinding> ConservativeMarkSweep<VM> {
+    pub fn new(
+        vm_map: &'static VMMap,
+        mmapper: &'static Mmapper,
+        options: Arc<UnsafeOptionsWrapper>,
+    ) -> Self {
+        let heap = HeapMeta::new(HEAP_START, HEAP_END);
+        // if global_alloc_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
+        // SideMetadataContext by default, so we don't need to add it here.
+        #[cfg(feature = "global_alloc_bit")]
+        let global_metadata_specs =
+            SideMetadataContext::new_global_specs(&[ACTIVE_CHUNK_METADATA_SPEC]);
+        // if global_alloc_bit is NOT enabled,
+        // we need to add ALLOC_SIDE_METADATA_SPEC to SideMetadataContext here.
+        #[cfg(not(feature = "global_alloc_bit"))]
+        let global_metadata_specs = SideMetadataContext::new_global_specs(&[
+            ALLOC_SIDE_METADATA_SPEC,
+            ACTIVE_CHUNK_METADATA_SPEC,
+        ]);
+
+        let res = ConservativeMarkSweep {
+            ms: MallocSpace::new(global_metadata_specs.clone()),
+            common: CommonPlan::new(
+                vm_map,
+                mmapper,
+                options,
+                heap,
+                &CONSERVATIVE_MS_CONSTRAINTS,
+                global_metadata_specs,
+            ),
+        };
+
+        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
+        // side metadata in extreme_assertions.
+        {
+            let mut side_metadata_sanity_checker = SideMetadataSanity::new();
+            res.common
+                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+            res.ms
+                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+        }
+
+        res
+    }
+
+    pub fn ms_space(&self) -> &MallocSpace<VM> {
+        &self.ms
+    }
+}

--- a/src/plan/conservative/marksweep/mod.rs
+++ b/src/plan/conservative/marksweep/mod.rs
@@ -1,0 +1,8 @@
+//! Plan: conservative-marksweep (currently using malloc as its freelist allocator)
+
+mod gc_work;
+mod global;
+pub mod mutator;
+
+pub use self::global::ConservativeMarkSweep;
+pub use self::global::CONSERVATIVE_MS_CONSTRAINTS;

--- a/src/plan/conservative/marksweep/mutator.rs
+++ b/src/plan/conservative/marksweep/mutator.rs
@@ -1,0 +1,60 @@
+use super::ConservativeMarkSweep;
+use crate::plan::barriers::NoBarrier;
+use crate::plan::mutator_context::create_allocator_mapping;
+use crate::plan::mutator_context::create_space_mapping;
+use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorConfig;
+use crate::plan::mutator_context::ReservedAllocators;
+use crate::plan::AllocationSemantics;
+use crate::util::alloc::allocators::AllocatorSelector;
+use crate::util::alloc::allocators::Allocators;
+use crate::util::{VMMutatorThread, VMWorkerThread};
+use crate::vm::VMBinding;
+use crate::Plan;
+use enum_map::EnumMap;
+
+pub fn ms_mutator_prepare<VM: VMBinding>(_mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {
+    // Do nothing
+}
+
+pub fn ms_mutator_release<VM: VMBinding>(_mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {
+    // Do nothing
+}
+
+const RESERVED_ALLOCATORS: ReservedAllocators = ReservedAllocators {
+    n_malloc: 1,
+    ..ReservedAllocators::DEFAULT
+};
+
+lazy_static! {
+    pub static ref ALLOCATOR_MAPPING: EnumMap<AllocationSemantics, AllocatorSelector> = {
+        let mut map = create_allocator_mapping(RESERVED_ALLOCATORS, true);
+        map[AllocationSemantics::Default] = AllocatorSelector::Malloc(0);
+        map
+    };
+}
+
+pub fn create_ms_mutator<VM: VMBinding>(
+    mutator_tls: VMMutatorThread,
+    plan: &'static dyn Plan<VM = VM>,
+) -> Mutator<VM> {
+    let ms = plan.downcast_ref::<ConservativeMarkSweep<VM>>().unwrap();
+    let config = MutatorConfig {
+        allocator_mapping: &*ALLOCATOR_MAPPING,
+        space_mapping: box {
+            let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, plan);
+            vec.push((AllocatorSelector::Malloc(0), ms.ms_space()));
+            vec
+        },
+        prepare_func: &ms_mutator_prepare,
+        release_func: &ms_mutator_release,
+    };
+
+    Mutator {
+        allocators: Allocators::<VM>::new(mutator_tls, plan, &config.space_mapping),
+        barrier: box NoBarrier,
+        mutator_tls,
+        config,
+        plan,
+    }
+}

--- a/src/plan/conservative/mod.rs
+++ b/src/plan/conservative/mod.rs
@@ -1,0 +1,1 @@
+pub mod marksweep;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -40,6 +40,7 @@ pub use tracelocal::TraceLocal;
 mod transitive_closure;
 pub use transitive_closure::{ObjectsClosure, TransitiveClosure};
 
+mod conservative;
 mod generational;
 mod immix;
 mod markcompact;
@@ -51,6 +52,7 @@ mod semispace;
 // Expose plan constraints as public. Though a binding can get them from plan.constraints(),
 // it is possible for performance reasons that they want the constraints as constants.
 
+pub use conservative::marksweep::CONSERVATIVE_MS_CONSTRAINTS;
 pub use generational::copying::GENCOPY_CONSTRAINTS;
 pub use immix::IMMIX_CONSTRAINTS;
 pub use markcompact::MARKCOMPACT_CONSTRAINTS;

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -359,7 +359,11 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         let start = VM::VMObjectModel::ref_to_address(object);
         self.address_in_space(start)
     }
-
+    /// Searches for object in this space conservatively. Returns `None` if `address` was not allocated in this space.
+    fn find_conservatively(&self, address: Address) -> Option<ObjectReference> {
+        let _ = address;
+        None
+    }
     /**
      * This is called after we get result from page resources.  The space may
      * tap into the hook to monitor heap growth.  The call is made from within the

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -444,6 +444,11 @@ pub trait ProcessEdgesWork:
         }
     }
 
+    fn process_conservative_roots(&mut self, start: Address, end: Address) {
+        let _ = start;
+        let _ = end;
+        unreachable!("Unable to process conservative roots under this plan.");
+    }
     /// Flush the nodes in ProcessEdgesBase, and create a ScanObjects work packet for it. If the node set is empty,
     /// this method will simply return with no work packet created.
     #[cold]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -61,4 +61,6 @@ where
     /// Note that MMTk does not attempt to do anything to align the cursor to this value, but
     /// it merely asserts with this constant.
     const ALLOC_END_ALIGNMENT: usize = 1;
+
+    const CONSERVATIVE_SCANNING: bool = false;
 }

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -266,6 +266,16 @@ pub trait ObjectModel<VM: VMBinding> {
     /// Arguments:
     /// * `object`: The object to be dumped.
     fn dump_object(object: ObjectReference);
+
+    /// Possibly decode NaN-boxed/pointer tagged value that is found on stack into real address.
+    ///
+    /// Arguments:
+    /// * `address`: The address of possibly a pointer on the stack.
+    ///
+    /// NOTE: By default this method is no-op.
+    fn decode_conservative_address(address: Address) -> Address {
+        address
+    }
 }
 
 pub mod specs {

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -7,6 +7,7 @@ use crate::vm::VMBinding;
 
 /// VM-specific methods for scanning roots/objects.
 pub trait Scanning<VM: VMBinding> {
+    const SCAN_THREAD_STACK_CONSERVATIVELY: bool = VM::CONSERVATIVE_SCANNING;
     /// Scan stack roots after all mutators are paused.
     const SCAN_MUTATORS_IN_SAFEPOINT: bool = true;
 


### PR DESCRIPTION
Started work on conservative scanning support. What is done so far:
- Added `find_conservatively` method for `Space` trait. This method should return start of the object if it is allocated (no-op by default)
- Added `decode_conservative_address` to `ObjectModel` so if VM uses NaN boxing address might be unboxed to properly scan it
- Added `VMBinding::CONSERVATIVE_SCANNING: bool` to enable conservative scanning
- Added `alive_objects` hash set to `MallocSpace` for seeing if object is allocated when doing conservative scanning
- Added `ConservativeMarkSweep` plan which implements conservative mark-sweep 

TODOs: 
~~I haven't figured out where should I put `scan_conservatie_roots` or it should be `process_conservative_roots` under ProcessEdgeWork? If so I do not know how to get access to plan and space in ProcessEdgeWork~~
EDIT: I added `process_conservative_region` to ProcessEdgeWork and support for it in `ConservativeMarkSweep` although I haven't figured out how I can get access to ObjectModel there 