### PR TITLE
Decouple root scanning from ProcessEdgesWork.

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -29,6 +29,7 @@ pub use self::object_model::specs::*;
 pub use self::object_model::ObjectModel;
 pub use self::reference_glue::ReferenceGlue;
 pub use self::scanning::EdgeVisitor;
+pub use self::scanning::RootsHandlerFactory;
 pub use self::scanning::Scanning;
 
 /// The `VMBinding` trait associates with each trait, and provides VM-specific constants.

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -34,6 +34,25 @@ pub trait Scanning<VM: VMBinding> {
         edge_visitor: &mut EV,
     );
 
+    /// Scan and object and process all edges at the same time.
+    ///
+    /// Arguments:
+    /// * `tls`: The VM-specific thread-local storage for the current worker.
+    /// * `object`: The object to be scanned.
+    /// * `trace_object`: Called back for the value held in each edge. The return value of
+    ///   `trace_object` is the new value of the edge.
+    fn scan_object_and_process_edges<F: FnMut(ObjectReference) -> ObjectReference> (
+        _tls: VMWorkerThread,
+        _object: ObjectReference,
+        _trace_object: F,
+    ) {
+        unimplemented!()
+    }
+
+    fn supports_edge_enqueuing(_tls: VMWorkerThread, _object: ObjectReference) -> bool {
+        true
+    }
+
     /// MMTk calls this method at the first time during a collection that thread's stacks
     /// have been scanned. This can be used (for example) to clean up
     /// obsolete compiled methods that are no longer being executed.


### PR DESCRIPTION
This **draft** PR is a proposal for changing the root-scanning interface.

When scanning roots, the VM should only report what roots it has, not deciding what work packets to create.  But currently, `scan_thread_root`, `scan_thread_roots` and `scan_vm_specific_root` take a generic type parameter `<E: ProcessEdgesWork>` which binds them to a `ProcessEdgesWork`.  This may not be general enough, in two ways:

1.  Some VMs cannot present roots as edges.  They can only present roots as nodes because they cannot update the root edges.  One example is the Ruby VM.  It uses conservative stack scanning, and cannot update roots.  It gives the GC a list of **values** on the stack, and some of them are roots (can be filtered using the `is_mmtk_object` function in the core).
2.  Some GC algorithms do root scanning significantly differently than our current `ProcessEdgesWork`.  Although `ProcessEdgesWork` is still a trait, it is too tied to some kinds of GC.  For example, it contains the logic of tracing objects and  scanning objects (via `ScanObjects`).  The real culprit is the `ProcessEdgesWork`.

However, from the code in this PR, we observe that we need to wrap `ProcessEdgesWork` in such a complicated manner just to get a chance to call the plan-specific `trace_object` function.  Probably it is easier to do this refactoring if we eliminate (or weaken) the `ProcessEdgesWork` trait first.