### PR TITLE
Add a function to test if an arbitrary address is a valid object reference

### DIFF
--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -1,5 +1,7 @@
 . $(dirname "$0")/ci-common.sh
 
+export RUST_BACKTRACE=1
+
 for_all_features "cargo test"
 
 # For x86_64-linux, also check for i686
@@ -10,9 +12,33 @@ fi
 
 python examples/build.py
 
+ALL_PLANS=$(sed -n '/enum PlanSelector/,/}/p' src/util/options.rs | xargs | grep -o '{.*}' | grep -o '\w\+')
+
 # Test with DummyVM (each test in a separate run)
 cd vmbindings/dummyvm
-for t in $(ls src/tests/ -I mod.rs | sed -n 's/\.rs$//p'); do
-    cargo test -- $t;
-done;
+for fn in $(ls src/tests/*.rs); do
+    t=$(basename -s .rs $fn)
+
+    if [[ $t == "mod.rs" ]]; then
+        continue
+    fi
+
+    # Get the required plans.
+    # Some tests need to be run with multiple plans because
+    # some bugs can only be reproduced in some plans but not others.
+    PLANS=$(sed -n 's;^//\s*GITHUB-CI:\s*MMTK_PLAN=\(\w\+\)\s*$;\1;p' $fn)
+    if [[ $PLANS == 'all' ]]; then
+        PLANS=$ALL_PLANS
+    elif [[ -z $PLANS ]]; then
+        PLANS=NoGC
+    fi
+
+    # Some tests need some features enabled.
+    FEATURES=$(sed -n 's;^//\s*GITHUB-CI:\s*FEATURES=\([a-zA-Z0-9_,]\+\)\s*$;\1;p' $fn)
+
+    # Run the test with each plan it needs.
+    for MMTK_PLAN in $PLANS; do
+        env MMTK_PLAN=$MMTK_PLAN cargo test --features "$FEATURES" -- $t;
+    done
+done
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ code_space  = []
 # metadata
 global_alloc_bit = []
 
+# conservative garbage collection support
+is_mmtk_object = ["global_alloc_bit"]
+
 # Run sanity GC
 sanity = []
 # Run analysis

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -382,6 +382,19 @@ pub struct BasePlan<VM: VMBinding> {
     pub code_lo_space: ImmortalSpace<VM>,
     #[cfg(feature = "ro_space")]
     pub ro_space: ImmortalSpace<VM>,
+
+    /// A VM space is a space allocated and populated by the VM.  Currently it is used by JikesRVM
+    /// for boot image.
+    ///
+    /// If VM space is present, it has some special interaction with the
+    /// `memory_manager::is_mmtk_object` and the `memory_manager::is_in_mmtk_spaces` functions.
+    ///
+    /// -   The `is_mmtk_object` funciton requires the alloc_bit side metadata to identify objects,
+    ///     but currently we do not require the boot image to provide it, so it will not work if the
+    ///     address argument is in the VM space.
+    ///
+    /// -   The `is_in_mmtk_spaces` currently returns `true` if the given object reference is in
+    ///     the VM space.
     #[cfg(feature = "vm_space")]
     pub vm_space: ImmortalSpace<VM>,
 }

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -73,8 +73,18 @@ impl<VM: VMBinding> SFT for MallocSpace<VM> {
     }
 
     // For malloc space, we need to further check the alloc bit.
-    fn is_mmtk_object(&self, object: ObjectReference) -> bool {
+    fn is_in_space(&self, object: ObjectReference) -> bool {
         is_alloced_by_malloc(object)
+    }
+
+    /// For malloc space, we just use the side metadata.
+    #[cfg(feature = "is_mmtk_object")]
+    #[inline(always)]
+    fn is_mmtk_object(&self, addr: Address) -> bool {
+        debug_assert!(!addr.is_zero());
+        // `addr` cannot be mapped by us. It should be mapped by the malloc library.
+        debug_assert!(!addr.is_mapped());
+        has_object_alloced_by_malloc(addr)
     }
 
     fn initialize_object_metadata(&self, object: ObjectReference, _alloc: bool) {

--- a/src/policy/mallocspace/metadata.rs
+++ b/src/policy/mallocspace/metadata.rs
@@ -154,10 +154,17 @@ pub fn map_meta_space(metadata: &SideMetadataContext, addr: Address, size: usize
     }
 }
 
-// Check if a given object was allocated by malloc
+/// Check if a given object was allocated by malloc
 pub fn is_alloced_by_malloc(object: ObjectReference) -> bool {
-    is_meta_space_mapped_for_address(object.to_address())
-        && alloc_bit::is_alloced_object(object.to_address())
+    has_object_alloced_by_malloc(object.to_address())
+}
+
+/// Check if there is an object allocated by malloc at the address.
+///
+/// This function doesn't check if `addr` is aligned.
+/// If not, it will try to load the alloc bit for the address rounded down to the metadata's granularity.
+pub fn has_object_alloced_by_malloc(addr: Address) -> bool {
+    is_meta_space_mapped_for_address(addr) && alloc_bit::is_alloced_object(addr)
 }
 
 pub fn is_marked<VM: VMBinding>(object: ObjectReference, ordering: Option<Ordering>) -> bool {

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -500,8 +500,8 @@ impl ObjectReference {
         SFT_MAP.get(Address(self.0)).get_forwarded_object(self)
     }
 
-    pub fn is_mapped(self) -> bool {
-        SFT_MAP.is_in_space(self)
+    pub fn is_in_any_space(self) -> bool {
+        SFT_MAP.is_in_any_space(self)
     }
 
     #[cfg(feature = "sanity")]

--- a/src/util/is_mmtk_object.rs
+++ b/src/util/is_mmtk_object.rs
@@ -1,0 +1,12 @@
+use crate::mmtk::SFT_MAP;
+use crate::util::Address;
+
+/// The region size (in bytes) of the `ALLOC_BIT` side metadata.
+/// The VM can use this to check if an object is properly aligned.
+pub const ALLOC_BIT_REGION_SIZE: usize =
+    1usize << crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region;
+
+#[inline(always)]
+pub(crate) fn is_mmtk_object(addr: Address) -> bool {
+    SFT_MAP.is_mmtk_object(addr)
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -41,6 +41,8 @@ pub(crate) mod erase_vm;
 pub(crate) mod finalizable_processor;
 /// Heap implementation, including page resource, mmapper, etc.
 pub(crate) mod heap;
+#[cfg(feature = "is_mmtk_object")]
+pub mod is_mmtk_object;
 /// Logger initialization
 pub(crate) mod logger;
 /// Various malloc implementations (conditionally compiled by features)

--- a/vmbindings/dummyvm/Cargo.toml
+++ b/vmbindings/dummyvm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mmtk_dummyvm"
 version = "0.0.1"
 authors = [" <>"]
+edition = "2021"
 
 [lib]
 name = "mmtk_dummyvm"
@@ -15,6 +16,8 @@ lto = true
 mmtk = { path = "../../", version = "*" }
 libc = "0.2"
 lazy_static = "1.1"
+atomic_refcell = "0.1.7"
 
 [features]
 default = []
+is_mmtk_object = ["mmtk/is_mmtk_object"]

--- a/vmbindings/dummyvm/src/active_plan.rs
+++ b/vmbindings/dummyvm/src/active_plan.rs
@@ -2,8 +2,8 @@ use mmtk::Plan;
 use mmtk::vm::ActivePlan;
 use mmtk::util::opaque_pointer::*;
 use mmtk::Mutator;
-use DummyVM;
-use SINGLETON;
+use crate::DummyVM;
+use crate::SINGLETON;
 
 pub struct VMActivePlan<> {}
 

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -10,8 +10,8 @@ use mmtk::util::opaque_pointer::*;
 use mmtk::scheduler::{GCController, GCWorker};
 use mmtk::Mutator;
 use mmtk::MMTK;
-use DummyVM;
-use SINGLETON;
+use crate::DummyVM;
+use crate::SINGLETON;
 
 #[no_mangle]
 pub extern "C" fn mmtk_gc_init(heap_size: usize) {
@@ -97,17 +97,23 @@ pub extern "C" fn mmtk_total_bytes() -> usize {
 
 #[no_mangle]
 pub extern "C" fn mmtk_is_live_object(object: ObjectReference) -> bool{
-    object.is_live()
+    memory_manager::is_live_object(object)
+}
+
+#[cfg(feature = "is_mmtk_object")]
+#[no_mangle]
+pub extern "C" fn mmtk_is_mmtk_object(addr: Address) -> bool {
+    memory_manager::is_mmtk_object(addr)
 }
 
 #[no_mangle]
-pub extern "C" fn mmtk_is_mapped_object(object: ObjectReference) -> bool {
-    object.is_mapped()
+pub extern "C" fn mmtk_is_in_mmtk_spaces(object: ObjectReference) -> bool {
+    memory_manager::is_in_mmtk_spaces(object)
 }
 
 #[no_mangle]
 pub extern "C" fn mmtk_is_mapped_address(address: Address) -> bool {
-    address.is_mapped()
+    memory_manager::is_mapped_address(address)
 }
 
 #[no_mangle]

--- a/vmbindings/dummyvm/src/collection.rs
+++ b/vmbindings/dummyvm/src/collection.rs
@@ -3,7 +3,7 @@ use mmtk::vm::GCThreadContext;
 use mmtk::MutatorContext;
 use mmtk::util::opaque_pointer::*;
 use mmtk::scheduler::*;
-use DummyVM;
+use crate::DummyVM;
 
 pub struct VMCollection {}
 

--- a/vmbindings/dummyvm/src/lib.rs
+++ b/vmbindings/dummyvm/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_fn_trait_bound)] // for static fixtures
+
 extern crate mmtk;
 extern crate libc;
 #[macro_use]

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -3,9 +3,13 @@ use mmtk::util::metadata::header_metadata::HeaderMetadataSpec;
 use mmtk::util::{Address, ObjectReference};
 use mmtk::vm::*;
 use std::sync::atomic::Ordering;
-use DummyVM;
+use crate::DummyVM;
 
 pub struct VMObjectModel {}
+
+// This is intentionally set to a non-zero value to see if it breaks.
+// Change this if you want to test other values.
+pub const OBJECT_REF_OFFSET: usize = 6;
 
 impl ObjectModel<DummyVM> for VMObjectModel {
     const GLOBAL_LOG_BIT_SPEC: VMGlobalLogBitSpec = VMGlobalLogBitSpec::in_header(0);
@@ -20,7 +24,8 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         _mask: Option<usize>,
         _atomic_ordering: Option<Ordering>,
     ) -> usize {
-        unimplemented!()
+        // Do nothing at this moment.
+        0
     }
 
     fn store_metadata(
@@ -30,7 +35,7 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         _mask: Option<usize>,
         _atomic_ordering: Option<Ordering>,
     ) {
-        unimplemented!()
+        // Do nothing at this moment.
     }
 
     fn compare_exchange_metadata(
@@ -99,8 +104,8 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         unimplemented!()
     }
 
-    fn object_start_ref(_object: ObjectReference) -> Address {
-        unimplemented!()
+    fn object_start_ref(object: ObjectReference) -> Address {
+        object.to_address().sub(OBJECT_REF_OFFSET)
     }
 
     fn ref_to_address(_object: ObjectReference) -> Address {

--- a/vmbindings/dummyvm/src/reference_glue.rs
+++ b/vmbindings/dummyvm/src/reference_glue.rs
@@ -2,7 +2,7 @@ use mmtk::vm::ReferenceGlue;
 use mmtk::util::ObjectReference;
 use mmtk::TraceLocal;
 use mmtk::util::opaque_pointer::*;
-use DummyVM;
+use crate::DummyVM;
 
 pub struct VMReferenceGlue {}
 

--- a/vmbindings/dummyvm/src/tests/conservatism.rs
+++ b/vmbindings/dummyvm/src/tests/conservatism.rs
@@ -1,0 +1,154 @@
+// GITHUB-CI: MMTK_PLAN=all
+// GITHUB-CI: FEATURES=is_mmtk_object
+
+use crate::api::*;
+use crate::object_model::OBJECT_REF_OFFSET;
+use crate::tests::fixtures::{Fixture, SingleObject};
+use mmtk::util::constants::LOG_BITS_IN_WORD;
+use mmtk::util::is_mmtk_object::ALLOC_BIT_REGION_SIZE;
+use mmtk::util::*;
+
+static SINGLE_OBJECT: Fixture<SingleObject> = Fixture::new();
+
+fn basic_filter(addr: Address) -> bool {
+    !addr.is_zero() && addr.as_usize() % ALLOC_BIT_REGION_SIZE == OBJECT_REF_OFFSET
+}
+
+fn assert_filter_pass(addr: Address) {
+    assert!(
+        basic_filter(addr),
+        "{} should pass basic filter, but failed.",
+        addr,
+    );
+}
+
+fn assert_filter_fail(addr: Address) {
+    assert!(
+        !basic_filter(addr),
+        "{} should fail basic filter, but passed.",
+        addr,
+    );
+}
+
+fn assert_valid_objref(addr: Address) {
+    assert!(
+        mmtk_is_mmtk_object(addr),
+        "mmtk_is_mmtk_object({}) should return true. Got false.",
+        addr,
+    );
+}
+
+fn assert_invalid_objref(addr: Address, real: Address) {
+    assert!(
+        !mmtk_is_mmtk_object(addr),
+        "mmtk_is_mmtk_object({}) should return false. Got true. Real object: {}",
+        addr,
+        real,
+    );
+}
+
+#[test]
+pub fn null() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        let addr = Address::ZERO;
+        assert_filter_fail(addr);
+        assert_invalid_objref(addr, fixture.objref.to_address());
+    });
+}
+
+// This should be small enough w.r.t `HEAP_START` and `HEAP_END`.
+const SMALL_OFFSET: usize = 16384;
+
+#[test]
+pub fn too_small() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        for offset in 1usize..SMALL_OFFSET {
+            let addr = Address::ZERO + offset;
+            assert_invalid_objref(addr, fixture.objref.to_address());
+        }
+    });
+}
+
+#[test]
+pub fn max() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        let addr = Address::MAX;
+        assert_invalid_objref(addr, fixture.objref.to_address());
+    });
+}
+
+#[test]
+pub fn too_big() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        for offset in 1usize..SMALL_OFFSET {
+            let addr = Address::MAX - offset;
+            assert_invalid_objref(addr, fixture.objref.to_address());
+        }
+    });
+}
+
+#[test]
+pub fn direct_hit() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        let addr = fixture.objref.to_address();
+        assert_filter_pass(addr);
+        assert_valid_objref(addr);
+    });
+}
+
+const SEVERAL_PAGES: usize = 4 * mmtk::util::constants::BYTES_IN_PAGE;
+
+#[test]
+pub fn small_offsets() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        for offset in 1usize..SEVERAL_PAGES {
+            let addr = fixture.objref.to_address() + offset;
+            if basic_filter(addr) {
+                assert_invalid_objref(addr, fixture.objref.to_address());
+            }
+        }
+    });
+}
+
+#[test]
+pub fn medium_offsets_aligned() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        let alignment = std::mem::align_of::<Address>();
+        for offset in (alignment..(alignment * SEVERAL_PAGES)).step_by(alignment) {
+            let addr = fixture.objref.to_address() + offset;
+            assert_filter_pass(addr);
+            assert_invalid_objref(addr, fixture.objref.to_address());
+        }
+    });
+}
+
+#[test]
+pub fn large_offsets_aligned() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        for log_offset in 12usize..(usize::BITS as usize) {
+            let offset = 1usize << log_offset;
+            let addr = match fixture.objref.to_address().as_usize().checked_add(offset) {
+                Some(n) => unsafe { Address::from_usize(n) },
+                None => break,
+            };
+            assert_filter_pass(addr);
+            assert_invalid_objref(addr, fixture.objref.to_address());
+        }
+    });
+}
+
+#[test]
+pub fn negative_offsets() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        for log_offset in LOG_BITS_IN_WORD..(usize::BITS as usize) {
+            let offset = 1usize << log_offset;
+            let addr = match fixture.objref.to_address().as_usize().checked_sub(offset) {
+                Some(0) => break,
+                Some(n) => unsafe { Address::from_usize(n) },
+                None => break,
+            };
+            assert_filter_pass(addr);
+            assert_invalid_objref(addr, fixture.objref.to_address());
+        }
+    });
+}

--- a/vmbindings/dummyvm/src/tests/fixtures/mod.rs
+++ b/vmbindings/dummyvm/src/tests/fixtures/mod.rs
@@ -1,0 +1,68 @@
+use atomic_refcell::AtomicRefCell;
+use std::sync::Once;
+
+use mmtk::AllocationSemantics;
+use mmtk::util::{ObjectReference, VMThread, VMMutatorThread};
+
+use crate::api::*;
+use crate::object_model::OBJECT_REF_OFFSET;
+
+pub trait FixtureContent {
+    fn create() -> Self;
+}
+
+pub struct Fixture<T: FixtureContent> {
+    content: AtomicRefCell<Option<Box<T>>>,
+    once: Once,
+}
+
+unsafe impl<T: FixtureContent> Sync for Fixture<T> {}
+
+impl<T: FixtureContent> Fixture<T> {
+    pub const fn new() -> Self {
+        Self {
+            content: AtomicRefCell::new(None),
+            once: Once::new(),
+        }
+    }
+
+    pub fn with_fixture<F: Fn(&T)>(&self, func: F) {
+        self.once.call_once(|| {
+            let content = Box::new(T::create());
+            let mut borrow = self.content.borrow_mut();
+            *borrow = Some(content);
+        });
+        {
+            let borrow = self.content.borrow();
+            func(borrow.as_ref().unwrap())
+        }
+    }
+}
+
+pub struct SingleObject {
+    pub objref: ObjectReference,
+}
+
+impl FixtureContent for SingleObject {
+    fn create() -> Self {
+        const MB: usize = 1024 * 1024;
+        // 1MB heap
+        mmtk_gc_init(MB);
+        mmtk_initialize_collection(VMThread::UNINITIALIZED);
+        // Make sure GC does not run during test.
+        mmtk_disable_collection();
+        let handle = mmtk_bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
+
+        // A relatively small object, typical for Ruby.
+        let size = 40;
+        let semantics = AllocationSemantics::Default;
+
+        let addr = mmtk_alloc(handle, size, 8, 0, semantics);
+        assert!(!addr.is_zero());
+
+        let objref = unsafe { addr.add(OBJECT_REF_OFFSET).to_object_reference() };
+        mmtk_post_alloc(handle, objref, size, semantics);
+
+        SingleObject { objref }
+    }
+}

--- a/vmbindings/dummyvm/src/tests/is_in_mmtk_spaces.rs
+++ b/vmbindings/dummyvm/src/tests/is_in_mmtk_spaces.rs
@@ -1,0 +1,69 @@
+// GITHUB-CI: MMTK_PLAN=all
+
+use crate::tests::fixtures::{Fixture, SingleObject};
+use mmtk::memory_manager::is_in_mmtk_spaces;
+use mmtk::util::*;
+
+static SINGLE_OBJECT: Fixture<SingleObject> = Fixture::new();
+
+#[test]
+pub fn null() {
+    SINGLE_OBJECT.with_fixture(|_fixture| {
+        assert!(
+            !is_in_mmtk_spaces(unsafe { Address::ZERO.to_object_reference() }),
+            "NULL pointer should not be in any MMTk spaces."
+        );
+    });
+}
+
+#[test]
+pub fn max() {
+    SINGLE_OBJECT.with_fixture(|_fixture| {
+        assert!(
+            !is_in_mmtk_spaces(unsafe { Address::MAX.to_object_reference() }),
+            "Address::MAX should not be in any MMTk spaces."
+        );
+    });
+}
+
+#[test]
+pub fn direct_hit() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        assert!(
+            is_in_mmtk_spaces(fixture.objref),
+            "The address of the allocated object should be in the space"
+        );
+    });
+}
+
+#[test]
+pub fn large_offsets_aligned() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        for log_offset in 12usize..(usize::BITS as usize) {
+            let offset = 1usize << log_offset;
+            let addr = match fixture.objref.to_address().as_usize().checked_add(offset) {
+                Some(n) => unsafe { Address::from_usize(n) },
+                None => break,
+            };
+            // It's just a smoke test.  It is hard to predict if the addr is still in any space,
+            // but it must not crash.
+            let _ = is_in_mmtk_spaces(unsafe { addr.to_object_reference() });
+        }
+    });
+}
+
+#[test]
+pub fn negative_offsets() {
+    SINGLE_OBJECT.with_fixture(|fixture| {
+        for log_offset in 1usize..(usize::BITS as usize) {
+            let offset = 1usize << log_offset;
+            let addr = match fixture.objref.to_address().as_usize().checked_sub(offset) {
+                Some(n) => unsafe { Address::from_usize(n) },
+                None => break,
+            };
+            // It's just a smoke test.  It is hard to predict if the addr is still in any space,
+            // but it must not crash.
+            let _ = is_in_mmtk_spaces(unsafe { addr.to_object_reference() });
+        }
+    });
+}

--- a/vmbindings/dummyvm/src/tests/mod.rs
+++ b/vmbindings/dummyvm/src/tests/mod.rs
@@ -1,6 +1,9 @@
-// Each module should only contain one #[test] function.
-// We should run each module in a separate test process, as we do not have proper
-// setup/teardown procedure for MMTk instances.
+// NOTE: Since the dummyvm uses a global MMTK instance,
+// it will panic if MMTK initialized more than once per process.
+// We run each of the following modules in a separate test process.
+//
+// One way to avoid re-initialization is to have only one #[test] per module.
+// There are also helpers for creating fixtures in `fixture/mod.rs`.
 mod issue139;
 mod handle_mmap_oom;
 mod handle_mmap_conflict;
@@ -9,3 +12,7 @@ mod allocate_with_initialize_collection;
 mod allocate_with_disable_collection;
 mod allocate_with_re_enable_collection;
 mod malloc;
+#[cfg(feature = "is_mmtk_object")]
+mod conservatism;
+mod is_in_mmtk_spaces;
+mod fixtures;


### PR DESCRIPTION
This PR adds a function to support conservative GC.  It tests whether a given address (any address, no requirement) points to an object allocated in MMTk.

The function is named `memory_manager::is_mmtk_object`.  The existing `SFT::is_mmtk_object` is renamed to `SFT::is_in_space`, and `memory_manager::is_mapped_object is renamed to is_in_mmtk_spaces`.

This function requires the `global_alloc_bit` feature.

This PR does not change `memory_manager::is_mapped_address`.  That function is used only in JikesRVM for two purposes: testing if an object is in the heap, and testing if the code is (JIT-compiled) VM code, not native code. I am still uncertain about the appropriate approach for JikesRVM + Rust MMTk.