### PR TITLE
Prepare plan before compacting in MarkCompact

### DIFF
--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -194,8 +194,9 @@ pub trait Plan: 'static + Sync + Downcast {
             .load(Ordering::SeqCst)
     }
 
-    /// Prepare the plan before a GC. This is invoked in an initial step in the GC.
-    /// This is invoked once per GC by one worker thread. 'tls' is the worker thread that executes this method.
+    /// Prepare the plan before a transitive closure. This is invoked in an initial step before a transitive closure.
+    /// This is invoked once for each transitive closure by one worker thread. If a plan does multiple traces,
+    /// this method is expected to be called before each trace. 'tls' is the worker thread that executes this method.
     fn prepare(&mut self, tls: VMWorkerThread);
 
     /// Prepare a worker for a GC. Each worker has its own prepare method. This hook is for plan-specific

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -52,6 +52,7 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
             use crate::plan::global::Plan;
             let plan: &MarkCompact<VM> = mmtk.plan.downcast_ref::<MarkCompact<VM>>().unwrap();
             // This should be the only packet that is executing at the point.
+            #[allow(clippy::cast_ref_to_mut)]
             let plan_mut: &mut MarkCompact<VM> = unsafe { &mut *(plan as *const _ as *mut _) };
             plan_mut.prepare(_worker.tls);
         }

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -27,11 +27,12 @@ use crate::util::opaque_pointer::*;
 use crate::util::options::UnsafeOptionsWrapper;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
+use std::sync::Arc;
 
 #[cfg(debug_assertions)]
-use std::{collections::HashSet, sync::{Arc, Mutex}};
-#[cfg(debug_assertions)]
 use crate::util::ObjectReference;
+#[cfg(debug_assertions)]
+use std::{collections::HashSet, sync::Mutex};
 
 pub struct MarkCompact<VM: VMBinding> {
     pub mc_space: MarkCompactSpace<VM>,

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -153,7 +153,6 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
 
     pub fn prepare(&mut self, full_heap: bool) {
         if full_heap {
-            debug_assert!(self.treadmill.from_space_empty());
             self.mark_state = MARK_BIT - self.mark_state;
         }
         self.treadmill.flip(full_heap);


### PR DESCRIPTION
This PR closes https://github.com/mmtk/mmtk-core/issues/520.

This PR
1. adds a proper `max_non_los_default_alloc_bytes` for mark compact
2. adds a `prepare()` call for mark compact before the compact transitive closure
3. adds some assertions to check if the two traces in mark compact traverse the same set of objects
4. removes an assertion from LOS prepare