### PR TITLE
ProcessEdgesBase now takes <VM> as type parameter

### DIFF
--- a/docs/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/tutorial/code/mygc_semispace/gc_work.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 // ANCHOR: mygc_process_edges
 pub struct MyGCProcessEdges<VM: VMBinding> {
     plan: &'static MyGC<VM>,
-    base: ProcessEdgesBase<MyGCProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 // ANCHOR_END: mygc_process_edges
 
@@ -61,7 +61,7 @@ impl<VM:VMBinding> ProcessEdgesWork for MyGCProcessEdges<VM> {
 
 // ANCHOR: deref
 impl<VM: VMBinding> Deref for MyGCProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/src/plan/generational/copying/gc_work.rs
+++ b/src/plan/generational/copying/gc_work.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 pub struct GenCopyMatureProcessEdges<VM: VMBinding> {
     plan: &'static GenCopy<VM>,
-    base: ProcessEdgesBase<GenCopyMatureProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> GenCopyMatureProcessEdges<VM> {
@@ -51,7 +51,7 @@ impl<VM: VMBinding> ProcessEdgesWork for GenCopyMatureProcessEdges<VM> {
 }
 
 impl<VM: VMBinding> Deref for GenCopyMatureProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     fn deref(&self) -> &Self::Target {
         &self.base
     }

--- a/src/plan/generational/gc_work.rs
+++ b/src/plan/generational/gc_work.rs
@@ -9,7 +9,7 @@ use std::ops::{Deref, DerefMut};
 /// Process edges for a nursery GC. A generatinoal plan should use this type for a nursery GC.
 pub struct GenNurseryProcessEdges<VM: VMBinding> {
     gen: &'static Gen<VM>,
-    base: ProcessEdgesBase<GenNurseryProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> ProcessEdgesWork for GenNurseryProcessEdges<VM> {
@@ -37,7 +37,7 @@ impl<VM: VMBinding> ProcessEdgesWork for GenNurseryProcessEdges<VM> {
 }
 
 impl<VM: VMBinding> Deref for GenNurseryProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     fn deref(&self) -> &Self::Target {
         &self.base
     }

--- a/src/plan/generational/immix/gc_work.rs
+++ b/src/plan/generational/immix/gc_work.rs
@@ -17,7 +17,7 @@ use crate::plan::immix::gc_work::TraceKind;
 /// of process_edge() as the immix plan does).
 pub(super) struct GenImmixMatureProcessEdges<VM: VMBinding, const KIND: TraceKind> {
     plan: &'static GenImmix<VM>,
-    base: ProcessEdgesBase<GenImmixMatureProcessEdges<VM, KIND>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding, const KIND: TraceKind> ProcessEdgesWork
@@ -71,7 +71,7 @@ impl<VM: VMBinding, const KIND: TraceKind> ProcessEdgesWork
 }
 
 impl<VM: VMBinding, const KIND: TraceKind> Deref for GenImmixMatureProcessEdges<VM, KIND> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/src/plan/immix/gc_work.rs
+++ b/src/plan/immix/gc_work.rs
@@ -17,7 +17,7 @@ pub(super) struct ImmixProcessEdges<VM: VMBinding, const KIND: TraceKind> {
     // Use a static ref to the specific plan to avoid overhead from dynamic dispatch or
     // downcast for each traced object.
     plan: &'static Immix<VM>,
-    base: ProcessEdgesBase<Self>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding, const KIND: TraceKind> ImmixProcessEdges<VM, KIND> {
@@ -83,7 +83,7 @@ impl<VM: VMBinding, const KIND: TraceKind> ProcessEdgesWork for ImmixProcessEdge
 }
 
 impl<VM: VMBinding, const KIND: TraceKind> Deref for ImmixProcessEdges<VM, KIND> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -86,7 +86,7 @@ impl<VM: VMBinding> Compact<VM> {
 // Transitive closure to mark live objects
 pub struct MarkingProcessEdges<VM: VMBinding> {
     plan: &'static MarkCompact<VM>,
-    base: ProcessEdgesBase<MarkingProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> MarkingProcessEdges<VM> {
@@ -119,7 +119,7 @@ impl<VM: VMBinding> ProcessEdgesWork for MarkingProcessEdges<VM> {
 }
 
 impl<VM: VMBinding> Deref for MarkingProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base
@@ -136,7 +136,7 @@ impl<VM: VMBinding> DerefMut for MarkingProcessEdges<VM> {
 /// Transitive closure to update object references
 pub struct ForwardingProcessEdges<VM: VMBinding> {
     plan: &'static MarkCompact<VM>,
-    base: ProcessEdgesBase<ForwardingProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> ForwardingProcessEdges<VM> {
@@ -169,7 +169,7 @@ impl<VM: VMBinding> ProcessEdgesWork for ForwardingProcessEdges<VM> {
 }
 
 impl<VM: VMBinding> Deref for ForwardingProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/src/plan/marksweep/gc_work.rs
+++ b/src/plan/marksweep/gc_work.rs
@@ -17,7 +17,7 @@ use super::MarkSweep;
 
 pub struct MSProcessEdges<VM: VMBinding> {
     plan: &'static MarkSweep<VM>,
-    base: ProcessEdgesBase<MSProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> ProcessEdgesWork for MSProcessEdges<VM> {
@@ -45,7 +45,7 @@ impl<VM: VMBinding> ProcessEdgesWork for MSProcessEdges<VM> {
 }
 
 impl<VM: VMBinding> Deref for MSProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/src/plan/pageprotect/gc_work.rs
+++ b/src/plan/pageprotect/gc_work.rs
@@ -11,7 +11,7 @@ pub struct PPProcessEdges<VM: VMBinding> {
     /// Use a static ref to the specific plan to avoid overhead from dynamic dispatch or
     /// downcast for each traced object.
     plan: &'static PageProtect<VM>,
-    base: ProcessEdgesBase<PPProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> ProcessEdgesWork for PPProcessEdges<VM> {
@@ -41,7 +41,7 @@ impl<VM: VMBinding> ProcessEdgesWork for PPProcessEdges<VM> {
 }
 
 impl<VM: VMBinding> Deref for PPProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/src/plan/semispace/gc_work.rs
+++ b/src/plan/semispace/gc_work.rs
@@ -11,7 +11,7 @@ pub struct SSProcessEdges<VM: VMBinding> {
     // Use a static ref to the specific plan to avoid overhead from dynamic dispatch or
     // downcast for each traced object.
     plan: &'static SemiSpace<VM>,
-    base: ProcessEdgesBase<SSProcessEdges<VM>>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> SSProcessEdges<VM> {
@@ -52,7 +52,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SSProcessEdges<VM> {
 }
 
 impl<VM: VMBinding> Deref for SSProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -323,22 +323,22 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanVMSpecificRoots<E> {
     }
 }
 
-pub struct ProcessEdgesBase<E: ProcessEdgesWork> {
+pub struct ProcessEdgesBase<VM: VMBinding> {
     pub edges: Vec<Address>,
     pub nodes: Vec<ObjectReference>,
-    mmtk: &'static MMTK<E::VM>,
+    mmtk: &'static MMTK<VM>,
     // Use raw pointer for fast pointer dereferencing, instead of using `Option<&'static mut GCWorker<E::VM>>`.
     // Because a copying gc will dereference this pointer at least once for every object copy.
-    worker: *mut GCWorker<E::VM>,
+    worker: *mut GCWorker<VM>,
     pub roots: bool,
 }
 
-unsafe impl<E: ProcessEdgesWork> Send for ProcessEdgesBase<E> {}
+unsafe impl<VM: VMBinding> Send for ProcessEdgesBase<VM> {}
 
-impl<E: ProcessEdgesWork> ProcessEdgesBase<E> {
+impl<VM: VMBinding> ProcessEdgesBase<VM> {
     // Requires an MMTk reference. Each plan-specific type that uses ProcessEdgesBase can get a static plan reference
     // at creation. This avoids overhead for dynamic dispatch or downcasting plan for each object traced.
-    pub fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<E::VM>) -> Self {
+    pub fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         #[cfg(feature = "extreme_assertions")]
         if crate::util::edge_logger::should_check_duplicate_edges(&*mmtk.plan) {
             for edge in &edges {
@@ -354,19 +354,19 @@ impl<E: ProcessEdgesWork> ProcessEdgesBase<E> {
             roots,
         }
     }
-    pub fn set_worker(&mut self, worker: &mut GCWorker<E::VM>) {
+    pub fn set_worker(&mut self, worker: &mut GCWorker<VM>) {
         self.worker = worker;
     }
     #[inline]
-    pub fn worker(&self) -> &'static mut GCWorker<E::VM> {
+    pub fn worker(&self) -> &'static mut GCWorker<VM> {
         unsafe { &mut *self.worker }
     }
     #[inline]
-    pub fn mmtk(&self) -> &'static MMTK<E::VM> {
+    pub fn mmtk(&self) -> &'static MMTK<VM> {
         self.mmtk
     }
     #[inline]
-    pub fn plan(&self) -> &'static dyn Plan<VM = E::VM> {
+    pub fn plan(&self) -> &'static dyn Plan<VM = VM> {
         &*self.mmtk.plan
     }
     /// Pop all nodes from nodes, and clear nodes to an empty vector.
@@ -384,7 +384,7 @@ impl<E: ProcessEdgesWork> ProcessEdgesBase<E> {
 
 /// Scan & update a list of object slots
 pub trait ProcessEdgesWork:
-    Send + 'static + Sized + DerefMut + Deref<Target = ProcessEdgesBase<Self>>
+    Send + 'static + Sized + DerefMut + Deref<Target = ProcessEdgesBase<Self::VM>>
 {
     type VM: VMBinding;
 

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -141,12 +141,11 @@ impl<P: Plan> GCWork<P::VM> for SanityRelease<P> {
 
 // #[derive(Default)]
 pub struct SanityGCProcessEdges<VM: VMBinding> {
-    base: ProcessEdgesBase<SanityGCProcessEdges<VM>>,
-    // phantom: PhantomData<VM>,
+    base: ProcessEdgesBase<VM>,
 }
 
 impl<VM: VMBinding> Deref for SanityGCProcessEdges<VM> {
-    type Target = ProcessEdgesBase<Self>;
+    type Target = ProcessEdgesBase<VM>;
     fn deref(&self) -> &Self::Target {
         &self.base
     }


### PR DESCRIPTION
This PR simplifies type parmeter for `ProcessEdgesBase` (from `ProcessEdgesWork` to `VM`).