### PR TITLE
Fix object reference confusion for mark compact

### DIFF
--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -50,11 +50,11 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         // scheduler.work_buckets[WorkBucketStage::RefForwarding]
         //     .add(ScanStackRoots::<ForwardingProcessEdges<VM>>::new());
         for mutator in VM::VMActivePlan::mutators() {
-            mmtk.scheduler.work_buckets[WorkBucketStage::RefForwarding]
+            mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
                 .add(ScanStackRoot::<ForwardingProcessEdges<VM>>(mutator));
         }
 
-        mmtk.scheduler.work_buckets[WorkBucketStage::RefForwarding]
+        mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
             .add(ScanVMSpecificRoots::<ForwardingProcessEdges<VM>>::new());
     }
 }

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -111,20 +111,6 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         scheduler.work_buckets[WorkBucketStage::Release]
             .add(Release::<MarkCompactGCWorkContext<VM>>::new(self));
 
-        // Reference processing
-        if !*self.base().options.no_reference_types {
-            use crate::util::reference_processor::{SoftRefProcessing, WeakRefProcessing, PhantomRefProcessing};
-            scheduler.work_buckets[WorkBucketStage::SoftRefClosure].add(SoftRefProcessing::<MarkingProcessEdges<VM>>::new());
-            scheduler.work_buckets[WorkBucketStage::WeakRefClosure].add(WeakRefProcessing::<MarkingProcessEdges<VM>>::new());
-            scheduler.work_buckets[WorkBucketStage::PhantomRefClosure].add(PhantomRefProcessing::<MarkingProcessEdges<VM>>::new());
-
-            use crate::util::reference_processor::RefForwarding;
-            scheduler.work_buckets[WorkBucketStage::RefForwarding].add(RefForwarding::<ForwardingProcessEdges<VM>>::new());
-
-            use crate::util::reference_processor::RefEnqueue;
-            scheduler.work_buckets[WorkBucketStage::Release].add(RefEnqueue::<ForwardingProcessEdges<VM>>::new());
-        }
-
         // Finalization
         if !*self.base().options.no_finalizer {
             use crate::util::finalizable_processor::{Finalization, ForwardFinalization};

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -120,6 +120,9 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
 
             use crate::util::reference_processor::RefForwarding;
             scheduler.work_buckets[WorkBucketStage::RefForwarding].add(RefForwarding::<ForwardingProcessEdges<VM>>::new());
+
+            use crate::util::reference_processor::RefEnqueue;
+            scheduler.work_buckets[WorkBucketStage::Release].add(RefEnqueue::<ForwardingProcessEdges<VM>>::new());
         }
 
         // Finalization

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -18,6 +18,9 @@ pub struct MarkCompactSpace<VM: VMBinding> {
 
 const GC_MARK_BIT_MASK: usize = 1;
 
+/// For each MarkCompact object, we need one extra word for storing forwarding pointer (Lisp-2 implementation).
+/// Note that considering the object alignment, we may end up allocating/reserving more than one word per object.
+/// See [`MarkCompactSpace::HEADER_RESERVED_IN_BYTES`].
 pub const GC_EXTRA_HEADER_WORD: usize = 1;
 const GC_EXTRA_HEADER_BYTES: usize = GC_EXTRA_HEADER_WORD << LOG_BYTES_IN_WORD;
 
@@ -27,11 +30,13 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
     }
 
     #[inline(always)]
