### PR TITLE
Introduce a context object for GC controller thread

### DIFF
--- a/docs/tutorial/code/mygc_semispace/global.rs
+++ b/docs/tutorial/code/mygc_semispace/global.rs
@@ -79,9 +79,8 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
         &mut self,
         heap_size: usize,
         vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
     ) {
-        self.common.gc_init(heap_size, vm_map, scheduler);
+        self.common.gc_init(heap_size, vm_map);
         self.copyspace0.init(&vm_map);
         self.copyspace1.init(&vm_map);
     }

--- a/examples/mmtk.h
+++ b/examples/mmtk.h
@@ -86,7 +86,7 @@ extern void mmtk_scan_region();
 extern void mmtk_handle_user_collection_request(void* tls);
 
 // Run the main loop for the GC controller thread. Does not return
-extern void mmtk_start_control_collector(void* tls);
+extern void mmtk_start_control_collector(void* tls, void* worker);
 
 // Run the main loop for a GC worker. Does not return
 extern void mmtk_start_worker(void* tls, void* worker);

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -25,21 +25,6 @@ use crate::util::{Address, ObjectReference};
 use crate::vm::VMBinding;
 use std::sync::atomic::Ordering;
 
-/// Run the main loop for the GC controller thread. This method does not return.
-///
-/// Arguments:
-/// * `tls`: The thread that will be used as the GC controller.
-/// * `gc_controller`: The execution context of the GC controller threa.
-///   It is the `GCController` passed to `Collection::spawn_gc_thread`.
-/// * `mmtk`: A reference to an MMTk instance.
-pub fn start_control_collector<VM: VMBinding>(
-    tls: VMWorkerThread,
-    gc_controller: &mut GCController<VM>,
-    _mmtk: &'static MMTK<VM>,
-) {
-    gc_controller.run(tls);
-}
-
 /// Initialize an MMTk instance. A VM should call this method after creating an [MMTK](../mmtk/struct.MMTK.html)
 /// instance but before using any of the methods provided in MMTk. This method will attempt to initialize a
 /// logger. If the VM would like to use its own logger, it should initialize the logger before calling this method.
@@ -167,6 +152,21 @@ pub fn get_allocator_mapping<VM: VMBinding>(
     mmtk.plan.get_allocator_mapping()[semantics]
 }
 
+/// Run the main loop for the GC controller thread. This method does not return.
+///
+/// Arguments:
+/// * `tls`: The thread that will be used as the GC controller.
+/// * `gc_controller`: The execution context of the GC controller threa.
+///   It is the `GCController` passed to `Collection::spawn_gc_thread`.
+/// * `mmtk`: A reference to an MMTk instance.
+pub fn start_control_collector<VM: VMBinding>(
+    _mmtk: &'static MMTK<VM>,
+    tls: VMWorkerThread,
+    gc_controller: &mut GCController<VM>,
+) {
+    gc_controller.run(tls);
+}
+
 /// Run the main loop of a GC worker. This method does not return.
 ///
 /// Arguments:
