### PR TITLE
Refactor scheduler and worker creation

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -196,7 +196,7 @@ pub fn initialize_collection<VM: VMBinding>(mmtk: &'static MMTK<VM>, tls: VMThre
         !mmtk.plan.is_initialized(),
         "MMTk collection has been initialized (was initialize_collection() already called before?)"
     );
-    mmtk.scheduler.initialize(*mmtk.options.threads, mmtk, tls);
+    mmtk.scheduler.spawn_gc_threads(mmtk, tls);
     mmtk.plan.base().initialized.store(true, Ordering::SeqCst);
 }
 

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -57,8 +57,15 @@ impl<VM: VMBinding> MMTK<VM> {
         // The first call will initialize SFT map. Other calls will be blocked until SFT map is initialized.
         SFT_MAP.initialize_once();
 
-        let scheduler = GCWorkScheduler::new();
         let options = Arc::new(UnsafeOptionsWrapper::new(Options::default()));
+
+        let num_workers = if cfg!(feature = "single_worker") {
+            1
+        } else {
+            *options.threads
+        };
+
+        let scheduler = GCWorkScheduler::new(num_workers);
         let plan = crate::plan::create_plan(
             *options.plan,
             &VM_MAP,

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -86,7 +86,7 @@ impl<VM: VMBinding> GCController<VM> {
                 }
             }
             let _guard = self.scheduler.worker_monitor.0.lock().unwrap();
-            if self.scheduler.worker_group().all_parked() && self.scheduler.all_buckets_empty() {
+            if self.scheduler.all_workers_parked() && self.scheduler.all_buckets_empty() {
                 break;
             }
         }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -49,7 +49,7 @@ impl<C: GCWorkContext + 'static> GCWork<C::VM> for Prepare<C> {
             mmtk.scheduler.work_buckets[WorkBucketStage::Prepare]
                 .add(PrepareMutator::<C::VM>::new(mutator));
         }
-        for w in &mmtk.scheduler.worker_group().workers_shared {
+        for w in &mmtk.scheduler.workers_shared {
             w.local_work_bucket.add(PrepareCollector);
         }
     }
@@ -117,7 +117,7 @@ impl<C: GCWorkContext + 'static> GCWork<C::VM> for Release<C> {
             mmtk.scheduler.work_buckets[WorkBucketStage::Release]
                 .add(ReleaseMutator::<C::VM>::new(mutator));
         }
