### PR TITLE
Notify workers when finishing all coord work

### DIFF
--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -18,6 +18,10 @@ pub struct GCWorkerShared<VM: VMBinding> {
     /// Worker-local statistics data.
     stat: AtomicRefCell<WorkerLocalStat<VM>>,
     /// A queue of GCWork that can only be processed by the owned thread.
+    ///
+    /// Note: Currently, designated work cannot be added from the GC controller thread, or
+    /// there will be synchronization problems.  If it is necessary to do so, we need to
+    /// update the code in `GCWorkScheduler::poll_slow` for proper synchornization.
     pub designated_work: ArrayQueue<Box<dyn GCWork<VM>>>,
     /// Handle for stealing packets from the current worker
     pub stealer: Option<Stealer<Box<dyn GCWork<VM>>>>,


### PR DESCRIPTION
The coordinator thread did not notify GC workers when it finishes
executing all coordinator work packets.  That caused deadlock when all
GC workers are parked before the coordinator finishes executing all
coordinator work packets.

We let the coordinator thread notify one GC worker after draining all
pending coordinator work packets.  One GC worker is enough to identify
that the condition to open more buckets is met.