@@ -175,9 +175,9 @@ pub fn get_allocator_mapping<VM: VMBinding>(
 ///   It is the `GCWorker` passed to `Collection::spawn_gc_thread`.
 /// * `mmtk`: A reference to an MMTk instance.
 pub fn start_worker<VM: VMBinding>(
+    mmtk: &'static MMTK<VM>,
     tls: VMWorkerThread,
     worker: &mut GCWorker<VM>,
-    mmtk: &'static MMTK<VM>,
 ) {
     worker.run(tls, mmtk);
 }

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -28,8 +28,10 @@ use std::sync::atomic::Ordering;
 /// Run the main loop for the GC controller thread. This method does not return.
 ///
 /// Arguments:
-/// * `mmtk`: A reference to an MMTk instance.
 /// * `tls`: The thread that will be used as the GC controller.
+/// * `gc_controller`: The execution context of the GC controller threa.
+///   It is the `GCController` passed to `Collection::spawn_gc_thread`.
+/// * `mmtk`: A reference to an MMTk instance.
 pub fn start_control_collector<VM: VMBinding>(
     tls: VMWorkerThread,
     gc_controller: &mut GCController<VM>,
@@ -169,7 +171,8 @@ pub fn get_allocator_mapping<VM: VMBinding>(
 ///
 /// Arguments:
 /// * `tls`: The thread that will be used as the GC worker.
-/// * `worker`: A reference to the GC worker.
+/// * `worker`: The execution context of the GC worker thread.
+///   It is the `GCWorker` passed to `Collection::spawn_gc_thread`.
 /// * `mmtk`: A reference to an MMTk instance.
 pub fn start_worker<VM: VMBinding>(
     tls: VMWorkerThread,
@@ -181,13 +184,13 @@ pub fn start_worker<VM: VMBinding>(
 
 /// Initialize the scheduler and GC workers that are required for doing garbage collections.
 /// This is a mandatory call for a VM during its boot process once its thread system
-/// is ready. This should only be called once. This call will invoke Collection::spawn_worker_thread()
+/// is ready. This should only be called once. This call will invoke Collection::spawn_gc_thread()
 /// to create GC threads.
 ///
 /// Arguments:
 /// * `mmtk`: A reference to an MMTk instance.
 /// * `tls`: The thread that wants to enable the collection. This value will be passed back to the VM in
-///   Collection::spawn_worker_thread() so that the VM knows the context.
+///   Collection::spawn_gc_thread() so that the VM knows the context.
 pub fn initialize_collection<VM: VMBinding>(mmtk: &'static MMTK<VM>, tls: VMThread) {
     assert!(
         !mmtk.plan.is_initialized(),

--- a/src/plan/gc_requester.rs
+++ b/src/plan/gc_requester.rs
@@ -8,7 +8,9 @@ struct RequestSync {
     last_request_count: isize,
 }
 
-pub struct ControllerCollectorContext<VM: VMBinding> {
+/// GC requester.  This object allows other threads to request (trigger) GC,
+/// and the GC coordinator thread waits for GC requests using this object.
+pub struct GCRequester<VM: VMBinding> {
     request_sync: Mutex<RequestSync>,
     request_condvar: Condvar,
     request_flag: AtomicBool,
@@ -16,15 +18,15 @@ pub struct ControllerCollectorContext<VM: VMBinding> {
 }
 
 // Clippy says we need this...
-impl<VM: VMBinding> Default for ControllerCollectorContext<VM> {
+impl<VM: VMBinding> Default for GCRequester<VM> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<VM: VMBinding> ControllerCollectorContext<VM> {
+impl<VM: VMBinding> GCRequester<VM> {
     pub fn new() -> Self {
-        ControllerCollectorContext {
+        GCRequester {
             request_sync: Mutex::new(RequestSync {
                 request_count: 0,
                 last_request_count: -1,

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -72,13 +72,8 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         self.gen.last_collection_full_heap()
     }
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.gen.gc_init(heap_size, vm_map, scheduler);
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.gen.gc_init(heap_size, vm_map);
         self.copyspace0.init(vm_map);
         self.copyspace1.init(vm_map);
     }

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -74,13 +74,8 @@ impl<VM: VMBinding> Gen<VM> {
     }
 
     /// Initialize Gen. This should be called by the gc_init() API call.
-    pub fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.common.gc_init(heap_size, vm_map, scheduler);
+    pub fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.common.gc_init(heap_size, vm_map);
         self.nursery.init(vm_map);
     }
 

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -97,13 +97,8 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         self.gen.collection_required(self, space_full, space)
     }
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.gen.gc_init(heap_size, vm_map, scheduler);
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.gen.gc_init(heap_size, vm_map);
         self.immix.init(vm_map);
     }
 

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -155,12 +155,7 @@ pub trait Plan: 'static + Sync + Downcast {
     }
 
     // unsafe because this can only be called once by the init thread
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<Self::VM>>,
-    );
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap);
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector>;
 
@@ -337,7 +332,7 @@ pub struct BasePlan<VM: VMBinding> {
     pub max_collection_attempts: AtomicUsize,
     // Current collection attempt
     pub cur_collection_attempts: AtomicUsize,
-    pub control_collector_context: ControllerCollectorContext<VM>,
+    pub control_collector_context: Arc<ControllerCollectorContext<VM>>,
     pub stats: Stats,
     mmapper: &'static Mmapper,
     pub vm_map: &'static VMMap,
@@ -468,7 +463,7 @@ impl<VM: VMBinding> BasePlan<VM> {
             allocation_success: AtomicBool::new(false),
             max_collection_attempts: AtomicUsize::new(0),
             cur_collection_attempts: AtomicUsize::new(0),
-            control_collector_context: ControllerCollectorContext::new(),
+            control_collector_context: Arc::new(ControllerCollectorContext::new()),
             stats,
             mmapper,
             heap,
@@ -484,12 +479,7 @@ impl<VM: VMBinding> BasePlan<VM> {
         }
     }
 
-    pub fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
+    pub fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         vm_map.boot();
         vm_map.finalize_static_space_map(
             self.heap.get_discontig_start(),
@@ -498,7 +488,6 @@ impl<VM: VMBinding> BasePlan<VM> {
         self.heap
             .total_pages
             .store(bytes_to_pages(heap_size), Ordering::Relaxed);
-        self.control_collector_context.init(scheduler);
 
         #[cfg(feature = "code_space")]
         self.code_space.init(vm_map);
@@ -854,13 +843,8 @@ impl<VM: VMBinding> CommonPlan<VM> {
         }
     }
 
-    pub fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.base.gc_init(heap_size, vm_map, scheduler);
+    pub fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.base.gc_init(heap_size, vm_map);
         self.immortal.init(vm_map);
         self.los.init(vm_map);
     }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -69,13 +69,8 @@ impl<VM: VMBinding> Plan for Immix<VM> {
         }
     }
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.common.gc_init(heap_size, vm_map, scheduler);
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.common.gc_init(heap_size, vm_map);
         self.immix_space.init(vm_map);
     }
 

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -50,13 +50,8 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         &MARKCOMPACT_CONSTRAINTS
     }
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.common.gc_init(heap_size, vm_map, scheduler);
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.common.gc_init(heap_size, vm_map);
         self.mc_space.init(vm_map);
     }
 

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -134,7 +134,6 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         #[cfg(feature = "sanity")]
         scheduler.work_buckets[WorkBucketStage::Final]
             .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new(self));
-        scheduler.set_finalizer(Some(EndOfGC));
     }
 
     fn collection_required(&self, space_full: bool, space: &dyn Space<Self::VM>) -> bool {

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -42,13 +42,8 @@ pub const MS_CONSTRAINTS: PlanConstraints = PlanConstraints {
 impl<VM: VMBinding> Plan for MarkSweep<VM> {
     type VM = VM;
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.common.gc_init(heap_size, vm_map, scheduler);
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.common.gc_init(heap_size, vm_map);
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -16,7 +16,7 @@
 mod barriers;
 pub use barriers::BarrierSelector;
 
-pub mod controller_collector_context;
+pub(crate) mod gc_requester;
 
 mod global;
 pub(crate) use global::create_gc_worker_context;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -16,7 +16,7 @@
 mod barriers;
 pub use barriers::BarrierSelector;
 
-mod controller_collector_context;
+pub mod controller_collector_context;
 
 mod global;
 pub(crate) use global::create_gc_worker_context;

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -41,13 +41,8 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &NOGC_CONSTRAINTS
     }
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.base.gc_init(heap_size, vm_map, scheduler);
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.base.gc_init(heap_size, vm_map);
 
         // FIXME correctly initialize spaces based on options
         self.nogc_space.init(vm_map);

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -39,12 +39,7 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         &CONSTRAINTS
     }
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         // Warn users that the plan may fail due to maximum mapping allowed.
         warn!(
             "PageProtect uses a high volume of memory mappings. \
@@ -56,7 +51,7 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
                 ""
             }
         );
-        self.common.gc_init(heap_size, vm_map, scheduler);
+        self.common.gc_init(heap_size, vm_map);
         self.space.init(vm_map);
     }
 

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -63,13 +63,8 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         }
     }
 
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-        scheduler: &Arc<GCWorkScheduler<VM>>,
-    ) {
-        self.common.gc_init(heap_size, vm_map, scheduler);
+    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
+        self.common.gc_init(heap_size, vm_map);
 
         self.copyspace0.init(vm_map);
         self.copyspace1.init(vm_map);

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -1,32 +1,41 @@
 //! The GC controller thread.
+//!
+//! MMTk has many GC threads.  There are many GC worker threads and one GC controller thread.
+//! The GC controller thread responds to GC requests and coordinates the workers to perform GC.
 
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 
-use crate::plan::controller_collector_context::ControllerCollectorContext;
-use crate::scheduler::gc_work::ScheduleCollection;
+use crate::plan::gc_requester::GCRequester;
+use crate::scheduler::gc_work::{EndOfGC, ScheduleCollection};
 use crate::scheduler::CoordinatorMessage;
 use crate::util::VMWorkerThread;
 use crate::vm::VMBinding;
 use crate::MMTK;
 
-use super::{GCWorkScheduler, GCWorker};
+use super::{GCWork, GCWorkScheduler, GCWorker};
 
+/// The thread local struct for the GC controller, the counterpart of `GCWorker`.
 pub struct GCController<VM: VMBinding> {
+    /// The reference to the MMTk instance.
     mmtk: &'static MMTK<VM>,
-    requester: Arc<ControllerCollectorContext<VM>>,
+    /// The reference to the GC requester.
+    requester: Arc<GCRequester<VM>>,
+    /// The reference to the scheduler.
     scheduler: Arc<GCWorkScheduler<VM>>,
+    /// The receiving end of the channel to get controller/coordinator message from workers.
     receiver: Receiver<CoordinatorMessage<VM>>,
-    coordinator_worker: Box<GCWorker<VM>>,
+    /// The `GCWorker` is used to execute packets. The controller is also a `GCWorker`.
+    coordinator_worker: GCWorker<VM>,
 }
 
 impl<VM: VMBinding> GCController<VM> {
     pub fn new(
         mmtk: &'static MMTK<VM>,
-        requester: Arc<ControllerCollectorContext<VM>>,
+        requester: Arc<GCRequester<VM>>,
         scheduler: Arc<GCWorkScheduler<VM>>,
         receiver: Receiver<CoordinatorMessage<VM>>,
-        coordinator_worker: Box<GCWorker<VM>>,
+        coordinator_worker: GCWorker<VM>,
     ) -> Box<GCController<VM>> {
         Box::new(Self {
             mmtk,
@@ -52,21 +61,20 @@ impl<VM: VMBinding> GCController<VM> {
             // when GC is requested.
             // let user_triggered_collection: bool = SelectedPlan::is_user_triggered_collection();
 
-            self.scheduler.set_initializer(Some(ScheduleCollection));
-            self.wait_for_completion();
+            self.do_gc_until_completion();
             debug!("[STWController: Worker threads complete!]");
         }
     }
 
-    /// Drain the message queue and execute coordinator work.
-    pub fn wait_for_completion(&mut self) {
+    /// Coordinate workers to perform GC in response to a GC request.
+    pub fn do_gc_until_completion(&mut self) {
         let worker = &mut self.coordinator_worker;
         let mmtk = self.mmtk;
 
-        // At the start of a GC, we probably already have received a `ScheduleCollection` work. Run it now.
-        if let Some(mut initializer) = self.scheduler.take_initializer() {
-            initializer.do_work_with_stat(worker, mmtk);
-        }
+        // Schedule collection.
+        ScheduleCollection.do_work_with_stat(worker, mmtk);
+
+        // Drain the message queue and execute coordinator work.
         loop {
             let message = self.receiver.recv().unwrap();
             match message {
@@ -85,7 +93,6 @@ impl<VM: VMBinding> GCController<VM> {
         for message in self.receiver.try_iter() {
             if let CoordinatorMessage::Work(mut work) = message {
                 work.do_work_with_stat(worker, mmtk);
-                //self.process_coordinator_work(work);
             }
         }
         self.scheduler.deactivate_all();
@@ -94,9 +101,8 @@ impl<VM: VMBinding> GCController<VM> {
         //       Otherwise, for generational GCs, workers will receive and process
         //       newly generated remembered-sets from those open buckets.
         //       But these remsets should be preserved until next GC.
-        if let Some(mut finalizer) = self.scheduler.take_finalizer() {
-            finalizer.do_work_with_stat(worker, mmtk);
-        }
+        EndOfGC.do_work_with_stat(worker, mmtk);
+
         self.scheduler.debug_assert_all_buckets_deactivated();
     }
 }

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -1,29 +1,38 @@
 //! The GC controller thread.
 
+use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 
 use crate::plan::controller_collector_context::ControllerCollectorContext;
 use crate::scheduler::gc_work::ScheduleCollection;
+use crate::scheduler::CoordinatorMessage;
 use crate::util::VMWorkerThread;
 use crate::vm::VMBinding;
+use crate::MMTK;
 
 use super::{GCWorkScheduler, GCWorker};
 
 pub struct GCController<VM: VMBinding> {
+    mmtk: &'static MMTK<VM>,
     requester: Arc<ControllerCollectorContext<VM>>,
     scheduler: Arc<GCWorkScheduler<VM>>,
+    receiver: Receiver<CoordinatorMessage<VM>>,
     coordinator_worker: Box<GCWorker<VM>>,
 }
 
 impl<VM: VMBinding> GCController<VM> {
     pub fn new(
+        mmtk: &'static MMTK<VM>,
         requester: Arc<ControllerCollectorContext<VM>>,
         scheduler: Arc<GCWorkScheduler<VM>>,
+        receiver: Receiver<CoordinatorMessage<VM>>,
         coordinator_worker: Box<GCWorker<VM>>,
     ) -> Box<GCController<VM>> {
         Box::new(Self {
+            mmtk,
             requester,
             scheduler,
+            receiver,
             coordinator_worker,
         })
     }
@@ -44,9 +53,50 @@ impl<VM: VMBinding> GCController<VM> {
             // let user_triggered_collection: bool = SelectedPlan::is_user_triggered_collection();
 
             self.scheduler.set_initializer(Some(ScheduleCollection));
-            self.scheduler
-                .wait_for_completion(&mut self.coordinator_worker);
+            self.wait_for_completion();
             debug!("[STWController: Worker threads complete!]");
         }
+    }
+
+    /// Drain the message queue and execute coordinator work.
+    pub fn wait_for_completion(&mut self) {
+        let worker = &mut self.coordinator_worker;
+        let mmtk = self.mmtk;
+
+        // At the start of a GC, we probably already have received a `ScheduleCollection` work. Run it now.
+        if let Some(mut initializer) = self.scheduler.take_initializer() {
+            initializer.do_work_with_stat(worker, mmtk);
+        }
+        loop {
+            let message = self.receiver.recv().unwrap();
+            match message {
+                CoordinatorMessage::Work(mut work) => {
+                    work.do_work_with_stat(worker, mmtk);
+                }
+                CoordinatorMessage::AllWorkerParked | CoordinatorMessage::BucketDrained => {
+                    self.scheduler.update_buckets();
+                }
+            }
+            let _guard = self.scheduler.worker_monitor.0.lock().unwrap();
+            if self.scheduler.worker_group().all_parked() && self.scheduler.all_buckets_empty() {
+                break;
+            }
+        }
+        for message in self.receiver.try_iter() {
+            if let CoordinatorMessage::Work(mut work) = message {
+                work.do_work_with_stat(worker, mmtk);
+                //self.process_coordinator_work(work);
+            }
+        }
+        self.scheduler.deactivate_all();
+        // Finalization: Resume mutators, reset gc states
+        // Note: Resume-mutators must happen after all work buckets are closed.
+        //       Otherwise, for generational GCs, workers will receive and process
+        //       newly generated remembered-sets from those open buckets.
+        //       But these remsets should be preserved until next GC.
+        if let Some(mut finalizer) = self.scheduler.take_finalizer() {
+            finalizer.do_work_with_stat(worker, mmtk);
+        }
+        self.scheduler.debug_assert_all_buckets_deactivated();
     }
 }

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -1,0 +1,52 @@
+//! The GC controller thread.
+
+use std::sync::Arc;
+
+use crate::plan::controller_collector_context::ControllerCollectorContext;
+use crate::scheduler::gc_work::ScheduleCollection;
+use crate::util::VMWorkerThread;
+use crate::vm::VMBinding;
+
+use super::{GCWorkScheduler, GCWorker};
+
+pub struct GCController<VM: VMBinding> {
+    requester: Arc<ControllerCollectorContext<VM>>,
+    scheduler: Arc<GCWorkScheduler<VM>>,
+    coordinator_worker: Box<GCWorker<VM>>,
+}
+
+impl<VM: VMBinding> GCController<VM> {
+    pub fn new(
+        requester: Arc<ControllerCollectorContext<VM>>,
+        scheduler: Arc<GCWorkScheduler<VM>>,
+        coordinator_worker: Box<GCWorker<VM>>,
+    ) -> Box<GCController<VM>> {
+        Box::new(Self {
+            requester,
+            scheduler,
+            coordinator_worker,
+        })
+    }
+
+    pub fn run(&mut self, tls: VMWorkerThread) {
+        // Initialize the GC worker for coordinator. We are not using the run() method from
+        // GCWorker so we manually initialize the worker here.
+        self.coordinator_worker.tls = tls;
+
+        loop {
+            debug!("[STWController: Waiting for request...]");
+            self.requester.wait_for_request();
+            debug!("[STWController: Request recieved.]");
+
+            // For heap growth logic
+            // FIXME: This is not used. However, we probably want to set a 'user_triggered' flag
+            // when GC is requested.
+            // let user_triggered_collection: bool = SelectedPlan::is_user_triggered_collection();
+
+            self.scheduler.set_initializer(Some(ScheduleCollection));
+            self.scheduler
+                .wait_for_completion(&mut self.coordinator_worker);
+            debug!("[STWController: Worker threads complete!]");
+        }
+    }
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -19,6 +19,9 @@ pub use work_bucket::WorkBucketStage;
 mod worker;
 pub use worker::GCWorker;
 
+mod controller;
+pub use controller::GCController;
+
 pub(crate) mod gc_work;
 pub use gc_work::ProcessEdgesWork;
 // TODO: We shouldn't need to expose ScanStackRoot. However, OpenJDK uses it.

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::mmtk::MMTK;
 use crate::util::copy::GCWorkerCopyContext;
 use crate::util::opaque_pointer::*;
-use crate::vm::{Collection, VMBinding};
+use crate::vm::{Collection, GCThreadContext, VMBinding};
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
@@ -165,7 +165,7 @@ impl<VM: VMBinding> WorkerGroup<VM> {
         // Therefore we defer the spawning operation later.
         let deferred_spawn = Box::new(move |tls| {
             for worker in workers_to_spawn.drain(..) {
-                VM::VMCollection::spawn_worker_thread(tls, Some(worker));
+                VM::VMCollection::spawn_gc_thread(tls, GCThreadContext::<VM>::Worker(worker));
             }
         });
 

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -155,7 +155,7 @@ impl<VM: VMBinding> WorkerGroup<VM> {
             workers_to_spawn.push(worker);
         }
 
-        // NOTE: We cannot call spawn_worker_thread here,
+        // NOTE: We cannot call spawn_gc_thread here,
         // because the worker will access `Scheduler::worker_group` immediately after started,
         // but that field will not be assigned to before this function returns.
         // Therefore we defer the spawning operation later.

--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -4,7 +4,7 @@ use crate::scheduler::*;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
 
-/// Thread context for the spawned GC thread.  It is used by spawn_worker_thread.
+/// Thread context for the spawned GC thread.  It is used by spawn_gc_thread.
 pub enum GCThreadContext<VM: VMBinding> {
     Controller(Box<GCController<VM>>),
     Worker(Box<GCWorker<VM>>),
@@ -54,11 +54,11 @@ pub trait Collection<VM: VMBinding> {
     /// * `tls`: The thread pointer for the parent thread that we spawn new threads from. This is the same `tls` when the VM
     ///   calls `initialize_collection()` and passes as an argument.
     /// * `ctx`: The context for the GC thread.
-    ///   * If `Controller` is passed, it means spawning a GC thread for the GC controller.
+    ///   * If `Controller` is passed, it means spawning a thread to run as the GC controller.
     ///     The spawned thread shall call `memory_manager::start_control_collector`.
-    ///   * If `Worker` is passed, it means spawning a GC worker thread.
+    ///   * If `Worker` is passed, it means spawning a thread to run as a GC worker.
     ///     The spawned thread shall call `memory_manager::start_worker`.
-    ///   In either case, the `Box` inside should be passed back to
+    ///   In either case, the `Box` inside should be passed back to the called function.
     fn spawn_gc_thread(tls: VMThread, ctx: GCThreadContext<VM>);
 
     /// Allow VM-specific behaviors for a mutator after all the mutators are stopped and before any actual GC work starts.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -24,6 +24,7 @@ mod reference_glue;
 mod scanning;
 pub use self::active_plan::ActivePlan;
 pub use self::collection::Collection;
+pub use self::collection::GCThreadContext;
 pub use self::object_model::specs::*;
 pub use self::object_model::ObjectModel;
 pub use self::reference_glue::ReferenceGlue;

--- a/vmbindings/dummyvm/api/mmtk.h
+++ b/vmbindings/dummyvm/api/mmtk.h
@@ -86,7 +86,7 @@ extern void mmtk_scan_region();
 extern void mmtk_handle_user_collection_request(void* tls);
 
 // Run the main loop for the GC controller thread. Does not return
-extern void mmtk_start_control_collector(void* tls);
+extern void mmtk_start_control_collector(void* tls, void* worker);
 
 // Run the main loop for a GC worker. Does not return
 extern void mmtk_start_worker(void* tls, void* worker);

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -7,7 +7,7 @@ use mmtk::memory_manager;
 use mmtk::AllocationSemantics;
 use mmtk::util::{ObjectReference, Address};
 use mmtk::util::opaque_pointer::*;
-use mmtk::scheduler::GCWorker;
+use mmtk::scheduler::{GCController, GCWorker};
 use mmtk::Mutator;
 use mmtk::MMTK;
 use DummyVM;
@@ -23,8 +23,8 @@ pub extern "C" fn mmtk_gc_init(heap_size: usize) {
 }
 
 #[no_mangle]
-pub extern "C" fn mmtk_start_control_collector(tls: VMWorkerThread) {
-    memory_manager::start_control_collector(&SINGLETON, tls);
+pub extern "C" fn mmtk_start_control_collector(tls: VMWorkerThread, controller: &'static mut GCController<DummyVM>) {
+    memory_manager::start_control_collector(tls, controller, &SINGLETON);
 }
 
 #[no_mangle]
@@ -61,8 +61,8 @@ pub extern "C" fn mmtk_will_never_move(object: ObjectReference) -> bool {
 }
 
 #[no_mangle]
-pub extern "C" fn mmtk_start_worker(tls: VMWorkerThread, worker: &'static mut GCWorker<DummyVM>, mmtk: &'static MMTK<DummyVM>) {
-    memory_manager::start_worker::<DummyVM>(tls, worker, mmtk)
+pub extern "C" fn mmtk_start_worker(tls: VMWorkerThread, worker: &'static mut GCWorker<DummyVM>) {
+    memory_manager::start_worker::<DummyVM>(tls, worker, &SINGLETON)
 }
 
 #[no_mangle]

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -23,11 +23,6 @@ pub extern "C" fn mmtk_gc_init(heap_size: usize) {
 }
 
 #[no_mangle]
-pub extern "C" fn mmtk_start_control_collector(tls: VMWorkerThread, controller: &'static mut GCController<DummyVM>) {
-    memory_manager::start_control_collector(tls, controller, &SINGLETON);
-}
-
-#[no_mangle]
 pub extern "C" fn mmtk_bind_mutator(tls: VMMutatorThread) -> *mut Mutator<DummyVM> {
     Box::into_raw(memory_manager::bind_mutator(&SINGLETON, tls))
 }
@@ -61,8 +56,13 @@ pub extern "C" fn mmtk_will_never_move(object: ObjectReference) -> bool {
 }
 
 #[no_mangle]
+pub extern "C" fn mmtk_start_control_collector(tls: VMWorkerThread, controller: &'static mut GCController<DummyVM>) {
+    memory_manager::start_control_collector(&SINGLETON, tls, controller);
+}
+
+#[no_mangle]
 pub extern "C" fn mmtk_start_worker(tls: VMWorkerThread, worker: &'static mut GCWorker<DummyVM>) {
-    memory_manager::start_worker::<DummyVM>(tls, worker, &SINGLETON)
+    memory_manager::start_worker::<DummyVM>(&SINGLETON, tls, worker)
 }
 
 #[no_mangle]

--- a/vmbindings/dummyvm/src/collection.rs
+++ b/vmbindings/dummyvm/src/collection.rs
@@ -1,4 +1,5 @@
 use mmtk::vm::Collection;
+use mmtk::vm::GCThreadContext;
 use mmtk::MutatorContext;
 use mmtk::util::opaque_pointer::*;
 use mmtk::scheduler::*;
@@ -19,7 +20,7 @@ impl Collection<DummyVM> for VMCollection {
         panic!("block_for_gc is not implemented")
     }
 
-    fn spawn_worker_thread(_tls: VMThread, _ctx: Option<Box<GCWorker<DummyVM>>>) {
+    fn spawn_gc_thread(_tls: VMThread, _ctx: GCThreadContext<DummyVM>) {
 
     }
 


### PR DESCRIPTION
This is one of a series of planned changes to refactor the scheduler.  The problems are described in issue https://github.com/mmtk/mmtk-core/issues/532

This PR introduces the `GCController` struct.  Like `GCWorker`, a `GCController` shall be owned by the GC controller thread.  It owns its `GCWorker` (the `coordinator_worker`) and the receiving end of the worker-to-controller channel. It also has references to the data structures it needs to work with, including the scheduler and the `ControllerCollectorContext` which is used to trigger GC.

Because of this new struct, some related fields and operations are removed from `ControllerCollectorContext` and `GCWorkScheduler`.

There is also an API change.  `spawn_worker_thread` is renamed to `spawn_gc_thread`.  Now both GC worker threads and the GC controller thread are spawn with a context object.

This PR does not change the two-phase initialisation of `GCWorkScheduler`.  It will be done in another PR.