### PR TITLE
Add a retry mechanism for publishing mmtk-core to crates.io

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -28,12 +28,9 @@ jobs:
       # The script will retry publish for 5 times with 60 seconds between the retries.
       - name: Public mmtk-core
         run: |
-          n=0
-          until [ "$n" -ge 5 ]
-          do
+          for n in {1..5}; do
             echo "Attempt #"$n
             cargo publish && break
-            n=$((n+1))
             echo "Wait for Retry #"$n
             sleep 60
           done

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Publish sub crates
         run: |
           cargo publish --manifest-path=macros/Cargo.toml
+      # Publish MMTk core.
+      # As mmtk-core depends on the crate we just publish above, in practice there could be
+      # a delay before we can find the exact version for the dependent crate on crates.io.
+      # The script will retry publish for 5 times with 60 seconds between the retries.
       - name: Public mmtk-core
         run: |
-          cargo publish
+          n=0
+          until [ "$n" -ge 5 ]
+          do
+            echo "Attempt #"$n
+            cargo publish && break
+            n=$((n+1))
+            echo "Wait for Retry #"$n
+            sleep 60
+          done


### PR DESCRIPTION
This PR adds retry in the github workflow for publishing the crates.

As we introduced a sub-crate `mmtk-macros` in https://github.com/mmtk/mmtk-core/pull/575, we need to publish both `mmtk-macros` and `mmtk`. What we do for the workflow is that we publish `mmtk-macros` first, and then publish `mmtk`. However, in practice, we have seen that the workflow runs failed since the change ([v0.12.0](https://github.com/mmtk/mmtk-core/actions/runs/2335401806) and [v0.13.0](https://github.com/mmtk/mmtk-core/actions/runs/2568842940)). The publishing for `mmtk-macros` succeeded, but the publishing for `mmtk` failed due to missing the dependency for `mmtk-macros`. I published those two versions manually with simply `cargo publish`, and it worked fine. I think there could be some delay in crates.io before we can see the new version of `mmtk-macros` that we publish. Hopefully adding retry for publishing `mmtk` can fix this.