### PR TITLE
Edge trait

### DIFF
--- a/docs/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/tutorial/code/mygc_semispace/gc_work.rs
@@ -42,7 +42,7 @@ impl<VM:VMBinding> ProcessEdgesWork for MyGCProcessEdges<VM> {
     type VM = VM;
     type ScanObjectsWorkType = ScanObjects<Self>;
 
-    fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
+    fn new(edges: Vec<EdgeOf<Self>>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
         let plan = base.plan().downcast_ref::<MyGC<VM>>().unwrap();
         Self { base, plan }

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -2,6 +2,9 @@
 use crate::plan::Plan;
 use crate::policy::space::SFTMap;
 use crate::scheduler::GCWorkScheduler;
+
+#[cfg(feature = "extreme_assertions")]
+use crate::util::edge_logger::EdgeLogger;
 use crate::util::finalizable_processor::FinalizableProcessor;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
@@ -86,7 +89,9 @@ pub struct MMTK<VM: VMBinding> {
         Mutex<FinalizableProcessor<<VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType>>,
     pub(crate) scheduler: Arc<GCWorkScheduler<VM>>,
     #[cfg(feature = "sanity")]
-    pub(crate) sanity_checker: Mutex<SanityChecker>,
+    pub(crate) sanity_checker: Mutex<SanityChecker<VM::VMEdge>>,
+    #[cfg(feature = "extreme_assertions")]
+    pub(crate) edge_logger: EdgeLogger<VM::VMEdge>,
     inside_harness: AtomicBool,
 }
 
@@ -130,6 +135,8 @@ impl<VM: VMBinding> MMTK<VM> {
             #[cfg(feature = "sanity")]
             sanity_checker: Mutex::new(SanityChecker::new()),
             inside_harness: AtomicBool::new(false),
+            #[cfg(feature = "extreme_assertions")]
+            edge_logger: EdgeLogger::new(),
         }
     }
 

--- a/src/plan/generational/gc_work.rs
+++ b/src/plan/generational/gc_work.rs
@@ -1,7 +1,8 @@
 use crate::plan::generational::global::Gen;
 use crate::policy::space::Space;
 use crate::scheduler::gc_work::*;
-use crate::util::{Address, ObjectReference};
+use crate::util::ObjectReference;
+use crate::vm::edge_shape::Edge;
 use crate::vm::*;
 use crate::MMTK;
 use std::ops::{Deref, DerefMut};
@@ -18,7 +19,7 @@ impl<VM: VMBinding> ProcessEdgesWork for GenNurseryProcessEdges<VM> {
     type VM = VM;
     type ScanObjectsWorkType = ScanObjects<Self>;
 
-    fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
+    fn new(edges: Vec<EdgeOf<Self>>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
         let gen = base.plan().generational();
         Self { gen, base }
@@ -34,11 +35,11 @@ impl<VM: VMBinding> ProcessEdgesWork for GenNurseryProcessEdges<VM> {
             .trace_object_nursery(&mut self.base.nodes, object, worker)
     }
     #[inline]
-    fn process_edge(&mut self, slot: Address) {
-        let object = unsafe { slot.load::<ObjectReference>() };
+    fn process_edge(&mut self, slot: EdgeOf<Self>) {
+        let object = slot.load();
         let new_object = self.trace_object(object);
         debug_assert!(!self.gen.nursery.in_space(new_object));
-        unsafe { slot.store(new_object) };
+        slot.store(new_object);
     }
 
     #[inline(always)]

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -43,7 +43,7 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         VM::VMScanning::prepare_for_roots_re_scanning();
         mmtk.plan.base().prepare_for_stack_scanning();
         #[cfg(feature = "extreme_assertions")]
-        crate::util::edge_logger::reset();
+        mmtk.edge_logger.reset();
 
         // TODO investigate why the following will create duplicate edges
         // scheduler.work_buckets[WorkBucketStage::RefForwarding]

--- a/src/plan/tracing.rs
+++ b/src/plan/tracing.rs
@@ -3,9 +3,9 @@
 
 use std::mem;
 
-use crate::scheduler::gc_work::ProcessEdgesWork;
+use crate::scheduler::gc_work::{EdgeOf, ProcessEdgesWork};
 use crate::scheduler::{GCWorker, WorkBucketStage};
-use crate::util::{Address, ObjectReference};
+use crate::util::ObjectReference;
 use crate::vm::EdgeVisitor;
 
 /// This trait represents an object queue to enqueue objects during tracing.
@@ -63,7 +63,7 @@ impl ObjectQueue for VectorObjectQueue {
 
 /// A transitive closure visitor to collect all the edges of an object.
 pub struct ObjectsClosure<'a, E: ProcessEdgesWork> {
-    buffer: Vec<Address>,
+    buffer: Vec<EdgeOf<E>>,
     worker: &'a mut GCWorker<E::VM>,
 }
 
@@ -85,9 +85,9 @@ impl<'a, E: ProcessEdgesWork> ObjectsClosure<'a, E> {
     }
 }
 
-impl<'a, E: ProcessEdgesWork> EdgeVisitor for ObjectsClosure<'a, E> {
+impl<'a, E: ProcessEdgesWork> EdgeVisitor<EdgeOf<E>> for ObjectsClosure<'a, E> {
     #[inline(always)]
-    fn visit_edge(&mut self, slot: Address) {
+    fn visit_edge(&mut self, slot: EdgeOf<E>) {
         if self.buffer.is_empty() {
             self.buffer.reserve(E::CAPACITY);
         }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -5,6 +5,7 @@ use crate::plan::ObjectsClosure;
 use crate::plan::VectorObjectQueue;
 use crate::util::metadata::*;
 use crate::util::*;
+use crate::vm::edge_shape::Edge;
 use crate::vm::*;
 use crate::*;
 use std::marker::PhantomData;
@@ -227,7 +228,7 @@ impl<VM: VMBinding> GCWork<VM> for EndOfGC {
         #[cfg(feature = "extreme_assertions")]
         if crate::util::edge_logger::should_check_duplicate_edges(&*mmtk.plan) {
             // reset the logging info at the end of each GC
-            crate::util::edge_logger::reset();
+            mmtk.edge_logger.reset();
         }
 
         if <VM as VMBinding>::VMCollection::COORDINATOR_ONLY_STW {
@@ -331,7 +332,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanVMSpecificRoots<E> {
 }
 
 pub struct ProcessEdgesBase<VM: VMBinding> {
-    pub edges: Vec<Address>,
+    pub edges: Vec<VM::VMEdge>,
     pub nodes: VectorObjectQueue,
     mmtk: &'static MMTK<VM>,
     // Use raw pointer for fast pointer dereferencing, instead of using `Option<&'static mut GCWorker<E::VM>>`.
@@ -345,12 +346,12 @@ unsafe impl<VM: VMBinding> Send for ProcessEdgesBase<VM> {}
 impl<VM: VMBinding> ProcessEdgesBase<VM> {
     // Requires an MMTk reference. Each plan-specific type that uses ProcessEdgesBase can get a static plan reference
     // at creation. This avoids overhead for dynamic dispatch or downcasting plan for each object traced.
-    pub fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
+    pub fn new(edges: Vec<VM::VMEdge>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         #[cfg(feature = "extreme_assertions")]
         if crate::util::edge_logger::should_check_duplicate_edges(&*mmtk.plan) {
             for edge in &edges {
                 // log edge, panic if already logged
-                crate::util::edge_logger::log_edge(*edge);
+                mmtk.edge_logger.log_edge(*edge);
             }
         }
         Self {
@@ -388,6 +389,9 @@ impl<VM: VMBinding> ProcessEdgesBase<VM> {
     }
 }
 
+/// A short-hand for `<E::VM as VMBinding>::VMEdge`.
+pub type EdgeOf<E> = <<E as ProcessEdgesWork>::VM as VMBinding>::VMEdge;
+
 /// Scan & update a list of object slots
 //
 // Note: be very careful when using this trait. process_node() will push objects
@@ -407,7 +411,8 @@ pub trait ProcessEdgesWork:
     const CAPACITY: usize = 4096;
     const OVERWRITE_REFERENCE: bool = true;
     const SCAN_OBJECTS_IMMEDIATELY: bool = true;
-    fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<Self::VM>) -> Self;
+
+    fn new(edges: Vec<EdgeOf<Self>>, roots: bool, mmtk: &'static MMTK<Self::VM>) -> Self;
 
     /// Trace an MMTk object. The implementation should forward this call to the policy-specific
     /// `trace_object()` methods, depending on which space this object is in.
@@ -463,11 +468,11 @@ pub trait ProcessEdgesWork:
     }
 
     #[inline]
-    fn process_edge(&mut self, slot: Address) {
-        let object = unsafe { slot.load::<ObjectReference>() };
+    fn process_edge(&mut self, slot: EdgeOf<Self>) {
+        let object = slot.load();
         let new_object = self.trace_object(object);
         if Self::OVERWRITE_REFERENCE {
-            unsafe { slot.store(new_object) };
+            slot.store(new_object);
         }
     }
 
@@ -511,7 +516,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SFTProcessEdges<VM> {
     type VM = VM;
     type ScanObjectsWorkType = ScanObjects<Self>;
 
-    fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
+    fn new(edges: Vec<EdgeOf<Self>>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
         Self { base }
     }
@@ -552,8 +557,8 @@ impl<E: ProcessEdgesWork> Clone for ProcessEdgesWorkRootsWorkFactory<E> {
     }
 }
 
-impl<E: ProcessEdgesWork> RootsWorkFactory for ProcessEdgesWorkRootsWorkFactory<E> {
-    fn create_process_edge_roots_work(&mut self, edges: Vec<Address>) {
+impl<E: ProcessEdgesWork> RootsWorkFactory<EdgeOf<E>> for ProcessEdgesWorkRootsWorkFactory<E> {
+    fn create_process_edge_roots_work(&mut self, edges: Vec<EdgeOf<E>>) {
         crate::memory_manager::add_work_packet(
             self.mmtk,
             WorkBucketStage::Closure,
@@ -827,7 +832,7 @@ impl<VM: VMBinding, P: PlanTraceObject<VM> + Plan<VM = VM>, const KIND: TraceKin
     type VM = VM;
     type ScanObjectsWorkType = PlanScanObjects<Self, P>;
 
-    fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
+    fn new(edges: Vec<EdgeOf<Self>>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
         let plan = base.plan().downcast_ref::<P>().unwrap();
         Self { plan, base }
@@ -854,11 +859,11 @@ impl<VM: VMBinding, P: PlanTraceObject<VM> + Plan<VM = VM>, const KIND: TraceKin
     }
 
     #[inline]
-    fn process_edge(&mut self, slot: Address) {
-        let object = unsafe { slot.load::<ObjectReference>() };
+    fn process_edge(&mut self, slot: EdgeOf<Self>) {
+        let object = slot.load();
         let new_object = self.trace_object(object);
         if P::may_move_objects::<KIND>() {
-            unsafe { slot.store(new_object) };
+            slot.store(new_object);
         }
     }
 }

--- a/src/util/edge_logger.rs
+++ b/src/util/edge_logger.rs
@@ -5,39 +5,53 @@
 //!
 
 use crate::plan::Plan;
-use crate::util::Address;
+use crate::vm::edge_shape::Edge;
 use crate::vm::VMBinding;
 use std::collections::HashSet;
 use std::sync::RwLock;
 
-lazy_static! {
+pub struct EdgeLogger<ES: Edge> {
     // A private hash-set to keep track of edges.
-    static ref EDGE_LOG: RwLock<HashSet<Address>> = RwLock::new(HashSet::new());
+    edge_log: RwLock<HashSet<ES>>,
+}
+
+unsafe impl<ES: Edge> Sync for EdgeLogger<ES> {}
+
+impl<ES: Edge> EdgeLogger<ES> {
+    pub fn new() -> Self {
+        Self {
+            edge_log: Default::default(),
+        }
+    }
+
+    /// Logs an edge.
+    /// Panics if the edge was already logged.
+    ///
+    /// # Arguments
+    ///
+    /// * `edge` - The edge to log.
+    ///
+    pub fn log_edge(&self, edge: ES) {
+        trace!("log_edge({:?})", edge);
+        let mut edge_log = self.edge_log.write().unwrap();
+        assert!(
+            edge_log.insert(edge),
+            "duplicate edge ({:?}) detected",
+            edge
+        );
+    }
+
+    /// Reset the edge logger by clearing the hash-set of edges.
+    /// This function is called at the end of each GC iteration.
+    ///
+    pub fn reset(&self) {
+        let mut edge_log = self.edge_log.write().unwrap();
+        edge_log.clear();
+    }
 }
 
 /// Whether we should check duplicate edges. This depends on the actual plan.
 pub fn should_check_duplicate_edges<VM: VMBinding>(plan: &dyn Plan<VM = VM>) -> bool {
     // If a plan allows tracing duplicate edges, we should not run this check.
     !plan.constraints().may_trace_duplicate_edges
-}
-
-/// Logs an edge.
-/// Panics if the edge was already logged.
-///
-/// # Arguments
-///
-/// * `edge` - The edge to log.
-///
-pub fn log_edge(edge: Address) {
-    trace!("log_edge({})", edge);
-    let mut edge_log = EDGE_LOG.write().unwrap();
-    assert!(edge_log.insert(edge), "duplicate edge ({}) detected", edge);
-}
-
-/// Reset the edge logger by clearing the hash-set of edges.
-/// This function is called at the end of each GC iteration.
-///
-pub fn reset() {
-    let mut edge_log = EDGE_LOG.write().unwrap();
-    edge_log.clear();
 }

--- a/src/vm/edge_shape.rs
+++ b/src/vm/edge_shape.rs
@@ -1,0 +1,115 @@
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use atomic::Atomic;
+
+use crate::util::{Address, ObjectReference};
+
+/// An abstract edge.  An edge holds an object reference.  When we load from it, we get an
+/// ObjectReference; we can also store an ObjectReference into it.
+///
+/// This intends to abstract out the differences of reference field representation among different
+/// VMs.  If the VM represent a reference field as a word that holds the pointer to the object, it
+/// can use the default `SimpleEdge` we provide.  In some cases, the VM need to implement its own
+/// `Edge` instances.
+///
+/// For example:
+/// -   The VM uses compressed pointer (Compressed OOP in OpenJDK's terminology), where the heap
+///     size is limited, and a 64-bit pointer is stored in a 32-bit slot.
+/// -   The VM uses tagged pointer, where some bits of a word are used as metadata while the rest
+///     are used as pointer.
+/// -   A field holds a pointer to the middle of an object (an object field, or an array element,
+///     or some arbitrary offset) for some reasons.
+///
+/// When loading, `Edge::load` shall decode its internal representation to a "regular"
+/// `ObjectReference` which is applicable to `ObjectModel::object_start_ref`.  The implementation
+/// can do this with any appropriate operations, usually shifting and masking bits or subtracting
+/// offset from the address.  By doing this conversion, MMTk can implement GC algorithms in a
+/// VM-neutral way, knowing only `ObjectReference`.
+///
+/// When GC moves object, `Edge::store` shall convert the updated `ObjectReference` back to the
+/// edge-specific representation.  Compressed pointers remain compressed; tagged pointers preserve
+/// their tag bits; and offsetted pointers keep their offsets.
+///
+/// The methods of this trait are called on hot paths.  Please ensure they have high performance.
+/// Use inlining when appropriate.
+///
+/// Note: this trait only concerns the representation (i.e. the shape) of the edge, not its
+/// semantics, such as whether it holds strong or weak references.  If a VM holds a weak reference
+/// in a word as a pointer, it can also use `SimpleEdge` for weak reference fields.
+pub trait Edge: Copy + Send + Debug + PartialEq + Eq + Hash {
+    /// Load object reference from the edge.
+    fn load(&self) -> ObjectReference;
+
+    /// Store the object reference `object` into the edge.
+    fn store(&self, object: ObjectReference);
+
+    /// Prefetch the edge so that a subsequent `load` will be faster.
+    #[inline(always)]
+    fn prefetch_load(&self) {
+        // no-op by default
+    }
+
+    /// Prefetch the edge so that a subsequent `store` will be faster.
+    #[inline(always)]
+    fn prefetch_store(&self) {
+        // no-op by default
+    }
+}
+
+/// A simple edge implementation that represents a word-sized slot where an ObjectReference value
+/// is stored as is.  It is the default edge type, and should be suitable for most VMs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SimpleEdge {
+    slot_addr: *mut Atomic<ObjectReference>,
+}
+
+impl SimpleEdge {
+    /// Create a simple edge from an address.
+    ///
+    /// Arguments:
+    /// *   `address`: The address in memory where an `ObjectReference` is stored.
+    #[inline(always)]
+    pub fn from_address(address: Address) -> Self {
+        Self {
+            slot_addr: address.to_mut_ptr(),
+        }
+    }
+
+    /// Get the address of the edge.
+    ///
+    /// Return the address at which the `ObjectReference` is stored.
+    #[inline(always)]
+    pub fn as_address(&self) -> Address {
+        Address::from_mut_ptr(self.slot_addr)
+    }
+}
+
+unsafe impl Send for SimpleEdge {}
+
+impl Edge for SimpleEdge {
+    #[inline(always)]
+    fn load(&self) -> ObjectReference {
+        unsafe { (*self.slot_addr).load(atomic::Ordering::Relaxed) }
+    }
+
+    #[inline(always)]
+    fn store(&self, object: ObjectReference) {
+        unsafe { (*self.slot_addr).store(object, atomic::Ordering::Relaxed) }
+    }
+}
+
+/// For backword compatibility.
+/// We let Address implement Edge so existing bindings that use `Address` to represent an edge can
+/// continue to work.
+impl Edge for Address {
+    #[inline(always)]
+    fn load(&self) -> ObjectReference {
+        unsafe { Address::load(*self) }
+    }
+
+    #[inline(always)]
+    fn store(&self, object: ObjectReference) {
+        unsafe { Address::store(*self, object) }
+    }
+}

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19,6 +19,7 @@ use crate::util::constants::*;
 
 mod active_plan;
 mod collection;
+pub mod edge_shape;
 mod object_model;
 mod reference_glue;
 mod scanning;
@@ -44,6 +45,9 @@ where
     type VMCollection: Collection<Self>;
     type VMActivePlan: ActivePlan<Self>;
     type VMReferenceGlue: ReferenceGlue<Self>;
+
+    /// The type of edges in this VM.
+    type VMEdge: edge_shape::Edge;
 
     /// A value to fill in alignment gaps. This value can be used for debugging.
     const ALIGNMENT_VALUE: usize = 0xdead_beef;

--- a/tests/test_roots_work_factory.rs
+++ b/tests/test_roots_work_factory.rs
@@ -20,7 +20,7 @@ impl MockScanning {
         self.roots.extend(roots);
     }
 
-    fn mock_scan_roots(&self, mut factory: impl mmtk::vm::RootsWorkFactory) {
+    fn mock_scan_roots(&self, mut factory: impl mmtk::vm::RootsWorkFactory<Address>) {
         factory.create_process_edge_roots_work(self.roots.clone());
     }
 }
@@ -41,7 +41,7 @@ struct MockFactory {
     a: Arc<Mutex<String>>,
 }
 
-impl RootsWorkFactory for MockFactory {
+impl RootsWorkFactory<Address> for MockFactory {
     fn create_process_edge_roots_work(&mut self, edges: Vec<Address>) {
         assert_eq!(edges, EDGES);
         match self.round {

--- a/vmbindings/dummyvm/Cargo.toml
+++ b/vmbindings/dummyvm/Cargo.toml
@@ -17,6 +17,7 @@ mmtk = { path = "../../", version = "*" }
 libc = "0.2"
 lazy_static = "1.1"
 atomic_refcell = "0.1.7"
+atomic = "0.4.6"
 
 [features]
 default = []

--- a/vmbindings/dummyvm/src/edges.rs
+++ b/vmbindings/dummyvm/src/edges.rs
@@ -1,0 +1,157 @@
+use atomic::Atomic;
+use mmtk::{
+    util::{Address, ObjectReference},
+    vm::edge_shape::{Edge, SimpleEdge},
+};
+
+/// If a VM supports multiple kinds of edges, we can use tagged union to represent all of them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DummyVMEdge {
+    Simple(SimpleEdge),
+    #[cfg(target_pointer_width = "64")]
+    Compressed(only_64_bit::CompressedOopEdge),
+    Offset(OffsetEdge),
+    Value(ValueEdge),
+}
+
+unsafe impl Send for DummyVMEdge {}
+
+impl Edge for DummyVMEdge {
+    fn load(&self) -> ObjectReference {
+        match self {
+            DummyVMEdge::Simple(e) => e.load(),
+            #[cfg(target_pointer_width = "64")]
+            DummyVMEdge::Compressed(e) => e.load(),
+            DummyVMEdge::Offset(e) => e.load(),
+            DummyVMEdge::Value(e) => e.load(),
+        }
+    }
+
+    fn store(&self, object: ObjectReference) {
+        match self {
+            DummyVMEdge::Simple(e) => e.store(object),
+            #[cfg(target_pointer_width = "64")]
+            DummyVMEdge::Compressed(e) => e.store(object),
+            DummyVMEdge::Offset(e) => e.store(object),
+            DummyVMEdge::Value(e) => e.store(object),
+        }
+    }
+}
+
+/// Compressed OOP edge only makes sense on 64-bit architectures.
+#[cfg(target_pointer_width = "64")]
+pub mod only_64_bit {
+    use super::*;
+
+    /// This represents a location that holds a 32-bit pointer on a 64-bit machine.
+    ///
+    /// OpenJDK uses this kind of edge to store compressed OOPs on 64-bit machines.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct CompressedOopEdge {
+        slot_addr: *mut Atomic<u32>,
+    }
+
+    unsafe impl Send for CompressedOopEdge {}
+
+    impl CompressedOopEdge {
+        pub fn from_address(address: Address) -> Self {
+            Self {
+                slot_addr: address.to_mut_ptr(),
+            }
+        }
+        pub fn as_address(&self) -> Address {
+            Address::from_mut_ptr(self.slot_addr)
+        }
+    }
+
+    impl Edge for CompressedOopEdge {
+        fn load(&self) -> ObjectReference {
+            let compressed = unsafe { (*self.slot_addr).load(atomic::Ordering::Relaxed) };
+            let expanded = (compressed as usize) << 3;
+            unsafe { Address::from_usize(expanded).to_object_reference() }
+        }
+
+        fn store(&self, object: ObjectReference) {
+            let expanded = object.to_address().as_usize();
+            let compressed = (expanded >> 3) as u32;
+            unsafe { (*self.slot_addr).store(compressed, atomic::Ordering::Relaxed) }
+        }
+    }
+}
+
+/// This represents an edge that holds a pointer to the *middle* of an object, and the offset is known.
+///
+/// Julia uses this trick to facilitate deleting array elements from the front.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct OffsetEdge {
+    slot_addr: *mut Atomic<Address>,
+    offset: usize,
+}
+
+unsafe impl Send for OffsetEdge {}
+
+impl OffsetEdge {
+    pub fn new_no_offset(address: Address) -> Self {
+        Self {
+            slot_addr: address.to_mut_ptr(),
+            offset: 0,
+        }
+    }
+
+    pub fn new_with_offset(address: Address, offset: usize) -> Self {
+        Self {
+            slot_addr: address.to_mut_ptr(),
+            offset,
+        }
+    }
+
+    pub fn slot_address(&self) -> Address {
+        Address::from_mut_ptr(self.slot_addr)
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+impl Edge for OffsetEdge {
+    fn load(&self) -> ObjectReference {
+        let middle = unsafe { (*self.slot_addr).load(atomic::Ordering::Relaxed) };
+        let begin = middle - self.offset;
+        unsafe { begin.to_object_reference() }
+    }
+
+    fn store(&self, object: ObjectReference) {
+        let begin = object.to_address();
+        let middle = begin + self.offset;
+        unsafe { (*self.slot_addr).store(middle, atomic::Ordering::Relaxed) }
+    }
+}
+
+/// This edge presents the object reference itself to mmtk-core.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ValueEdge {
+    value: ObjectReference,
+}
+
+unsafe impl Send for ValueEdge {}
+
+impl ValueEdge {
+    pub fn new(value: ObjectReference) -> Self {
+        Self { value }
+    }
+
+    pub fn value(&self) -> ObjectReference {
+        self.value
+    }
+}
+
+impl Edge for ValueEdge {
+    fn load(&self) -> ObjectReference {
+        self.value
+    }
+
+    fn store(&self, _object: ObjectReference) {
+        // No-op.  Value edges are immutable.
+    }
+}

--- a/vmbindings/dummyvm/src/lib.rs
+++ b/vmbindings/dummyvm/src/lib.rs
@@ -16,6 +16,7 @@ pub mod api;
 
 #[cfg(test)]
 mod tests;
+mod edges;
 
 #[derive(Default)]
 pub struct DummyVM;
@@ -26,6 +27,7 @@ impl VMBinding for DummyVM {
     type VMCollection = collection::VMCollection;
     type VMActivePlan = active_plan::VMActivePlan;
     type VMReferenceGlue = reference_glue::VMReferenceGlue;
+    type VMEdge = edges::DummyVMEdge;
 
     /// Allowed maximum alignment as shift by min alignment.
     const MAX_ALIGNMENT_SHIFT: usize = 6_usize - Self::LOG_MIN_ALIGNMENT as usize;

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -9,10 +9,7 @@ pub struct VMObjectModel {}
 
 // This is intentionally set to a non-zero value to see if it breaks.
 // Change this if you want to test other values.
-#[cfg(target_pointer_width = "64")]
-pub const OBJECT_REF_OFFSET: usize = 6;
-#[cfg(target_pointer_width = "32")]
-pub const OBJECT_REF_OFFSET: usize = 2;
+pub const OBJECT_REF_OFFSET: usize = 4;
 
 impl ObjectModel<DummyVM> for VMObjectModel {
     const GLOBAL_LOG_BIT_SPEC: VMGlobalLogBitSpec = VMGlobalLogBitSpec::in_header(0);

--- a/vmbindings/dummyvm/src/scanning.rs
+++ b/vmbindings/dummyvm/src/scanning.rs
@@ -1,4 +1,5 @@
 use crate::DummyVM;
+use crate::edges::DummyVMEdge;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::ObjectReference;
 use mmtk::vm::EdgeVisitor;
@@ -9,20 +10,20 @@ use mmtk::Mutator;
 pub struct VMScanning {}
 
 impl Scanning<DummyVM> for VMScanning {
-    fn scan_thread_roots(_tls: VMWorkerThread, _factory: impl RootsWorkFactory) {
+    fn scan_thread_roots(_tls: VMWorkerThread, _factory: impl RootsWorkFactory<DummyVMEdge>) {
         unimplemented!()
     }
     fn scan_thread_root(
         _tls: VMWorkerThread,
         _mutator: &'static mut Mutator<DummyVM>,
-        _factory: impl RootsWorkFactory,
+        _factory: impl RootsWorkFactory<DummyVMEdge>,
     ) {
         unimplemented!()
     }
-    fn scan_vm_specific_roots(_tls: VMWorkerThread, _factory: impl RootsWorkFactory) {
+    fn scan_vm_specific_roots(_tls: VMWorkerThread, _factory: impl RootsWorkFactory<DummyVMEdge>) {
         unimplemented!()
     }
-    fn scan_object<EV: EdgeVisitor>(
+    fn scan_object<EV: EdgeVisitor<DummyVMEdge>>(
         _tls: VMWorkerThread,
         _object: ObjectReference,
         _edge_visitor: &mut EV,

--- a/vmbindings/dummyvm/src/tests/conservatism.rs
+++ b/vmbindings/dummyvm/src/tests/conservatism.rs
@@ -13,7 +13,7 @@ lazy_static! {
 }
 
 fn basic_filter(addr: Address) -> bool {
-    !addr.is_zero() && addr.as_usize() % ALLOC_BIT_REGION_SIZE == OBJECT_REF_OFFSET
+    !addr.is_zero() && addr.as_usize() % ALLOC_BIT_REGION_SIZE == (OBJECT_REF_OFFSET % ALLOC_BIT_REGION_SIZE)
 }
 
 fn assert_filter_pass(addr: Address) {

--- a/vmbindings/dummyvm/src/tests/edges_test.rs
+++ b/vmbindings/dummyvm/src/tests/edges_test.rs
@@ -1,0 +1,169 @@
+// GITHUB-CI: MMTK_PLAN=NoGC
+
+use atomic::{Atomic, Ordering};
+use mmtk::{
+    util::{Address, ObjectReference},
+    vm::edge_shape::{Edge, SimpleEdge},
+};
+
+use crate::{
+    edges::{DummyVMEdge, OffsetEdge, ValueEdge},
+    tests::fixtures::{Fixture, TwoObjects},
+};
+
+#[cfg(target_pointer_width = "64")]
+use crate::edges::only_64_bit::CompressedOopEdge;
+
+lazy_static! {
+    static ref FIXTURE: Fixture<TwoObjects> = Fixture::new();
+}
+
+#[test]
+pub fn load_simple() {
+    FIXTURE.with_fixture(|fixture| {
+        let mut slot: Atomic<ObjectReference> = Atomic::new(fixture.objref1);
+
+        let edge = SimpleEdge::from_address(Address::from_ref(&mut slot));
+        let objref = edge.load();
+
+        assert_eq!(objref, fixture.objref1);
+    });
+}
+
+#[test]
+pub fn store_simple() {
+    FIXTURE.with_fixture(|fixture| {
+        let mut slot: Atomic<ObjectReference> = Atomic::new(fixture.objref1);
+
+        let edge = SimpleEdge::from_address(Address::from_ref(&mut slot));
+        edge.store(fixture.objref2);
+        assert_eq!(slot.load(Ordering::SeqCst), fixture.objref2);
+
+        let objref = edge.load();
+        assert_eq!(objref, fixture.objref2);
+    });
+}
+
+#[cfg(target_pointer_width = "64")]
+mod only_64_bit {
+    use super::*;
+
+    // Two 35-bit addresses aligned to 8 bytes (3 zeros in the lowest bits).
+    const COMPRESSABLE_ADDR1: usize = 0b101_10111011_11011111_01111110_11111000usize;
+    const COMPRESSABLE_ADDR2: usize = 0b110_11110111_01101010_11011101_11101000usize;
+
+    #[test]
+    pub fn load_compressed() {
+        // Note: We cannot guarantee GC will allocate an object in the low address region.
+        // So we make up addresses just for testing the bit operations of compressed OOP edges.
+        let compressed1 = (COMPRESSABLE_ADDR1 >> 3) as u32;
+        let objref1 = unsafe { Address::from_usize(COMPRESSABLE_ADDR1).to_object_reference() };
+
+        let mut slot: Atomic<u32> = Atomic::new(compressed1);
+
+        let edge = CompressedOopEdge::from_address(Address::from_ref(&mut slot));
+        let objref = edge.load();
+
+        assert_eq!(objref, objref1);
+    }
+
+    #[test]
+    pub fn store_compressed() {
+        // Note: We cannot guarantee GC will allocate an object in the low address region.
+        // So we make up addresses just for testing the bit operations of compressed OOP edges.
+        let compressed1 = (COMPRESSABLE_ADDR1 >> 3) as u32;
+        let compressed2 = (COMPRESSABLE_ADDR2 >> 3) as u32;
+        let objref2 = unsafe { Address::from_usize(COMPRESSABLE_ADDR2).to_object_reference() };
+
+        let mut slot: Atomic<u32> = Atomic::new(compressed1);
+
+        let edge = CompressedOopEdge::from_address(Address::from_ref(&mut slot));
+        edge.store(objref2);
+        assert_eq!(slot.load(Ordering::SeqCst), compressed2);
+
+        let objref = edge.load();
+        assert_eq!(objref, objref2);
+    }
+}
+
+#[test]
+pub fn load_offset() {
+    const OFFSET: usize = 48;
+    FIXTURE.with_fixture(|fixture| {
+        let addr1 = fixture.objref1.to_address();
+        let mut slot: Atomic<Address> = Atomic::new(addr1 + OFFSET);
+
+        let edge = OffsetEdge::new_with_offset(Address::from_ref(&mut slot), OFFSET);
+        let objref = edge.load();
+
+        assert_eq!(objref, fixture.objref1);
+    });
+}
+
+#[test]
+pub fn store_offset() {
+    const OFFSET: usize = 48;
+    FIXTURE.with_fixture(|fixture| {
+        let addr1 = fixture.objref1.to_address();
+        let addr2 = fixture.objref2.to_address();
+        let mut slot: Atomic<Address> = Atomic::new(addr1 + OFFSET);
+
+        let edge = OffsetEdge::new_with_offset(Address::from_ref(&mut slot), OFFSET);
+        edge.store(fixture.objref2);
+        assert_eq!(slot.load(Ordering::SeqCst), addr2 + OFFSET);
+
+        let objref = edge.load();
+        assert_eq!(objref, fixture.objref2);
+    });
+}
+
+#[test]
+pub fn load_value() {
+    FIXTURE.with_fixture(|fixture| {
+        let edge = ValueEdge::new(fixture.objref1);
+        let objref = edge.load();
+
+        assert_eq!(objref, fixture.objref1);
+    });
+}
+
+#[test]
+pub fn mixed() {
+    const OFFSET: usize = 48;
+
+    FIXTURE.with_fixture(|fixture| {
+        let addr1 = fixture.objref1.to_address();
+        let addr2 = fixture.objref2.to_address();
+
+        let mut slot1: Atomic<ObjectReference> = Atomic::new(fixture.objref1);
+        let mut slot3: Atomic<Address> = Atomic::new(addr1 + OFFSET);
+
+        let edge1 = SimpleEdge::from_address(Address::from_ref(&mut slot1));
+        let edge3 = OffsetEdge::new_with_offset(Address::from_ref(&mut slot3), OFFSET);
+        let edge4 = ValueEdge::new(fixture.objref1);
+
+        let de1 = DummyVMEdge::Simple(edge1);
+        let de3 = DummyVMEdge::Offset(edge3);
+        let de4 = DummyVMEdge::Value(edge4);
+
+        let edges = vec![de1, de3, de4];
+        for (i, edge) in edges.iter().enumerate() {
+            let objref = edge.load();
+            assert_eq!(objref, fixture.objref1, "Edge {} is not properly loaded", i);
+        }
+
+        let mutable_edges = vec![de1, de3];
+        for (i, edge) in mutable_edges.iter().enumerate() {
+            edge.store(fixture.objref2);
+            let objref = edge.load();
+            assert_eq!(
+                objref, fixture.objref2,
+                "Edge {} is not properly loaded after store",
+                i
+            );
+        }
+
+        assert_eq!(slot1.load(Ordering::SeqCst), fixture.objref2);
+        assert_eq!(slot3.load(Ordering::SeqCst), addr2 + OFFSET);
+    });
+}

--- a/vmbindings/dummyvm/src/tests/fixtures/mod.rs
+++ b/vmbindings/dummyvm/src/tests/fixtures/mod.rs
@@ -109,3 +109,34 @@ impl FixtureContent for MMTKSingleton {
         }
     }
 }
+
+pub struct TwoObjects {
+    pub objref1: ObjectReference,
+    pub objref2: ObjectReference,
+}
+
+impl FixtureContent for TwoObjects {
+    fn create() -> Self {
+        const MB: usize = 1024 * 1024;
+        // 1MB heap
+        mmtk_init(MB);
+        mmtk_initialize_collection(VMThread::UNINITIALIZED);
+        // Make sure GC does not run during test.
+        mmtk_disable_collection();
+        let handle = mmtk_bind_mutator(VMMutatorThread(VMThread::UNINITIALIZED));
+
+        let size = 128;
+        let semantics = AllocationSemantics::Default;
+
+        let addr = mmtk_alloc(handle, size, 8, 0, semantics);
+        assert!(!addr.is_zero());
+
+        let objref1 = unsafe { addr.add(OBJECT_REF_OFFSET).to_object_reference() };
+        mmtk_post_alloc(handle, objref1, size, semantics);
+
+        let objref2 = unsafe { addr.add(OBJECT_REF_OFFSET).to_object_reference() };
+        mmtk_post_alloc(handle, objref2, size, semantics);
+
+        TwoObjects { objref1, objref2 }
+    }
+}

--- a/vmbindings/dummyvm/src/tests/mod.rs
+++ b/vmbindings/dummyvm/src/tests/mod.rs
@@ -20,3 +20,4 @@ mod malloc_ms;
 mod conservatism;
 mod is_in_mmtk_spaces;
 mod fixtures;
+mod edges_test;


### PR DESCRIPTION
We make the representation of edges VM-specific.  The MMTk core only
depends on the abstract Edge trait.  This allows VM bindings to custom
the behaviour of loading/storing of edges, and support features like
compressed OOPs.

Some example `Edge` implementations are in `vmbindings/dummyvm/src/edges.rs`.  There is a test case `vmbindings/dummyvm/src/tests/edges_test.rs` to show what to expect.

This PR involves API change.  Migration guide is in the commit message.

Binding PRs:
-   OpenJDK: https://github.com/mmtk/mmtk-openjdk/pull/160
-   JikesRVM: https://github.com/mmtk/mmtk-jikesrvm/pull/121
-   V8: https://github.com/mmtk/mmtk-v8/pull/66
-   Ruby: https://github.com/mmtk/mmtk-ruby/pull/9

Closes: https://github.com/mmtk/mmtk-core/issues/573