### PR TITLE
Immix should declare that it will use forwarding specs in VMObjectModel.

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -166,6 +166,8 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 MetadataSpec::OnSide(Block::MARK_TABLE),
                 MetadataSpec::OnSide(ChunkMap::ALLOC_TABLE),
                 *VM::VMObjectModel::LOCAL_MARK_BIT_SPEC,
+                *VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC,
+                *VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC,
             ]
         } else {
             vec![
@@ -174,6 +176,8 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 MetadataSpec::OnSide(Block::MARK_TABLE),
                 MetadataSpec::OnSide(ChunkMap::ALLOC_TABLE),
                 *VM::VMObjectModel::LOCAL_MARK_BIT_SPEC,
+                *VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC,
+                *VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC,
             ]
         })
     }


### PR DESCRIPTION
Immix uses forwarding bits and pointers. However, it does not add them to its side metadata context. So if a binding uses side metadata for those specs, Immix won't initialise the side metadata for those specs.

`CopySpace` properly deals with this:
https://github.com/mmtk/mmtk-core/blob/e0273429f5239ab03407b4a93b52b21f45930d88/src/policy/copyspace.rs#L141-L144