### PR TITLE
Fix allocation bytes increment for precise stress test

### DIFF
--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -373,7 +373,7 @@ pub struct BasePlan<VM: VMBinding> {
     stacks_prepared: AtomicBool,
     pub mutator_iterator_lock: Mutex<()>,
     // A counter that keeps tracks of the number of bytes allocated since last stress test
-    allocation_bytes: AtomicUsize,
+    pub allocation_bytes: AtomicUsize,
     // Wrapper around analysis counters
     #[cfg(feature = "analysis")]
     pub analysis_manager: AnalysisManager<VM>,

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -173,14 +173,18 @@ impl<VM: VMBinding> BumpAllocator<VM> {
             );
             if !stress_test {
                 self.set_limit(acquired_start, acquired_start + block_size);
+                self.alloc(size, align, offset)
             } else {
                 // For a stress test, we artificially make the fastpath fail by
                 // manipulating the limit as below.
                 // The assumption here is that we use an address range such that
                 // cursor > block_size always.
                 self.set_limit(acquired_start, unsafe { Address::from_usize(block_size) });
+                // Note that we have just acquired a new block so we know that we don't have to go
+                // through the entire allocation sequence again, we can directly call the slow path
+                // allocation.
+                self.alloc_slow_once_precise_stress(size, align, offset, false)
             }
-            self.alloc(size, align, offset)
         }
     }
 }

--- a/src/util/rust_util.rs
+++ b/src/util/rust_util.rs
@@ -1,10 +1,38 @@
-/// Const funciton for min value of two usize numbers.
+/// Const function for min value of two usize numbers.
 pub const fn min_of_usize(a: usize, b: usize) -> usize {
     if a > b {
         b
     } else {
         a
     }
+}
+
+#[cfg(feature = "nightly")]
+use core::intrinsics::{likely, unlikely};
+
+// likely() and unlikely() compiler hints in stable Rust
+// [1]: https://github.com/rust-lang/hashbrown/blob/a41bd76de0a53838725b997c6085e024c47a0455/src/raw/mod.rs#L48-L70
+// [2]: https://users.rust-lang.org/t/compiler-hint-for-unlikely-likely-for-if-branches/62102/3
+#[cfg(not(feature = "nightly"))]
+#[inline]
+#[cold]
+fn cold() {}
+
+#[cfg(not(feature = "nightly"))]
+#[inline]
+pub fn likely(b: bool) -> bool {
+    if !b {
+        cold();
+    }
+    b
+}
+#[cfg(not(feature = "nightly"))]
+#[inline]
+pub fn unlikely(b: bool) -> bool {
+    if b {
+        cold();
+    }
+    b
 }
 
 use std::cell::UnsafeCell;


### PR DESCRIPTION
This change fixes two related bugs:

  1. Currently, when a thread-local block is exhausted, there will be
     multiple nested allocation calls (specifically to
     `alloc_slow_inline`) that will try to increase the allocation bytes
     resulting in double counting of an allocation. We mitigate this by
     ensuring that calls to `alloc_slow_inline` are not re-entrant

  2. ImmixAllocator missed updates to the allocation bytes counter after
     the first GC. This was due to the ImmixAllocator reusing lines
     which implicitly updated the cursor and limit. The updated cursor
     and limit didn't fail the test for fast path and hence, the
     allocator missed updates to the allocation bytes. We fix this by
     directly calling the slow path (instead of going through the fast
     path) after obtaining a recycled line in the case when stress test
     is active