### PR TITLE
Remove ProcessEdgesBase::worker

### DIFF
--- a/src/plan/generational/gc_work.rs
+++ b/src/plan/generational/gc_work.rs
@@ -1,6 +1,6 @@
 use crate::plan::generational::global::Gen;
 use crate::policy::space::Space;
-use crate::scheduler::gc_work::*;
+use crate::scheduler::{gc_work::*, GCWorker};
 use crate::util::{Address, ObjectReference};
 use crate::vm::*;
 use crate::MMTK;
@@ -23,16 +23,20 @@ impl<VM: VMBinding> ProcessEdgesWork for GenNurseryProcessEdges<VM> {
         Self { gen, base }
     }
     #[inline]
-    fn trace_object(&mut self, object: ObjectReference) -> ObjectReference {
+    fn trace_object(
+        &mut self,
+        worker: &mut GCWorker<Self::VM>,
+        object: ObjectReference,
+    ) -> ObjectReference {
         if object.is_null() {
             return object;
         }
-        self.gen.trace_object_nursery(self, object, self.worker())
+        self.gen.trace_object_nursery(self, object, worker)
     }
     #[inline]
-    fn process_edge(&mut self, slot: Address) {
+    fn process_edge(&mut self, worker: &mut GCWorker<Self::VM>, slot: Address) {
         let object = unsafe { slot.load::<ObjectReference>() };
-        let new_object = self.trace_object(object);
+        let new_object = self.trace_object(worker, object);
         debug_assert!(!self.gen.nursery.in_space(new_object));
         unsafe { slot.store(new_object) };
     }

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -136,11 +136,11 @@ impl<VM: VMBinding> GCWorker<VM> {
         &mut self.copy
     }
 
-    pub fn do_work(&'static mut self, mut work: impl GCWork<VM>) {
+    pub fn do_work(&mut self, mut work: impl GCWork<VM>) {
         work.do_work(self, self.mmtk);
     }
 
-    pub fn do_boxed_work(&'static mut self, mut work: Box<dyn GCWork<VM>>) {
+    pub fn do_boxed_work(&mut self, mut work: Box<dyn GCWork<VM>>) {
         work.do_work(self, self.mmtk);
     }
 


### PR DESCRIPTION
The `ProcessEdgesBase::worker` field is a `*mut GCWorker<VM>`.  This is unsafe.

```rust
pub struct ProcessEdgesBase<VM: VMBinding> {
    pub edges: Vec<Address>,
    pub nodes: Vec<ObjectReference>,
    mmtk: &'static MMTK<VM>,
    worker: *mut GCWorker<VM>,  // This is unsafe. Remove it
    pub roots: bool,
} 
```

`ProcessEdgesWork` needs to access the worker instance because

1.  `XxxxxxSpace::trace_object` needs a `GCWorker<VM>`  reference to get the `CopyContext`, and
2.  `flush()` needs a `GCWorker<VM>` to submit or execute `ScanObjects` work packets.

Currently, `ProcessEdgesWork` attempts to give itself access to `GCWorker` by holding a `*mut GCWorker<VM>` in the `ProcessEdgesBase::worker` field.  *This is unsafe*, because the work packet is not associated to a `GCWorker` until it is executed by a `GCWorker`.  The access to the `*mut GCWorker<VM>` pointer is invalid before `do_work` starts, and after `do_work` finishes.

In idiomatic Rust, if the `GCWorker` is only valid to access during the execution of `gc_work`, it should be passed to `gc_work` as a `&mut GCWorker<VM>` reference.  Rust's borrowing semantics will ensure that it is only borrowed during the execution of `gc_work`.

Actually `GCWork::do_work` already has a `worker: &mut GCWorker<VM>` parameter.  So we can pass it through levels of function calls to give them access to `GCWorker`.

This PR attempts to do this.

**DRAFT**: I added `&mut GCWorker` parameter to too many functions, but only a few functions actually use it.  This may indicate that there is still some room for refactoring.  One possibility is to introduce a struct that has a lifetime parameter `'w` and contains a `&'w mut GCWorker`, and use that struct as the `self`, but only during the execution of `do_work`.