### PR TITLE
Don't panic if forwarding word is not FORWARDED and add debug assertions

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -394,6 +394,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             // We lost the forwarding race as some other thread has set the forwarding word; wait
             // until the object has been forwarded by the winner. Note that the object may not
             // necessarily get forwarded since Immix opportunistically moves objects.
+            #[allow(clippy::let_and_return)]
             let new_object =
                 ForwardingWord::spin_and_get_forwarded_object::<VM>(object, forwarding_status);
             #[cfg(debug_assertions)]
@@ -401,14 +402,14 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 if new_object == object {
                     debug_assert!(
                         self.is_marked(object, self.mark_state) || self.defrag.space_exhausted() || Self::is_pinned(object),
-                        "Forwarded object is the same as original object {:?} even though it should have been copied",
+                        "Forwarded object is the same as original object {} even though it should have been copied",
                         object,
                     );
                 } else {
                     // new_object != object
                     debug_assert!(
                         !Block::containing::<VM>(new_object).is_defrag_source(),
-                        "Block {:?} containing forwarded object {:?} should not be a defragmentation source",
+                        "Block {:?} containing forwarded object {} should not be a defragmentation source",
                         Block::containing::<VM>(new_object),
                         new_object,
                     );
@@ -420,7 +421,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             // forwarding status and return the unmoved object
             debug_assert!(
                 self.defrag.space_exhausted() || Self::is_pinned(object),
-                "Forwarded object is the same as original object {:?} even though it should have been copied",
+                "Forwarded object is the same as original object {} even though it should have been copied",
                 object,
             );
             ForwardingWord::clear_forwarding_bits::<VM>(object);

--- a/src/util/object_forwarding.rs
+++ b/src/util/object_forwarding.rs
@@ -67,7 +67,7 @@ pub fn spin_and_get_forwarded_object<VM: VMBinding>(
         // the forwarding word while another thread was stuck spinning in the above loop.
         // See: https://github.com/mmtk/mmtk-core/issues/579
         debug_assert!(
-            forwarding_bits == FORWARDED || forwarding_bits == FORWARDING_NOT_TRIGGERED_YET,
+            forwarding_bits == FORWARDING_NOT_TRIGGERED_YET,
             "Invalid/Corrupted forwarding word {:x} for object {}",
             forwarding_bits,
             object,

--- a/src/util/object_forwarding.rs
+++ b/src/util/object_forwarding.rs
@@ -67,8 +67,8 @@ pub fn spin_and_get_forwarded_object<VM: VMBinding>(
         // the forwarding word while another thread was stuck spinning in the above loop.
         // See: https://github.com/mmtk/mmtk-core/issues/579
         debug_assert!(
-            forwarding_bits != BEING_FORWARDED,
-            "Invalid/Corrupted forwarding word {} for object {:?}",
+            forwarding_bits == FORWARDED || forwarding_bits == FORWARDING_NOT_TRIGGERED_YET,
+            "Invalid/Corrupted forwarding word {:x} for object {}",
             forwarding_bits,
             object,
         );


### PR DESCRIPTION
Some policies (such as Immix) can leave objects inplace and can reset
the forwarding word while tracing (such as when Immix is out of space in
its copy allocators). In such a case, we simply want to return the
current object instead of attempting to read the forwarding pointer.
This commit removes our faulty assumption and assertion and adds further
debug assertions for a sanity check.

Closes #579