### PR TITLE
Add prefix to MMTk API

### DIFF
--- a/examples/allocation_benchmark.c
+++ b/examples/allocation_benchmark.c
@@ -5,11 +5,11 @@
 
 int main() {
     volatile uint64_t * tmp;
-    gc_init(1024*1024*1024);
-    MMTk_Mutator handle = bind_mutator(0);
+    mmtk_gc_init(1024*1024*1024);
+    MMTk_Mutator handle = mmtk_bind_mutator(0);
 
     for (int i=0; i<1024*1024*100; i++) {
-        tmp = alloc(handle, 8, 1, 0, 0);
+        tmp = mmtk_alloc(handle, 8, 1, 0, 0);
         #ifdef STORE
             *tmp = 42;
         #endif

--- a/examples/main.c
+++ b/examples/main.c
@@ -2,13 +2,13 @@
 #include "mmtk.h"
 
 int main(int argc, char* argv[]){
-    gc_init(1024*1024);
+    mmtk_gc_init(1024*1024);
 
-    MMTk_Mutator handle = bind_mutator(0);
-    
+    MMTk_Mutator handle = mmtk_bind_mutator(0);
+
     for (int i=0;i<4;i++){
         int arr_size = 10000;
-        int* my_arr = alloc(handle, sizeof(int)*arr_size, 8, 0, 0);
+        int* my_arr = mmtk_alloc(handle, sizeof(int)*arr_size, 8, 0, 0);
         if (!my_arr){
             printf("OOM\n");
             break;

--- a/examples/mmtk.h
+++ b/examples/mmtk.h
@@ -1,8 +1,9 @@
 // This is an example of native API for the single instance MMTk.
 
-// Note: the mmtk core does not directly provide this API. However, it provides a similar multi-instance Rust API.
-// A VM binding should write their own C header file (possibly based on this example with their own extension and modification),
-// and expose the Rust API based on their native API.
+// Note: the mmtk core does not directly provide this API. However, it provides
+// a similar multi-instance Rust API.  A VM binding should write their own C
+// header file (possibly based on this example with their own extension and
+// modification), and expose the Rust API based on their native API.
 
 #ifndef MMTK_H
 #define MMTK_H
@@ -15,79 +16,113 @@ extern "C" {
 #endif
 
 typedef void* MMTk_Mutator;
-typedef void* MMTk_TraceLocal;
 
-/**
- * Allocation
- */
-extern MMTk_Mutator bind_mutator(void *tls);
-extern void destroy_mutator(MMTk_Mutator mutator);
+// Initialize an MMTk instance
+extern void mmtk_gc_init(size_t heap_size);
 
-extern void* alloc(MMTk_Mutator mutator, size_t size,
-    size_t align, ssize_t offset, int allocator);
+// Request MMTk to create a new mutator for the given `tls` thread
+extern MMTk_Mutator mmtk_bind_mutator(void* tls);
 
-extern void* alloc_slow(MMTk_Mutator mutator, size_t size,
-    size_t align, ssize_t offset, int allocator);
+// Reclaim mutator that is no longer needed
+extern void mmtk_destroy_mutator(MMTk_Mutator mutator);
 
-extern void post_alloc(MMTk_Mutator mutator, void* refer, void* type_refer,
-    int bytes, int allocator);
+// Flush mutator local state
+extern void mmtk_flush_mutator(MMTk_Mutator mutator);
 
-extern bool is_live_object(void* ref);
-extern bool is_mapped_object(void* ref);
-extern bool is_mapped_address(void* addr);
-extern void modify_check(void* ref);
+// Initialize MMTk scheduler and GC workers
+extern void mmtk_initialize_collection(void* tls);
 
-/**
- * Tracing
- */
-extern void report_delayed_root_edge(MMTk_TraceLocal trace_local,
-                                     void* addr);
+// Allow MMTk to perform a GC when the heap is full
+extern void mmtk_enable_collection();
 
-extern bool will_not_move_in_current_collection(MMTk_TraceLocal trace_local,
-                                                void* obj);
+// Disallow MMTk to perform a GC when the heap is full
+extern void mmtk_disable_collection();
 
-extern void process_interior_edge(MMTk_TraceLocal trace_local, void* target,
-                                  void* slot, bool root);
+// Allocate memory for an object
+extern void* mmtk_alloc(MMTk_Mutator mutator,
+                        size_t size,
+                        size_t align,
+                        ssize_t offset,
+                        int allocator);
 
-extern void* trace_get_forwarded_referent(MMTk_TraceLocal trace_local, void* obj);
+// Slowpath allocation for an object
+extern void* mmtk_alloc_slow(MMTk_Mutator mutator,
+                             size_t size,
+                             size_t align,
+                             ssize_t offset,
+                             int allocator);
 
-extern void* trace_get_forwarded_reference(MMTk_TraceLocal trace_local, void* obj);
+// Perform post-allocation hooks or actions such as initializing object metadata
+extern void mmtk_post_alloc(MMTk_Mutator mutator,
+                            void* refer,
+                            int bytes,
+                            int allocator);
 
-extern void* trace_retain_referent(MMTk_TraceLocal trace_local, void* obj);
+// Return if the object pointed to by `ref` is live
+extern bool mmtk_is_live_object(void* ref);
 
-/**
- * Misc
- */
-extern void gc_init(size_t heap_size);
-extern bool will_never_move(void* object);
-extern bool process(char* name, char* value);
-extern void scan_region();
-extern void handle_user_collection_request(void *tls);
+// Return if the object pointed to by `ref` is in mapped memory
+extern bool mmtk_is_mapped_object(void* ref);
 
-extern void start_control_collector(void *tls);
-extern void start_worker(void *tls, void* worker);
+// Return if the address pointed to by `addr` is in mapped memory
+extern bool mmtk_is_mapped_address(void* addr);
 
-/**
- * VM Accounting
- */
-extern size_t free_bytes();
-extern size_t total_bytes();
-extern size_t used_bytes();
-extern void* starting_heap_address();
-extern void* last_heap_address();
+// Check if a GC is in progress and if the object `ref` is movable
+extern void mmtk_modify_check(void* ref);
 
-/**
- * Reference Processing
- */
-extern void add_weak_candidate(void* ref, void* referent);
-extern void add_soft_candidate(void* ref, void* referent);
-extern void add_phantom_candidate(void* ref, void* referent);
+// Return if object pointed to by `object` will never move
+extern bool mmtk_will_never_move(void* object);
 
-extern void harness_begin(void *tls);
-extern void harness_end();
+// Process an MMTk option. Return true if option was processed successfully
+extern bool mmtk_process(char* name, char* value);
+
+// Process MMTk options. Return true if all options were processed successfully
+extern bool mmtk_process_bulk(char* options);
+
+// Sanity only. Scan heap for discrepancies and errors
+extern void mmtk_scan_region();
+
+// Request MMTk to trigger a GC. Note that this may not actually trigger a GC
+extern void mmtk_handle_user_collection_request(void* tls);
+
+// Run the main loop for the GC controller thread. Does not return
+extern void mmtk_start_control_collector(void* tls);
+
+// Run the main loop for a GC worker. Does not return
+extern void mmtk_start_worker(void* tls, void* worker);
+
+// Return the current amount of free memory in bytes
+extern size_t mmtk_free_bytes();
+
+// Return the current amount of used memory in bytes
+extern size_t mmtk_used_bytes();
+
+// Return the current amount of total memory in bytes
+extern size_t mmtk_total_bytes();
+
+// Return the starting address of MMTk's heap
+extern void* mmtk_starting_heap_address();
+
+// Return the ending address of MMTk's heap
+extern void* mmtk_last_heap_address();
+
+// Add a reference to the list of weak references
+extern void mmtk_add_weak_candidate(void* ref, void* referent);
+
+// Add a reference to the list of soft references
+extern void mmtk_add_soft_candidate(void* ref, void* referent);
+
+// Add a reference to the list of phantom references
+extern void mmtk_add_phantom_candidate(void* ref, void* referent);
+
+// Generic hook to allow benchmarks to be harnessed
+extern void mmtk_harness_begin(void* tls);
+
+// Generic hook to allow benchmarks to be harnessed
+extern void mmtk_harness_end();
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // MMTK_H
+#endif  // MMTK_H

--- a/vmbindings/dummyvm/api/mmtk.h
+++ b/vmbindings/dummyvm/api/mmtk.h
@@ -1,3 +1,10 @@
+// This is an example of native API for the single instance MMTk.
+
+// Note: the mmtk core does not directly provide this API. However, it provides
+// a similar multi-instance Rust API.  A VM binding should write their own C
+// header file (possibly based on this example with their own extension and
+// modification), and expose the Rust API based on their native API.
+
 #ifndef MMTK_H
 #define MMTK_H
 
@@ -9,75 +16,113 @@ extern "C" {
 #endif
 
 typedef void* MMTk_Mutator;
-typedef void* MMTk_TraceLocal;
 
-/**
- * Allocation
- */
-extern MMTk_Mutator bind_mutator(void *tls);
-extern void destroy_mutator(MMTk_Mutator mutator);
+// Initialize an MMTk instance
+extern void mmtk_gc_init(size_t heap_size);
 
-extern void* alloc(MMTk_Mutator mutator, size_t size,
-    size_t align, size_t offset, int allocator);
+// Request MMTk to create a new mutator for the given `tls` thread
+extern MMTk_Mutator mmtk_bind_mutator(void* tls);
 
-extern void post_alloc(MMTk_Mutator mutator, void* refer,
-    int bytes, int allocator);
+// Reclaim mutator that is no longer needed
+extern void mmtk_destroy_mutator(MMTk_Mutator mutator);
 
-extern bool is_live_object(void* ref);
-extern bool is_mapped_object(void* ref);
-extern bool is_mapped_address(void* addr);
-extern void modify_check(void* ref);
+// Flush mutator local state
+extern void mmtk_flush_mutator(MMTk_Mutator mutator);
 
-/**
- * Tracing
- */
-extern void report_delayed_root_edge(MMTk_TraceLocal trace_local,
-                                     void* addr);
+// Initialize MMTk scheduler and GC workers
+extern void mmtk_initialize_collection(void* tls);
 
-extern bool will_not_move_in_current_collection(MMTk_TraceLocal trace_local,
-                                                void* obj);
+// Allow MMTk to perform a GC when the heap is full
+extern void mmtk_enable_collection();
 
-extern void process_interior_edge(MMTk_TraceLocal trace_local, void* target,
-                                  void* slot, bool root);
+// Disallow MMTk to perform a GC when the heap is full
+extern void mmtk_disable_collection();
 
-extern void* trace_get_forwarded_referent(MMTk_TraceLocal trace_local, void* obj);
+// Allocate memory for an object
+extern void* mmtk_alloc(MMTk_Mutator mutator,
+                        size_t size,
+                        size_t align,
+                        ssize_t offset,
+                        int allocator);
 
-extern void* trace_get_forwarded_reference(MMTk_TraceLocal trace_local, void* obj);
+// Slowpath allocation for an object
+extern void* mmtk_alloc_slow(MMTk_Mutator mutator,
+                             size_t size,
+                             size_t align,
+                             ssize_t offset,
+                             int allocator);
 
-extern void* trace_retain_referent(MMTk_TraceLocal trace_local, void* obj);
+// Perform post-allocation hooks or actions such as initializing object metadata
+extern void mmtk_post_alloc(MMTk_Mutator mutator,
+                            void* refer,
+                            int bytes,
+                            int allocator);
 
-/**
- * Misc
- */
-extern void gc_init(size_t heap_size);
-extern bool will_never_move(void* object);
-extern bool process(char* name, char* value);
-extern void handle_user_collection_request(void *tls);
+// Return if the object pointed to by `ref` is live
+extern bool mmtk_is_live_object(void* ref);
 
-extern void start_control_collector(void *tls);
-extern void start_worker(void *tls, void* worker, void* mmtk);
+// Return if the object pointed to by `ref` is in mapped memory
+extern bool mmtk_is_mapped_object(void* ref);
 
-/**
- * VM Accounting
- */
-extern size_t free_bytes();
-extern size_t total_bytes();
-extern size_t used_bytes();
-extern void* starting_heap_address();
-extern void* last_heap_address();
+// Return if the address pointed to by `addr` is in mapped memory
+extern bool mmtk_is_mapped_address(void* addr);
 
-/**
- * Reference Processing
- */
-extern void add_weak_candidate(void* ref, void* referent);
-extern void add_soft_candidate(void* ref, void* referent);
-extern void add_phantom_candidate(void* ref, void* referent);
+// Check if a GC is in progress and if the object `ref` is movable
+extern void mmtk_modify_check(void* ref);
 
-extern void harness_begin(void *tls);
-extern void harness_end();
+// Return if object pointed to by `object` will never move
+extern bool mmtk_will_never_move(void* object);
+
+// Process an MMTk option. Return true if option was processed successfully
+extern bool mmtk_process(char* name, char* value);
+
+// Process MMTk options. Return true if all options were processed successfully
+extern bool mmtk_process_bulk(char* options);
+
+// Sanity only. Scan heap for discrepancies and errors
+extern void mmtk_scan_region();
+
+// Request MMTk to trigger a GC. Note that this may not actually trigger a GC
+extern void mmtk_handle_user_collection_request(void* tls);
+
+// Run the main loop for the GC controller thread. Does not return
+extern void mmtk_start_control_collector(void* tls);
+
+// Run the main loop for a GC worker. Does not return
+extern void mmtk_start_worker(void* tls, void* worker);
+
+// Return the current amount of free memory in bytes
+extern size_t mmtk_free_bytes();
+
+// Return the current amount of used memory in bytes
+extern size_t mmtk_used_bytes();
+
+// Return the current amount of total memory in bytes
+extern size_t mmtk_total_bytes();
+
+// Return the starting address of MMTk's heap
+extern void* mmtk_starting_heap_address();
+
+// Return the ending address of MMTk's heap
+extern void* mmtk_last_heap_address();
+
+// Add a reference to the list of weak references
+extern void mmtk_add_weak_candidate(void* ref, void* referent);
+
+// Add a reference to the list of soft references
+extern void mmtk_add_soft_candidate(void* ref, void* referent);
+
+// Add a reference to the list of phantom references
+extern void mmtk_add_phantom_candidate(void* ref, void* referent);
+
+// Generic hook to allow benchmarks to be harnessed
+extern void mmtk_harness_begin(void* tls);
+
+// Generic hook to allow benchmarks to be harnessed
+extern void mmtk_harness_end();
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // MMTK_H
+#endif  // MMTK_H

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -14,7 +14,7 @@ use DummyVM;
 use SINGLETON;
 
 #[no_mangle]
-pub extern "C" fn gc_init(heap_size: usize) {
+pub extern "C" fn mmtk_gc_init(heap_size: usize) {
     // # Safety
     // Casting `SINGLETON` as mutable is safe because `gc_init` will only be executed once by a single thread during startup.
     #[allow(clippy::cast_ref_to_mut)]
@@ -23,22 +23,22 @@ pub extern "C" fn gc_init(heap_size: usize) {
 }
 
 #[no_mangle]
-pub extern "C" fn start_control_collector(tls: VMWorkerThread) {
+pub extern "C" fn mmtk_start_control_collector(tls: VMWorkerThread) {
     memory_manager::start_control_collector(&SINGLETON, tls);
 }
 
 #[no_mangle]
-pub extern "C" fn bind_mutator(tls: VMMutatorThread) -> *mut Mutator<DummyVM> {
+pub extern "C" fn mmtk_bind_mutator(tls: VMMutatorThread) -> *mut Mutator<DummyVM> {
     Box::into_raw(memory_manager::bind_mutator(&SINGLETON, tls))
 }
 
 #[no_mangle]
-pub extern "C" fn destroy_mutator(mutator: *mut Mutator<DummyVM>) {
+pub extern "C" fn mmtk_destroy_mutator(mutator: *mut Mutator<DummyVM>) {
     memory_manager::destroy_mutator(unsafe { Box::from_raw(mutator) })
 }
 
 #[no_mangle]
-pub extern "C" fn alloc(mutator: *mut Mutator<DummyVM>, size: usize,
+pub extern "C" fn mmtk_alloc(mutator: *mut Mutator<DummyVM>, size: usize,
                     align: usize, offset: isize, mut semantics: AllocationSemantics) -> Address {
     if size >= SINGLETON.get_plan().constraints().max_non_los_default_alloc_bytes {
         semantics = AllocationSemantics::Los;
@@ -47,7 +47,7 @@ pub extern "C" fn alloc(mutator: *mut Mutator<DummyVM>, size: usize,
 }
 
 #[no_mangle]
-pub extern "C" fn post_alloc(mutator: *mut Mutator<DummyVM>, refer: ObjectReference,
+pub extern "C" fn mmtk_post_alloc(mutator: *mut Mutator<DummyVM>, refer: ObjectReference,
                                         bytes: usize, mut semantics: AllocationSemantics) {
     if bytes >= SINGLETON.get_plan().constraints().max_non_los_default_alloc_bytes {
         semantics = AllocationSemantics::Los;
@@ -56,108 +56,108 @@ pub extern "C" fn post_alloc(mutator: *mut Mutator<DummyVM>, refer: ObjectRefere
 }
 
 #[no_mangle]
-pub extern "C" fn will_never_move(object: ObjectReference) -> bool {
+pub extern "C" fn mmtk_will_never_move(object: ObjectReference) -> bool {
     !object.is_movable()
 }
 
 #[no_mangle]
-pub extern "C" fn start_worker(tls: VMWorkerThread, worker: &'static mut GCWorker<DummyVM>, mmtk: &'static MMTK<DummyVM>) {
+pub extern "C" fn mmtk_start_worker(tls: VMWorkerThread, worker: &'static mut GCWorker<DummyVM>, mmtk: &'static MMTK<DummyVM>) {
     memory_manager::start_worker::<DummyVM>(tls, worker, mmtk)
 }
 
 #[no_mangle]
-pub extern "C" fn initialize_collection(tls: VMThread) {
+pub extern "C" fn mmtk_initialize_collection(tls: VMThread) {
     memory_manager::initialize_collection(&SINGLETON, tls)
 }
 
 #[no_mangle]
-pub extern "C" fn disable_collection() {
+pub extern "C" fn mmtk_disable_collection() {
     memory_manager::disable_collection(&SINGLETON)
 }
 
 #[no_mangle]
-pub extern "C" fn enable_collection() {
+pub extern "C" fn mmtk_enable_collection() {
     memory_manager::enable_collection(&SINGLETON)
 }
 
 #[no_mangle]
-pub extern "C" fn used_bytes() -> usize {
+pub extern "C" fn mmtk_used_bytes() -> usize {
     memory_manager::used_bytes(&SINGLETON)
 }
 
 #[no_mangle]
-pub extern "C" fn free_bytes() -> usize {
+pub extern "C" fn mmtk_free_bytes() -> usize {
     memory_manager::free_bytes(&SINGLETON)
 }
 
 #[no_mangle]
-pub extern "C" fn total_bytes() -> usize {
+pub extern "C" fn mmtk_total_bytes() -> usize {
     memory_manager::total_bytes(&SINGLETON)
 }
 
 #[no_mangle]
-pub extern "C" fn is_live_object(object: ObjectReference) -> bool{
+pub extern "C" fn mmtk_is_live_object(object: ObjectReference) -> bool{
     object.is_live()
 }
 
 #[no_mangle]
-pub extern "C" fn is_mapped_object(object: ObjectReference) -> bool {
+pub extern "C" fn mmtk_is_mapped_object(object: ObjectReference) -> bool {
     object.is_mapped()
 }
 
 #[no_mangle]
-pub extern "C" fn is_mapped_address(address: Address) -> bool {
+pub extern "C" fn mmtk_is_mapped_address(address: Address) -> bool {
     address.is_mapped()
 }
 
 #[no_mangle]
-pub extern "C" fn modify_check(object: ObjectReference) {
+pub extern "C" fn mmtk_modify_check(object: ObjectReference) {
     memory_manager::modify_check(&SINGLETON, object)
 }
 
 #[no_mangle]
-pub extern "C" fn handle_user_collection_request(tls: VMMutatorThread) {
+pub extern "C" fn mmtk_handle_user_collection_request(tls: VMMutatorThread) {
     memory_manager::handle_user_collection_request::<DummyVM>(&SINGLETON, tls);
 }
 
 #[no_mangle]
-pub extern "C" fn add_weak_candidate(reff: ObjectReference, referent: ObjectReference) {
+pub extern "C" fn mmtk_add_weak_candidate(reff: ObjectReference, referent: ObjectReference) {
     memory_manager::add_weak_candidate(&SINGLETON, reff, referent)
 }
 
 #[no_mangle]
-pub extern "C" fn add_soft_candidate(reff: ObjectReference, referent: ObjectReference) {
+pub extern "C" fn mmtk_add_soft_candidate(reff: ObjectReference, referent: ObjectReference) {
     memory_manager::add_soft_candidate(&SINGLETON, reff, referent)
 }
 
 #[no_mangle]
-pub extern "C" fn add_phantom_candidate(reff: ObjectReference, referent: ObjectReference) {
+pub extern "C" fn mmtk_add_phantom_candidate(reff: ObjectReference, referent: ObjectReference) {
     memory_manager::add_phantom_candidate(&SINGLETON, reff, referent)
 }
 
 #[no_mangle]
-pub extern "C" fn harness_begin(tls: VMMutatorThread) {
+pub extern "C" fn mmtk_harness_begin(tls: VMMutatorThread) {
     memory_manager::harness_begin(&SINGLETON, tls)
 }
 
 #[no_mangle]
-pub extern "C" fn harness_end() {
+pub extern "C" fn mmtk_harness_end() {
     memory_manager::harness_end(&SINGLETON)
 }
 
 #[no_mangle]
-pub extern "C" fn process(name: *const c_char, value: *const c_char) -> bool {
+pub extern "C" fn mmtk_process(name: *const c_char, value: *const c_char) -> bool {
     let name_str: &CStr = unsafe { CStr::from_ptr(name) };
     let value_str: &CStr = unsafe { CStr::from_ptr(value) };
     memory_manager::process(&SINGLETON, name_str.to_str().unwrap(), value_str.to_str().unwrap())
 }
 
 #[no_mangle]
-pub extern "C" fn starting_heap_address() -> Address {
+pub extern "C" fn mmtk_starting_heap_address() -> Address {
     memory_manager::starting_heap_address()
 }
 
 #[no_mangle]
-pub extern "C" fn last_heap_address() -> Address {
+pub extern "C" fn mmtk_last_heap_address() -> Address {
     memory_manager::last_heap_address()
 }

--- a/vmbindings/dummyvm/src/tests/allocate_with_disable_collection.rs
+++ b/vmbindings/dummyvm/src/tests/allocate_with_disable_collection.rs
@@ -8,15 +8,15 @@ use mmtk::AllocationSemantics;
 pub fn allocate_with_disable_collection() {
     const MB: usize = 1024 * 1024;
     // 1MB heap
-    gc_init(MB);
-    initialize_collection(VMThread::UNINITIALIZED);
-    let handle = bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
+    mmtk_gc_init(MB);
+    mmtk_initialize_collection(VMThread::UNINITIALIZED);
+    let handle = mmtk_bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
     // Allocate 1MB. It should be fine.
-    let addr = alloc(handle, MB, 8, 0, AllocationSemantics::Default);
+    let addr = mmtk_alloc(handle, MB, 8, 0, AllocationSemantics::Default);
     assert!(!addr.is_zero());
     // Disable GC
-    disable_collection();
+    mmtk_disable_collection();
     // Allocate another MB. This exceeds the heap size. But as we have disabled GC, MMTk will not trigger a GC, and allow this allocation.
-    let addr = alloc(handle, MB, 8, 0, AllocationSemantics::Default);
+    let addr = mmtk_alloc(handle, MB, 8, 0, AllocationSemantics::Default);
     assert!(!addr.is_zero());
 }

--- a/vmbindings/dummyvm/src/tests/allocate_with_initialize_collection.rs
+++ b/vmbindings/dummyvm/src/tests/allocate_with_initialize_collection.rs
@@ -9,10 +9,10 @@ use mmtk::AllocationSemantics;
 pub fn allocate_with_initialize_collection() {
     const MB: usize = 1024 * 1024;
     // 1MB heap
-    gc_init(MB);
-    initialize_collection(VMThread::UNINITIALIZED);
-    let handle = bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
+    mmtk_gc_init(MB);
+    mmtk_initialize_collection(VMThread::UNINITIALIZED);
+    let handle = mmtk_bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
     // Attempt to allocate 2MB. This will trigger GC.
-    let addr = alloc(handle, 2 * MB, 8, 0, AllocationSemantics::Default);
+    let addr = mmtk_alloc(handle, 2 * MB, 8, 0, AllocationSemantics::Default);
     assert!(!addr.is_zero());
 }

--- a/vmbindings/dummyvm/src/tests/allocate_with_re_enable_collection.rs
+++ b/vmbindings/dummyvm/src/tests/allocate_with_re_enable_collection.rs
@@ -9,18 +9,18 @@ use mmtk::AllocationSemantics;
 pub fn allocate_with_re_enable_collection() {
     const MB: usize = 1024 * 1024;
     // 1MB heap
-    gc_init(MB);
-    initialize_collection(VMThread::UNINITIALIZED);
-    let handle = bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
+    mmtk_gc_init(MB);
+    mmtk_initialize_collection(VMThread::UNINITIALIZED);
+    let handle = mmtk_bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
     // Allocate 1MB. It should be fine.
-    let addr = alloc(handle, MB, 8, 0, AllocationSemantics::Default);
+    let addr = mmtk_alloc(handle, MB, 8, 0, AllocationSemantics::Default);
     assert!(!addr.is_zero());
     // Disable GC. So we can keep allocate without triggering a GC.
-    disable_collection();
-    let addr = alloc(handle, MB, 8, 0, AllocationSemantics::Default);
+    mmtk_disable_collection();
+    let addr = mmtk_alloc(handle, MB, 8, 0, AllocationSemantics::Default);
     assert!(!addr.is_zero());
     // Enable GC again. When we allocate, we should see a GC triggered immediately.
-    enable_collection();
-    let addr = alloc(handle, MB, 8, 0, AllocationSemantics::Default);
+    mmtk_enable_collection();
+    let addr = mmtk_alloc(handle, MB, 8, 0, AllocationSemantics::Default);
     assert!(!addr.is_zero());
 }

--- a/vmbindings/dummyvm/src/tests/allocate_without_initialize_collection.rs
+++ b/vmbindings/dummyvm/src/tests/allocate_without_initialize_collection.rs
@@ -9,9 +9,9 @@ use mmtk::AllocationSemantics;
 pub fn allocate_without_initialize_collection() {
     const MB: usize = 1024 * 1024;
     // 1MB heap
-    gc_init(MB);
-    let handle = bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
+    mmtk_gc_init(MB);
+    let handle = mmtk_bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
     // Attempt to allocate 2MB memory. This should trigger a GC, but as we never call initialize_collection(), we cannot do GC.
-    let addr = alloc(handle, 2 * MB, 8, 0, AllocationSemantics::Default);
+    let addr = mmtk_alloc(handle, 2 * MB, 8, 0, AllocationSemantics::Default);
     assert!(!addr.is_zero());
 }

--- a/vmbindings/dummyvm/src/tests/issue139.rs
+++ b/vmbindings/dummyvm/src/tests/issue139.rs
@@ -4,14 +4,14 @@ use mmtk::AllocationSemantics;
 
 #[test]
 pub fn issue139_alloc_non_multiple_of_min_alignment() {
-    gc_init(200*1024*1024);
-    let handle = bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
+    mmtk_gc_init(200*1024*1024);
+    let handle = mmtk_bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
 
     // Allocate 6 bytes with 8 bytes ailgnment required
-    let addr = alloc(handle, 14, 8, 0, AllocationSemantics::Default);
+    let addr = mmtk_alloc(handle, 14, 8, 0, AllocationSemantics::Default);
     assert!(addr.is_aligned_to(8));
     // After the allocation, the cursor is not MIN_ALIGNMENT aligned. If we have the assertion in the next allocation to check if the cursor is aligned to MIN_ALIGNMENT, it fails.
     // We have to remove that assertion.
-    let addr2 = alloc(handle, 14, 8, 0, AllocationSemantics::Default);
+    let addr2 = mmtk_alloc(handle, 14, 8, 0, AllocationSemantics::Default);
     assert!(addr2.is_aligned_to(8));
 }

--- a/vmbindings/dummyvm/src/tests/mod.rs
+++ b/vmbindings/dummyvm/src/tests/mod.rs
@@ -6,6 +6,6 @@ mod handle_mmap_oom;
 mod handle_mmap_conflict;
 mod allocate_without_initialize_collection;
 mod allocate_with_initialize_collection;
-mod allcoate_with_disable_collection;
+mod allocate_with_disable_collection;
 mod allocate_with_re_enable_collection;
 mod malloc;


### PR DESCRIPTION
Fixes #477 and #364 

I've also added brief comments to the exposed functions in the API. My understanding is that `TraceLocal` has been superseded by work packets, hence I have completely removed them from the header. Header was formatted using `clang-format`'s Chromium option.

(Also I'm not sure why `alloc_slow` is exposed in the API -- I haven't removed it, but I think it might be an artifact of refactoring)