### PR TITLE
Allow excluded bogus runs from being plotted in the perf history

### DIFF
--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -2,19 +2,19 @@ name: Performance Regression CI
 
 # Triggerred when a new commit is pushed to master
 on:
-  push:
-    branches:
-      - master
+  # push:
+  #   branches:
+  #     - master
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'self-hosted'
+  RESULT_REPO_BRANCH: 'self-hosted-test-220714'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
 
@@ -22,6 +22,8 @@ jobs:
   # JikesRVM
   jikesrvm-perf-regression:
     runs-on: [self-hosted, Linux, freq-scaling-off]
+    env:
+      HISTORY_EXCLUDE_RUNS: ${{ secrets.CI_HISTORY_EXCLUDE_RUNS }}
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2
@@ -41,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.7"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -82,6 +84,8 @@ jobs:
   # OpenJDK
   openjdk-perf-regression:
     runs-on: [self-hosted, Linux, freq-scaling-off]
+    env:
+      HISTORY_EXCLUDE_RUNS: ${{ secrets.CI_HISTORY_EXCLUDE_RUNS }}
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2
@@ -101,7 +105,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.7"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -165,7 +169,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.7"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true


### PR DESCRIPTION
We track performance for all of our commits (e.g. https://www.mmtk.io/ci-perf-result/master/openjdk_semispace_history.html). However, we may have some bogus runs that were recorded and plotted in the graph. This PR along with the change in `ci-perf-kit` (https://github.com/mmtk/ci-perf-kit/releases/tag/0.6.7) allows us to manually exclude certain runs from being plotted in the graph.

https://github.com/mmtk/ci-perf-kit/releases/tag/0.6.7 also fixes an issue that runs with no valid results will no longer be plotted as `0` in the graph. Instead, the graph will show a blank result for the run.