-        for w in &mmtk.scheduler.worker_group().workers_shared {
+        for w in &mmtk.scheduler.workers_shared {
             w.local_work_bucket.add(ReleaseCollector);
         }
         // TODO: Process weak references properly

--- a/src/scheduler/work_bucket.rs
+++ b/src/scheduler/work_bucket.rs
@@ -59,7 +59,7 @@ pub struct WorkBucket<VM: VMBinding> {
     /// A priority queue
     queue: RwLock<BinaryHeap<PrioritizedWork<VM>>>,
     monitor: Arc<(Mutex<()>, Condvar)>,
-    can_open: Option<Box<dyn (Fn() -> bool) + Send>>,
+    can_open: Option<Box<dyn (Fn(&GCWorkScheduler<VM>) -> bool) + Send>>,
 }
 
 impl<VM: VMBinding> WorkBucket<VM> {
@@ -132,12 +132,15 @@ impl<VM: VMBinding> WorkBucket<VM> {
         }
         self.queue.write().pop().map(|v| v.work)
     }
-    pub fn set_open_condition(&mut self, pred: impl Fn() -> bool + Send + 'static) {
+    pub fn set_open_condition(
+        &mut self,
+        pred: impl Fn(&GCWorkScheduler<VM>) -> bool + Send + 'static,
+    ) {
         self.can_open = Some(box pred);
     }
-    pub fn update(&self) -> bool {
+    pub fn update(&self, scheduler: &GCWorkScheduler<VM>) -> bool {
         if let Some(can_open) = self.can_open.as_ref() {
-            if !self.is_activated() && can_open() {
+            if !self.is_activated() && can_open(scheduler) {
                 self.activate();
                 return true;
             }

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -109,7 +109,7 @@ impl<P: Plan> GCWork<P::VM> for SanityPrepare<P> {
             mmtk.scheduler.work_buckets[WorkBucketStage::Prepare]
                 .add(PrepareMutator::<P::VM>::new(mutator));
         }
-        for w in &mmtk.scheduler.worker_group().workers_shared {
+        for w in &mmtk.scheduler.workers_shared {
             w.local_work_bucket.add(PrepareCollector);
         }
     }
@@ -133,7 +133,7 @@ impl<P: Plan> GCWork<P::VM> for SanityRelease<P> {
             mmtk.scheduler.work_buckets[WorkBucketStage::Release]
                 .add(ReleaseMutator::<P::VM>::new(mutator));
         }
-        for w in &mmtk.scheduler.worker_group().workers_shared {
+        for w in &mmtk.scheduler.workers_shared {
             w.local_work_bucket.add(ReleaseCollector);
         }
     }


### PR DESCRIPTION
This is part 2 of refactoring the scheduler: https://github.com/mmtk/mmtk-core/issues/532

~~**But don't merge it yet, because there is a known problem: it breaks options from command line**. See below.~~ For now we temporarily disable setting the number of GC threads from the command line.

We now construct the `GCWorkScheduler` in one step, so that we no longer need to make every field `Option<T>` and set the value during `initialize`.

To make it possible, we eliminated cyclic references by considering `MMTK`, `GCWorkScheduler` and `GCWorkerShared` as nested data, like this:
```rust
MMTK {
  ...
  sheduler: GCWorkScheduler {
    ...
    workers: vec![
      GCWorkerShared {...},
      GCWorkerShared {...},
      GCWorkerShared {...},
      ...
    ],
  }
}
```

So inner structures do not refer to outer structures.  We eliminated the `GCWorkScheduler::mmtk` field.

On the other hand, actors (threads) have references to all shared data they need.  Both `GCWorker` and `GCController` contain a reference to the `MMTK` instance, so they no longer need to navigate from the scheduler to MMTK.  And, obviously, private data of the actors (threads, including `GCWorker` and `GCController`) never refer to one another.

## Known problem

We create `GCWorkScheduler` when `MMTK` is created.  This is too early for now, because the `MMTK` instance is usually created statically by the VM.  When it is created, we still don't know how many threads we have.  The number of threads is determined by the `mmtk.options.threads` option, which can be set by either environment variable or command-line options.  This is too late for the creation of `GCWorkScheduler`.  The current PR will simply disregard any changes to the value of `mmtk.options.threads` after `GCWorkScheduler` is created.

To solve this problem, we need to make one (or both) of the following changes before applying this PR.

1.  Introducing a `MMTKBuilder`, and build the `MMTK` instance after options are parsed.
2.  Make it possible to add workers after `GCWorkScheduler` is created.
3.  Change `MMTK::scheduler` to `Option<Arc<GCWorkScheduler>>`.

We will need to do (1) anyway, because currently options are also held by an `UnsafeOptionsWrapper`, which is unsafe.

Method (2) needs to make the worker group synchronised (probably using a `RwLock`).  Adding a `RwLock` **directly** may add **performance overhead** because the work packet system frequently queries if all workers are parked.  To do it efficiently, we should redesign the synchronisation algorithm and make the lock more coarse-grained.  Issue https://github.com/mmtk/mmtk-core/issues/537 covers some of the details.

Method (2) will also enable the potential of dynamically adjusting the number of workers during execution, but let's not attempt that for now.

Method (3) simply pushes the `Option<T>` from the fields of `GCWorkScheduler` to the field of `MMTK`. It simply moves the problem to a different place.