-    fn get_forwarded_object(&self, _object: ObjectReference) -> Option<ObjectReference> {
-        // the current forwarding pointer implementation will store forwarding pointers
-        // in dead objects' header, which is not the case in mark compact. Mark compact
-        // implements its own forwarding mechanism
-        unimplemented!()
+    fn get_forwarded_object(&self, object: ObjectReference) -> Option<ObjectReference> {
+        let forwarding_pointer = Self::get_header_forwarding_pointer(object);
+        if forwarding_pointer.is_null() {
+            None
+        } else {
+            Some(forwarding_pointer)
+        }
     }
 
     fn is_live(&self, object: ObjectReference) -> bool {
@@ -93,12 +98,41 @@ impl<VM: VMBinding> Space<VM> for MarkCompactSpace<VM> {
 }
 
 impl<VM: VMBinding> MarkCompactSpace<VM> {
+    /// We need one extra header word for each object. Considering the alignment requirement, this is
+    /// the actual bytes we need to reserve for each allocation.
     pub const HEADER_RESERVED_IN_BYTES: usize = if VM::MAX_ALIGNMENT > GC_EXTRA_HEADER_BYTES {
         VM::MAX_ALIGNMENT
     } else {
         GC_EXTRA_HEADER_BYTES
     }
     .next_power_of_two();
+
+    // The following are a few functions for manipulating header forwarding poiner.
+    // Basically for each allocation request, we allocate extra bytes of [`HEADER_RESERVED_IN_BYTES`].
+    // From the allocation result we get (e.g. `alloc_res`), `alloc_res + HEADER_RESERVED_IN_BYTES` is the cell
+    // address we return to the binding. It ensures we have at least one word (`GC_EXTRA_HEADER_WORD`) before
+    // the cell address, and ensures the cell address is properly aligned.
+    // From the cell address, `cell - GC_EXTRA_HEADER_WORD` is where we store the header forwarding pointer.
+
+    /// Get the address for header forwarding pointer
+    fn header_forwarding_pointer_address(object: ObjectReference) -> Address {
+        VM::VMObjectModel::object_start_ref(object) - GC_EXTRA_HEADER_BYTES
+    }
+
+    /// Get header forwarding pointer for an object
+    fn get_header_forwarding_pointer(object: ObjectReference) -> ObjectReference {
+        unsafe { Self::header_forwarding_pointer_address(object).load::<ObjectReference>() }
+    }
+
+    /// Store header forwarding pointer for an object
+    fn store_header_forwarding_pointer(object: ObjectReference, forwarding_pointer: ObjectReference) {
+        unsafe { Self::header_forwarding_pointer_address(object).store::<ObjectReference>(forwarding_pointer); }
+    }
+
+    // Clear header forwarding pointer for an object
+    fn clear_header_forwarding_pointer(object: ObjectReference) {
+        crate::util::memory::zero(Self::header_forwarding_pointer_address(object), GC_EXTRA_HEADER_BYTES);
+    }
 
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -174,13 +208,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             trace.process_node(object);
         }
 
-        // For markcompact, only one word is required to store the forwarding pointer
-        // and it is always stored in front of the object start address. However, the
-        // number of extra bytes required is determined by the object alignment
-        let forwarding_pointer =
-            unsafe { (object.to_address() - GC_EXTRA_HEADER_BYTES).load::<Address>() };
-
-        unsafe { (forwarding_pointer + Self::HEADER_RESERVED_IN_BYTES).to_object_reference() }
+        Self::get_header_forwarding_pointer(object)
     }
 
     pub fn test_and_mark(object: ObjectReference) -> bool {
@@ -268,10 +296,15 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             let align = VM::VMObjectModel::get_align_when_copied(obj);
             let offset = VM::VMObjectModel::get_align_offset_when_copied(obj);
             to = align_allocation_no_fill::<VM>(to, align, offset);
-            let forwarding_pointer_addr = obj.to_address() - GC_EXTRA_HEADER_BYTES;
-            unsafe { forwarding_pointer_addr.store(to) }
+            let new_obj = VM::VMObjectModel::get_reference_when_copied_to(obj, to + Self::HEADER_RESERVED_IN_BYTES);
+
+            Self::store_header_forwarding_pointer(obj, new_obj);
+
+            trace!("Calculate forward: {} (size when copied = {}) ~> {} (size = {})", obj, VM::VMObjectModel::get_size_when_copied(obj), to, copied_size);
+
             to += copied_size;
         }
+        debug!("Calculate forward end: to = {}", to);
     }
 
     pub fn compact(&self) {
@@ -287,27 +320,26 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             // clear the alloc bit
             alloc_bit::unset_addr_alloc_bit(obj.to_address());
 
-            let forwarding_pointer_addr = obj.to_address() - GC_EXTRA_HEADER_BYTES;
-            let forwarding_pointer = unsafe { forwarding_pointer_addr.load::<Address>() };
-            if forwarding_pointer != Address::ZERO {
+            let forwarding_pointer = Self::get_header_forwarding_pointer(obj);
+
+            trace!("Compact {} to {}", obj, forwarding_pointer);
+            if !forwarding_pointer.is_null() {
                 let copied_size =
-                    VM::VMObjectModel::get_size_when_copied(obj) + Self::HEADER_RESERVED_IN_BYTES;
-                to = forwarding_pointer;
-                let object_addr = forwarding_pointer + Self::HEADER_RESERVED_IN_BYTES;
-                // clear forwarding pointer
-                crate::util::memory::zero(
-                    forwarding_pointer + Self::HEADER_RESERVED_IN_BYTES - GC_EXTRA_HEADER_BYTES,
-                    GC_EXTRA_HEADER_BYTES,
-                );
-                crate::util::memory::zero(forwarding_pointer_addr, GC_EXTRA_HEADER_BYTES);
+                    VM::VMObjectModel::get_size_when_copied(obj);
+                let new_object = forwarding_pointer;
+                Self::clear_header_forwarding_pointer(new_object);
+
                 // copy object
-                let target = unsafe { object_addr.to_object_reference() };
-                VM::VMObjectModel::copy_to(obj, target, Address::ZERO);
+                trace!(" copy from {} to {}", obj, new_object);
+                let end_of_new_object = VM::VMObjectModel::copy_to(obj, new_object, Address::ZERO);
                 // update alloc_bit,
-                alloc_bit::set_alloc_bit(target);
-                to += copied_size
+                alloc_bit::set_alloc_bit(new_object);
+                to = new_object.to_address() + copied_size;
+                debug_assert_eq!(end_of_new_object, to);
             }
         }
+
+        debug!("Compact end: to = {}", to);
 
         // reset the bump pointer
         self.pr.reset_cursor(to);
@@ -319,6 +351,6 @@ impl<VM: VMBinding> crate::util::linear_scan::LinearScanObjectSize for MarkCompa
     #[inline(always)]
     fn size(object: ObjectReference) -> usize {
         VM::VMObjectModel::get_current_size(object)
-            + MarkCompactSpace::<VM>::HEADER_RESERVED_IN_BYTES
+            // + MarkCompactSpace::<VM>::HEADER_RESERVED_IN_BYTES
     }
 }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -248,36 +248,33 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
     }
 
     pub fn deactivate_all(&self) {
-        self.work_buckets[WorkBucketStage::Prepare].deactivate();
-        self.work_buckets[WorkBucketStage::Closure].deactivate();
-        self.work_buckets[WorkBucketStage::RefClosure].deactivate();
-        self.work_buckets[WorkBucketStage::CalculateForwarding].deactivate();
-        self.work_buckets[WorkBucketStage::RefForwarding].deactivate();
-        self.work_buckets[WorkBucketStage::Compact].deactivate();
-        self.work_buckets[WorkBucketStage::Release].deactivate();
-        self.work_buckets[WorkBucketStage::Final].deactivate();
+        for (stage, bucket) in self.work_buckets.iter() {
+            if stage == WorkBucketStage::Unconstrained {
+                continue;
+            }
+
+            bucket.deactivate();
+        }
     }
 
     pub fn reset_state(&self) {
-        // self.work_buckets[WorkBucketStage::Prepare].deactivate();
-        self.work_buckets[WorkBucketStage::Closure].deactivate();
-        self.work_buckets[WorkBucketStage::RefClosure].deactivate();
-        self.work_buckets[WorkBucketStage::CalculateForwarding].deactivate();
-        self.work_buckets[WorkBucketStage::RefForwarding].deactivate();
-        self.work_buckets[WorkBucketStage::Compact].deactivate();
-        self.work_buckets[WorkBucketStage::Release].deactivate();
-        self.work_buckets[WorkBucketStage::Final].deactivate();
+        for (stage, bucket) in self.work_buckets.iter() {
+            if stage == WorkBucketStage::Unconstrained || stage == WorkBucketStage::Prepare {
+                continue;
+            }
+
+            bucket.deactivate();
+        }
     }
 
     pub fn debug_assert_all_buckets_deactivated(&self) {
-        debug_assert!(!self.work_buckets[WorkBucketStage::Prepare].is_activated());
-        debug_assert!(!self.work_buckets[WorkBucketStage::Closure].is_activated());
-        debug_assert!(!self.work_buckets[WorkBucketStage::RefClosure].is_activated());
-        debug_assert!(!self.work_buckets[WorkBucketStage::CalculateForwarding].is_activated());
-        debug_assert!(!self.work_buckets[WorkBucketStage::RefForwarding].is_activated());
-        debug_assert!(!self.work_buckets[WorkBucketStage::Compact].is_activated());
-        debug_assert!(!self.work_buckets[WorkBucketStage::Release].is_activated());
-        debug_assert!(!self.work_buckets[WorkBucketStage::Final].is_activated());
+        for (stage, bucket) in self.work_buckets.iter() {
+            if stage == WorkBucketStage::Unconstrained {
+                return;
+            }
+
+            debug_assert!(!bucket.is_activated());
+        }
     }
 
     pub fn add_coordinator_work(&self, work: impl CoordinatorWork<VM>, worker: &GCWorker<VM>) {

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -59,6 +59,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             WorkBucketStage::Closure => WorkBucket::new(false, worker_monitor.clone()),
             WorkBucketStage::RefClosure => WorkBucket::new(false, worker_monitor.clone()),
             WorkBucketStage::CalculateForwarding => WorkBucket::new(false, worker_monitor.clone()),
+            WorkBucketStage::SecondRoots => WorkBucket::new(false, worker_monitor.clone()),
             WorkBucketStage::RefForwarding => WorkBucket::new(false, worker_monitor.clone()),
             WorkBucketStage::Compact => WorkBucket::new(false, worker_monitor.clone()),
             WorkBucketStage::Release => WorkBucket::new(false, worker_monitor.clone()),
@@ -93,6 +94,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             open_next(Closure);
             open_next(RefClosure);
             open_next(CalculateForwarding);
+            open_next(SecondRoots);
             open_next(RefForwarding);
             open_next(Compact);
             open_next(Release);

--- a/src/scheduler/work_bucket.rs
+++ b/src/scheduler/work_bucket.rs
@@ -158,6 +158,7 @@ pub enum WorkBucketStage {
     // we may need more than one buckets for each reference strength.
     RefClosure,
     CalculateForwarding,
+    SecondRoots,
     RefForwarding,
     Compact,
     Release,


### PR DESCRIPTION
This pull request refactors `MarkCompactSpace`. The current implementation uses address and object reference interchangeably, which assumes bindings have no offset between object reference and address. This PR now properly uses object reference in `MarkCompactSpace`.

* `MarkCompactSpace` no longer casts an address directly to an object reference. It uses proper methods to get object references from the binding.
* `MarkCompactSpace` now stores an object reference to the new object as its forwarding pointer.
* `MarkCompactSpace` now has a few functions to access the forwarding pointer.
* A new work bucket `SecondRoots` is added. So the second round root scanning will happen before `RefForwarding`.