### PR TITLE
Fix updating of work packet statistics

### DIFF
--- a/src/scheduler/work_counter.rs
+++ b/src/scheduler/work_counter.rs
@@ -4,7 +4,7 @@
 //! work-packet level statistics
 //!
 //! See [`crate::util::statistics`] for collecting statistics over a GC cycle
-use std::time::SystemTime;
+use std::time::Instant;
 
 /// Common struct for different work counters
 ///
@@ -92,11 +92,11 @@ impl WorkCounterBase {
 
 /// Measure the durations of work packets
 ///
-/// Timing is based on [`SystemTime`]
+/// Timing is based on [`Instant`]
 #[derive(Copy, Clone, Debug)]
 pub(super) struct WorkDuration {
     base: WorkCounterBase,
-    start_value: Option<SystemTime>,
+    start_value: Option<Instant>,
     running: bool,
 }
 
@@ -112,12 +112,12 @@ impl WorkDuration {
 
 impl WorkCounter for WorkDuration {
     fn start(&mut self) {
-        self.start_value = Some(SystemTime::now());
+        self.start_value = Some(Instant::now());
         self.running = true;
     }
 
     fn stop(&mut self) {
-        let duration = self.start_value.unwrap().elapsed().unwrap().as_nanos() as f64;
+        let duration = self.start_value.unwrap().elapsed().as_nanos() as f64;
         self.base.merge_val(duration);
     }
 


### PR DESCRIPTION
Work packets can have different `TypeID`s but the same `work_name()`
since work names strip type parameters whereas `TypeID`s don't. Hence,
work packet statistics used to overwrite previously existing values
leading to incorrect values of the `work.*.{count,max,min,total}`
fields.

This commit fixes this bug by correctly updating the values. This commit
also closes https://github.com/mmtk/mmtk-core/issues/479 by converting
the work packet times to milliseconds.