### PR TITLE
Get finalizable object before object dies

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -490,13 +490,31 @@ pub fn add_finalizer<VM: VMBinding>(mmtk: &'static MMTK<VM>, object: ObjectRefer
 /// * `mmtk`: A reference to an MMTk instance.
 pub fn get_finalized_object<VM: VMBinding>(mmtk: &'static MMTK<VM>) -> Option<ObjectReference> {
     if *mmtk.options.no_finalizer {
-        warn!("get_object_for_finalization() is called when no_finalizer = true");
+        warn!("get_finalized_object() is called when no_finalizer = true");
     }
 
     mmtk.finalizable_processor
         .lock()
         .unwrap()
         .get_ready_object()
+}
+
+/// Get an object registered for finalization. The returned object may or may not be ready for
+/// finalization.
+///
+/// This is useful for some VMs which require all finalizable objects to be finalized on exit.
+///
+/// Arguments:
+/// * `mmtk`: A reference to an MMTk instance.
+pub fn get_object_added_for_finalization<VM: VMBinding>(mmtk: &'static MMTK<VM>) -> Option<ObjectReference> {
+    if *mmtk.options.no_finalizer {
+        warn!("get_object_added_for_finalization() is called when no_finalizer = true");
+    }
+
+    mmtk.finalizable_processor
+        .lock()
+        .unwrap()
+        .get_added_object()
 }
 
 /// Get the number of workers. MMTk spawns worker threads for the 'threads' defined in the options.

--- a/src/util/finalizable_processor.rs
+++ b/src/util/finalizable_processor.rs
@@ -101,6 +101,12 @@ impl FinalizableProcessor {
     pub fn get_ready_object(&mut self) -> Option<ObjectReference> {
         self.ready_for_finalize.pop()
     }
+
+    pub fn get_added_object(&mut self) -> Option<ObjectReference> {
+        self.ready_for_finalize.pop().or_else(|| {
+            self.candidates.pop()
+        })
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Add an API to get a reference to an object registered for finalization even before the object actual dies.  This is useful for VMs which calls all finalizers before VM exits, such as Ruby.

Draft: **This has not been tested, yet.**  Currently, the `Finalization` work packet depends on `ProcessEdgesWork`, but Ruby can only process objects at a time, and cannot enqueue edges.  This prevents me from testing it on Ruby.