### PR TITLE
Replace custom_derive with strum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,12 @@ doctest = false
 # MMTk macros
 mmtk-macros = { version = "0.12.0", path = "macros/" }
 
-custom_derive = "0.1"
-enum_derive = "0.1"
 libc = "0.2"
-jemalloc-sys = {version = "0.3.2", features = ["disable_initial_exec_tls"], optional = true }
-mimalloc-sys = {version = "0.1.6", optional = true }
-hoard-sys = {version = "0.1.1", optional = true }
+jemalloc-sys = { version = "0.3.2", features = ["disable_initial_exec_tls"], optional = true }
+mimalloc-sys = { version = "0.1.6", optional = true }
+hoard-sys = { version = "0.1.1", optional = true }
 lazy_static = "1.1"
-log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
 crossbeam-deque = "0.6"
 num_cpus = "1.8"
 enum-map = "0.6.2"
@@ -37,8 +35,10 @@ atomic-traits = "0.2.0"
 atomic = "0.4.6"
 spin = "0.5.2"
 env_logger = "0.8.2"
-pfm = {version = "0.1.0-beta.1", optional = true}
+pfm = { version = "0.1.0-beta.1", optional = true }
 atomic_refcell = "0.1.7"
+strum = "0.24"
+strum_macros = "0.24"
 
 [dev-dependencies]
 crossbeam = "0.7.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,12 +30,8 @@
 //!   i.e. [the memory manager API](memory_manager/index.html) that allows a language's memory manager to use MMTk
 //!   and [the VMBinding trait](vm/trait.VMBinding.html) that allows MMTk to call the language implementation.
 
-#[macro_use]
-extern crate custom_derive;
-#[macro_use]
-extern crate enum_derive;
-
 extern crate libc;
+extern crate strum_macros;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -4,29 +4,26 @@ use std::cell::UnsafeCell;
 use std::default::Default;
 use std::ops::Deref;
 use std::str::FromStr;
+use strum_macros::EnumString;
 
-custom_derive! {
-    #[derive(Copy, Clone, EnumFromStr, Debug)]
-    pub enum NurseryZeroingOptions {
-        Temporal,
-        Nontemporal,
-        Concurrent,
-        Adaptive,
-    }
+#[derive(Copy, Clone, EnumString, Debug)]
+pub enum NurseryZeroingOptions {
+    Temporal,
+    Nontemporal,
+    Concurrent,
+    Adaptive,
 }
 
-custom_derive! {
-    #[derive(Copy, Clone, EnumFromStr, Debug)]
-    pub enum PlanSelector {
-        NoGC,
-        SemiSpace,
-        GenCopy,
-        GenImmix,
-        MarkSweep,
-        PageProtect,
-        Immix,
-        MarkCompact,
-    }
+#[derive(Copy, Clone, EnumString, Debug)]
+pub enum PlanSelector {
+    NoGC,
+    SemiSpace,
+    GenCopy,
+    GenImmix,
+    MarkSweep,
+    PageProtect,
+    Immix,
+    MarkCompact,
 }
 
 /// MMTk option for perf events


### PR DESCRIPTION
The custom_derive crate has been inactive since 2016. This commit
replaces its use with the strum crate which is more recent and in active
development.