### PR TITLE
Add post_copy() for ImmixCopyContext: mark object and line

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -14,7 +14,9 @@ use crate::util::heap::HeapMeta;
 use crate::util::heap::PageResource;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{self, *};
-use crate::util::metadata::{self, compare_exchange_metadata, load_metadata, MetadataSpec, store_metadata};
+use crate::util::metadata::{
+    self, compare_exchange_metadata, load_metadata, store_metadata, MetadataSpec,
+};
 use crate::util::object_forwarding as ForwardingWord;
 use crate::util::{Address, ObjectReference};
 use crate::vm::*;
@@ -679,7 +681,10 @@ impl<VM: VMBinding> ImmixCopyContext<VM> {
     #[inline(always)]
     fn get_space(&self) -> &ImmixSpace<VM> {
         // Both copy allocators should point to the same space.
-        debug_assert_eq!(self.defrag_allocator.immix_space().common().descriptor, self.copy_allocator.immix_space().common().descriptor);
+        debug_assert_eq!(
+            self.defrag_allocator.immix_space().common().descriptor,
+            self.copy_allocator.immix_space().common().descriptor
+        );
         // Just get the space from either allocator
         self.defrag_allocator.immix_space()
     }


### PR DESCRIPTION
This PR adds `post_copy()` for `ImmixCopyContext`, which marks the new object and conditionally marks the line for the object. Without this PR, copied Immix objects were not considered as 'live' (by `is_live()`), and GC work after copying (such as reference processing) may behave incorrectly if they use `is_live()`. This PR is related to https://github.com/mmtk/mmtk-core/issues/501.