### PR TITLE
Node-enqueuing tracing.

### DIFF
--- a/docs/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/tutorial/code/mygc_semispace/gc_work.rs
@@ -40,6 +40,8 @@ pub struct MyGCProcessEdges<VM: VMBinding> {
 // ANCHOR: mygc_process_edges_impl
 impl<VM:VMBinding> ProcessEdgesWork for MyGCProcessEdges<VM> {
     type VM = VM;
+    type ScanObjectsWorkType = ScanObjects<Self>;
+
     fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
         let plan = base.plan().downcast_ref::<MyGC<VM>>().unwrap();
@@ -70,6 +72,11 @@ impl<VM:VMBinding> ProcessEdgesWork for MyGCProcessEdges<VM> {
         } else {
             self.plan.common.trace_object(queue, object, worker)
         }
+    }
+
+    #[inline(always)]
+    fn create_scan_work(&self, nodes: Vec<ObjectReference>, roots: bool) -> ScanObjects<Self> {
+        ScanObjects::<Self>::new(nodes, false, roots)
     }
 }
 // ANCHOR_END: mygc_process_edges_impl

--- a/src/plan/generational/gc_work.rs
+++ b/src/plan/generational/gc_work.rs
@@ -16,6 +16,7 @@ pub struct GenNurseryProcessEdges<VM: VMBinding> {
 
 impl<VM: VMBinding> ProcessEdgesWork for GenNurseryProcessEdges<VM> {
     type VM = VM;
+    type ScanObjectsWorkType = ScanObjects<Self>;
 
     fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
@@ -38,6 +39,11 @@ impl<VM: VMBinding> ProcessEdgesWork for GenNurseryProcessEdges<VM> {
         let new_object = self.trace_object(object);
         debug_assert!(!self.gen.nursery.in_space(new_object));
         unsafe { slot.store(new_object) };
+    }
+
+    #[inline(always)]
+    fn create_scan_work(&self, nodes: Vec<ObjectReference>, roots: bool) -> ScanObjects<Self> {
+        ScanObjects::<Self>::new(nodes, false, roots)
     }
 }
 

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -401,6 +401,9 @@ pub trait ProcessEdgesWork:
 {
     type VM: VMBinding;
 
+    /// The work packet type for scanning objects when using this ProcessEdgesWork.
+    type ScanObjectsWorkType: ScanObjectsWork<Self::VM>;
+
     const CAPACITY: usize = 4096;
     const OVERWRITE_REFERENCE: bool = true;
     const SCAN_OBJECTS_IMMEDIATELY: bool = true;
@@ -425,27 +428,28 @@ pub trait ProcessEdgesWork:
     /// Start the a scan work packet. If SCAN_OBJECTS_IMMEDIATELY, the work packet will be executed immediately, in this method.
     /// Otherwise, the work packet will be added the Closure work bucket and will be dispatched later by the scheduler.
     #[inline]
-    fn start_or_dispatch_scan_work(&mut self, work_packet: Box<dyn GCWork<Self::VM>>) {
+    fn start_or_dispatch_scan_work(&mut self, work_packet: impl GCWork<Self::VM>) {
         if Self::SCAN_OBJECTS_IMMEDIATELY {
             // We execute this `scan_objects_work` immediately.
             // This is expected to be a useful optimization because,
             // say for _pmd_ with 200M heap, we're likely to have 50000~60000 `ScanObjects` work packets
             // being dispatched (similar amount to `ProcessEdgesWork`).
             // Executing these work packets now can remarkably reduce the global synchronization time.
-            self.worker().do_boxed_work(work_packet);
+            self.worker().do_work(work_packet);
         } else {
-            self.mmtk.scheduler.work_buckets[WorkBucketStage::Closure].add_boxed(work_packet);
+            self.mmtk.scheduler.work_buckets[WorkBucketStage::Closure].add(work_packet);
         }
     }
 
-    /// Create scan work for the policy. By default, we use [`ScanObjects`](crate::scheduler::gc_work::ScanObjects).
-    /// If a policy has its own scan object work packet, they can override this method.
-    #[inline(always)]
-    fn create_scan_work(&self, nodes: Vec<ObjectReference>) -> Box<dyn GCWork<Self::VM>> {
-        Box::new(crate::scheduler::gc_work::ScanObjects::<Self>::new(
-            nodes, false,
-        ))
-    }
+    /// Create an object-scanning work packet to be used for this ProcessEdgesWork.
+    ///
+    /// `roots` indicates if we are creating a packet for root scanning.  It is only true when this
+    /// method is called to handle `RootsWorkFactory::create_process_node_roots_work`.
+    fn create_scan_work(
+        &self,
+        nodes: Vec<ObjectReference>,
+        roots: bool,
+    ) -> Self::ScanObjectsWorkType;
 
     /// Flush the nodes in ProcessEdgesBase, and create a ScanObjects work packet for it. If the node set is empty,
     /// this method will simply return with no work packet created.
@@ -455,7 +459,7 @@ pub trait ProcessEdgesWork:
             return;
         }
         let nodes = self.pop_nodes();
-        self.start_or_dispatch_scan_work(self.create_scan_work(nodes));
+        self.start_or_dispatch_scan_work(self.create_scan_work(nodes, false));
     }
 
     #[inline]
@@ -505,6 +509,8 @@ pub struct SFTProcessEdges<VM: VMBinding> {
 
 impl<VM: VMBinding> ProcessEdgesWork for SFTProcessEdges<VM> {
     type VM = VM;
+    type ScanObjectsWorkType = ScanObjects<Self>;
+
     fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
         Self { base }
@@ -529,6 +535,11 @@ impl<VM: VMBinding> ProcessEdgesWork for SFTProcessEdges<VM> {
         let sft = crate::mmtk::SFT_MAP.get(object.to_address());
         sft.sft_trace_object(&mut self.base.nodes, object, worker)
     }
+
+    #[inline(always)]
+    fn create_scan_work(&self, nodes: Vec<ObjectReference>, roots: bool) -> ScanObjects<Self> {
+        ScanObjects::<Self>::new(nodes, false, roots)
+    }
 }
 
 struct ProcessEdgesWorkRootsWorkFactory<E: ProcessEdgesWork> {
@@ -550,8 +561,20 @@ impl<E: ProcessEdgesWork> RootsWorkFactory for ProcessEdgesWorkRootsWorkFactory<
         );
     }
 
-    fn create_process_node_roots_work(&mut self, _nodes: Vec<ObjectReference>) {
-        todo!()
+    fn create_process_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
+        // Note: Node roots cannot be moved.  Currently, this implies that the plan must never
+        // move objects.  However, in the future, if we start to support object pinning, then
+        // moving plans that support object pinning (such as Immix) can still use node roots.
+        assert!(
+            !self.mmtk.plan.constraints().moves_objects,
+            "Attempted to add node roots when using a plan that moves objects.  Plan: {:?}",
+            *self.mmtk.options.plan
+        );
+
+        // We want to use E::create_scan_work.
+        let process_edges_work = E::new(vec![], true, self.mmtk);
+        let work = process_edges_work.create_scan_work(nodes, true);
+        crate::memory_manager::add_work_packet(self.mmtk, WorkBucketStage::Closure, work);
     }
 }
 
@@ -576,35 +599,168 @@ impl<VM: VMBinding> DerefMut for SFTProcessEdges<VM> {
     }
 }
 
-/// Scan & update a list of object slots.
-/// Note that this work packet does not do any policy-specific scan
-/// object work (it won't call `scan_object()` in [`policy::gc_work::PolicytraceObject`]).
-/// It should be used only for policies that do not have policy-specific scan_object().
+/// Trait for a work packet that scans objects
+pub trait ScanObjectsWork<VM: VMBinding>: GCWork<VM> + Sized {
+    /// The associated ProcessEdgesWork for processing the edges of the objects in this packet.
+    type E: ProcessEdgesWork<VM = VM>;
+
+    /// Return true if the objects in this packet are pointed by roots, in which case we need to
+    /// call trace_object on them.
+    fn roots(&self) -> bool;
+
+    /// Called after each object is scanned.
+    fn post_scan_object(&self, object: ObjectReference);
+
+    /// Create another object-scanning work packet of the same kind, to scan adjacent objects of
+    /// the objects in this packet.
+    fn make_another(&self, buffer: Vec<ObjectReference>) -> Self;
+
+    /// The common code for ScanObjects and PlanScanObjects.
+    fn do_work_common(
+        &self,
+        buffer: &[ObjectReference],
+        worker: &mut GCWorker<<Self::E as ProcessEdgesWork>::VM>,
+        mmtk: &'static MMTK<<Self::E as ProcessEdgesWork>::VM>,
+    ) {
+        let tls = worker.tls;
+
+        // If this is a root packet, the objects in this packet will have not been traced, yet.
+        //
+        // This step conceptually traces the edges from root slots to the objects they point to.
+        // However, VMs that deliver root objects instead of root edges are incapable of updating
+        // root slots.  Like processing an edge, we call `trace_object` on those objects, and
+        // assert the GC doesn't move those objects because we cannot store back to the slots.
+        //
+        // If this is a root packet, the `scanned_root_objects` variable will hold those root
+        // objects which are traced for the first time.
+        let scanned_root_objects = self.roots().then(|| {
+            // We create an instance of E to use its `trace_object` method and its object queue.
+            let mut process_edges_work = Self::E::new(vec![], false, mmtk);
+
+            for object in buffer.iter().copied() {
+                let new_object = process_edges_work.trace_object(object);
+                debug_assert_eq!(
+                    object, new_object,
+                    "Object moved while tracing root unmovable root object: {} -> {}",
+                    object, new_object
+                );
+            }
+
+            // This contains root objects that are visited the first time.
+            // It is sufficient to only scan these objects.
+            process_edges_work.nodes.take()
+        });
+
+        // If it is a root packet, scan the nodes that are first scanned;
+        // otherwise, scan the nodes in the buffer.
+        let objects_to_scan = scanned_root_objects.as_deref().unwrap_or(buffer);
+
+        // Then scan those objects for edges.
+        let mut scan_later = vec![];
+        {
+            let mut closure = ObjectsClosure::<Self::E>::new(worker);
+            for object in objects_to_scan.iter().copied() {
+                if <VM as VMBinding>::VMScanning::support_edge_enqueuing(tls, object) {
+                    // If an object supports edge-enqueuing, we enqueue its edges.
+                    <VM as VMBinding>::VMScanning::scan_object(tls, object, &mut closure);
+                    self.post_scan_object(object);
+                } else {
+                    // If an object does not support edge-enqueuing, we have to use
+                    // `Scanning::scan_object_and_trace_edges` and offload the job of updating the
+                    // reference field to the VM.
+                    //
+                    // However, at this point, `closure` is borrowing `worker`.
+                    // So we postpone the processing of objects that needs object enqueuing
+                    scan_later.push(object);
+                }
+            }
+        }
+
+        // If any object does not support edge-enqueuing, we process them now.
+        if !scan_later.is_empty() {
+            // We create an instance of E to use its `trace_object` method and its object queue.
+            let mut process_edges_work = Self::E::new(vec![], false, mmtk);
+            let mut closure = |object| process_edges_work.trace_object(object);
+
+            // Scan objects and trace their edges at the same time.
+            for object in scan_later.iter().copied() {
+                <VM as VMBinding>::VMScanning::scan_object_and_trace_edges(
+                    tls,
+                    object,
+                    &mut closure,
+                );
+                self.post_scan_object(object);
+            }
+
+            // Create work packets to scan adjacent objects.  We skip ProcessEdgesWork and create
+            // object-scanning packets directly, because the edges are already traced.
+            if !process_edges_work.nodes.is_empty() {
+                let next_nodes = process_edges_work.nodes.take();
+                let make_packet = |nodes| {
+                    let work_packet = self.make_another(nodes);
+                    memory_manager::add_work_packet(mmtk, WorkBucketStage::Closure, work_packet);
+                };
+
+                // Divide the resulting nodes into appropriately sized packets.
+                if next_nodes.len() <= Self::E::CAPACITY {
+                    make_packet(next_nodes);
+                } else {
+                    for chunk in next_nodes.chunks(Self::E::CAPACITY) {
+                        make_packet(chunk.into());
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Scan objects and enqueue the edges of the objects.  For objects that do not support
+/// edge-enqueuing, this work packet also processes the edges.
+///
+/// This work packet does not execute policy-specific post-scanning hooks
+/// (it won't call `post_scan_object()` in [`policy::gc_work::PolicyTraceObject`]).
+/// It should be used only for policies that do not perform policy-specific actions when scanning
+/// an object.
 pub struct ScanObjects<Edges: ProcessEdgesWork> {
     buffer: Vec<ObjectReference>,
     #[allow(unused)]
     concurrent: bool,
+    roots: bool,
     phantom: PhantomData<Edges>,
 }
 
 impl<Edges: ProcessEdgesWork> ScanObjects<Edges> {
-    pub fn new(buffer: Vec<ObjectReference>, concurrent: bool) -> Self {
+    pub fn new(buffer: Vec<ObjectReference>, concurrent: bool, roots: bool) -> Self {
         Self {
             buffer,
             concurrent,
+            roots,
             phantom: PhantomData,
         }
     }
 }
 
+impl<VM: VMBinding, E: ProcessEdgesWork<VM = VM>> ScanObjectsWork<VM> for ScanObjects<E> {
+    type E = E;
+
+    fn roots(&self) -> bool {
+        self.roots
+    }
+
+    #[inline(always)]
+    fn post_scan_object(&self, _object: ObjectReference) {
+        // Do nothing.
+    }
+
+    fn make_another(&self, buffer: Vec<ObjectReference>) -> Self {
+        Self::new(buffer, self.concurrent, false)
+    }
+}
+
 impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanObjects<E> {
-    fn do_work(&mut self, worker: &mut GCWorker<E::VM>, _mmtk: &'static MMTK<E::VM>) {
+    fn do_work(&mut self, worker: &mut GCWorker<E::VM>, mmtk: &'static MMTK<E::VM>) {
         trace!("ScanObjects");
-        {
-            let tls = worker.tls;
-            let mut closure = ObjectsClosure::<E>::new(worker);
-            <E::VM as VMBinding>::VMScanning::scan_objects(tls, &self.buffer, &mut closure);
-        }
+        self.do_work_common(&self.buffer, worker, mmtk);
         trace!("ScanObjects End");
     }
 }
@@ -637,7 +793,11 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ProcessModBuf<E> {
             if !self.modbuf.is_empty() {
                 let mut modbuf = vec![];
                 ::std::mem::swap(&mut modbuf, &mut self.modbuf);
-                GCWork::do_work(&mut ScanObjects::<E>::new(modbuf, false), worker, mmtk)
+                GCWork::do_work(
+                    &mut ScanObjects::<E>::new(modbuf, false, false),
+                    worker,
+                    mmtk,
+                )
             }
         } else {
             // Do nothing
@@ -665,6 +825,7 @@ impl<VM: VMBinding, P: PlanTraceObject<VM> + Plan<VM = VM>, const KIND: TraceKin
     for PlanProcessEdges<VM, P, KIND>
 {
     type VM = VM;
+    type ScanObjectsWorkType = PlanScanObjects<Self, P>;
 
     fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
         let base = ProcessEdgesBase::new(edges, roots, mmtk);
@@ -673,8 +834,12 @@ impl<VM: VMBinding, P: PlanTraceObject<VM> + Plan<VM = VM>, const KIND: TraceKin
     }
 
     #[inline(always)]
-    fn create_scan_work(&self, nodes: Vec<ObjectReference>) -> Box<dyn GCWork<Self::VM>> {
-        Box::new(PlanScanObjects::<Self, P>::new(self.plan, nodes, false))
+    fn create_scan_work(
+        &self,
+        nodes: Vec<ObjectReference>,
+        roots: bool,
+    ) -> Self::ScanObjectsWorkType {
+        PlanScanObjects::<Self, P>::new(self.plan, nodes, false, roots)
     }
 
     #[inline(always)]
@@ -718,40 +883,59 @@ impl<VM: VMBinding, P: PlanTraceObject<VM> + Plan<VM = VM>, const KIND: TraceKin
     }
 }
 
-/// This provides an implementation of scanning objects work. Each object will be scanned by calling `scan_object()`
-/// in `PlanTraceObject`.
+/// This is an alternative to `ScanObjects` that calls the `post_scan_object` of the policy
+/// selected by the plan.  It is applicable to plans that derive `PlanTraceObject`.
 pub struct PlanScanObjects<E: ProcessEdgesWork, P: Plan<VM = E::VM> + PlanTraceObject<E::VM>> {
     plan: &'static P,
     buffer: Vec<ObjectReference>,
     #[allow(dead_code)]
     concurrent: bool,
+    roots: bool,
     phantom: PhantomData<E>,
 }
 
 impl<E: ProcessEdgesWork, P: Plan<VM = E::VM> + PlanTraceObject<E::VM>> PlanScanObjects<E, P> {
-    pub fn new(plan: &'static P, buffer: Vec<ObjectReference>, concurrent: bool) -> Self {
+    pub fn new(
+        plan: &'static P,
+        buffer: Vec<ObjectReference>,
+        concurrent: bool,
+        roots: bool,
+    ) -> Self {
         Self {
             plan,
             buffer,
             concurrent,
+            roots,
             phantom: PhantomData,
         }
+    }
+}
+
+impl<E: ProcessEdgesWork, P: Plan<VM = E::VM> + PlanTraceObject<E::VM>> ScanObjectsWork<E::VM>
+    for PlanScanObjects<E, P>
+{
+    type E = E;
+
+    fn roots(&self) -> bool {
+        self.roots
+    }
+
+    #[inline(always)]
+    fn post_scan_object(&self, object: ObjectReference) {
+        self.plan.post_scan_object(object);
+    }
+
+    fn make_another(&self, buffer: Vec<ObjectReference>) -> Self {
+        Self::new(self.plan, buffer, self.concurrent, false)
     }
 }
 
 impl<E: ProcessEdgesWork, P: Plan<VM = E::VM> + PlanTraceObject<E::VM>> GCWork<E::VM>
     for PlanScanObjects<E, P>
 {
-    fn do_work(&mut self, worker: &mut GCWorker<E::VM>, _mmtk: &'static MMTK<E::VM>) {
+    fn do_work(&mut self, worker: &mut GCWorker<E::VM>, mmtk: &'static MMTK<E::VM>) {
         trace!("PlanScanObjects");
-        {
-            let tls = worker.tls;
-            let mut closure = ObjectsClosure::<E>::new(worker);
-            for object in &self.buffer {
-                <E::VM as VMBinding>::VMScanning::scan_object(tls, *object, &mut closure);
-                self.plan.post_scan_object(*object);
-            }
-        }
+        self.do_work_common(&self.buffer, worker, mmtk);
         trace!("PlanScanObjects End");
     }
 }

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -161,6 +161,7 @@ impl<VM: VMBinding> DerefMut for SanityGCProcessEdges<VM> {
 
 impl<VM: VMBinding> ProcessEdgesWork for SanityGCProcessEdges<VM> {
     type VM = VM;
+    type ScanObjectsWorkType = ScanObjects<Self>;
 
     const OVERWRITE_REFERENCE: bool = false;
     fn new(edges: Vec<Address>, roots: bool, mmtk: &'static MMTK<VM>) -> Self {
@@ -184,5 +185,13 @@ impl<VM: VMBinding> ProcessEdgesWork for SanityGCProcessEdges<VM> {
             self.nodes.enqueue(object);
         }
         object
+    }
+
+    fn create_scan_work(
+        &self,
+        nodes: Vec<ObjectReference>,
+        roots: bool,
+    ) -> Self::ScanObjectsWorkType {
+        ScanObjects::<Self>::new(nodes, false, roots)
     }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -30,6 +30,7 @@ pub use self::object_model::ObjectModel;
 pub use self::reference_glue::Finalizable;
 pub use self::reference_glue::ReferenceGlue;
 pub use self::scanning::EdgeVisitor;
+pub use self::scanning::ObjectTracer;
 pub use self::scanning::RootsWorkFactory;
 pub use self::scanning::Scanning;
 

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -3,11 +3,31 @@ use crate::util::VMWorkerThread;
 use crate::util::{Address, ObjectReference};
 use crate::vm::VMBinding;
 
-// Callback trait of scanning functions that report edges.
+/// Callback trait of scanning functions that report edges.
 pub trait EdgeVisitor {
     /// Call this function for each edge.
     fn visit_edge(&mut self, edge: Address);
-    // TODO: Add visit_soft_edge, visit_weak_edge, ... here.
+}
+
+/// This lets us use closures as EdgeVisitor.
+impl<F: FnMut(Address)> EdgeVisitor for F {
+    fn visit_edge(&mut self, edge: Address) {
+        self(edge)
+    }
+}
+
+/// Callback trait of scanning functions that directly trace through edges.
+pub trait ObjectTracer {
+    /// Call this function for the content of each edge,
+    /// and assign the returned value back to the edge.
+    fn trace_object(&mut self, object: ObjectReference) -> ObjectReference;
+}
+
+/// This lets us use closures as ObjectTracer.
+impl<F: FnMut(ObjectReference) -> ObjectReference> ObjectTracer for F {
+    fn trace_object(&mut self, object: ObjectReference) -> ObjectReference {
+        self(object)
+    }
 }
 
 /// Root-scanning methods use this trait to create work packets for processing roots.
@@ -60,8 +80,30 @@ pub trait Scanning<VM: VMBinding> {
     /// `SCAN_MUTATORS_IN_SAFEPOINT` should also be enabled
     const SINGLE_THREAD_MUTATOR_SCANNING: bool = true;
 
-    /// Delegated scanning of a object, visiting each pointer field
-    /// encountered.
+    /// Return true if the given object supports edge enqueuing.
+    ///
+    /// -   If this returns true, MMTk core will call `scan_object` on the object.
+    /// -   Otherwise, MMTk core will call `scan_object_and_trace_edges` on the object.
+    ///
+    /// For maximum performance, the VM should support edge-enqueuing for as many objects as
+    /// practical.  Also note that this method is called for every object to be scanned, so it
+    /// must be fast.  The VM binding should avoid expensive checks and keep it as efficient as
+    /// possible.  Add `#[inline(always)]` to ensure it is inlined.
+    ///
+    /// Arguments:
+    /// * `tls`: The VM-specific thread-local storage for the current worker.
+    /// * `object`: The object to be scanned.
+    #[inline(always)]
+    fn support_edge_enqueuing(_tls: VMWorkerThread, _object: ObjectReference) -> bool {
+        true
+    }
+
+    /// Delegated scanning of a object, visiting each reference field encountered.
+    ///
+    /// The VM shall call `edge_visitor.visit_edge` on each reference field.
+    ///
+    /// The VM may skip a reference field if it holds a null reference.  If the VM supports tagged
+    /// references, it must skip tagged reference fields which are not holding references.
     ///
     /// Arguments:
     /// * `tls`: The VM-specific thread-local storage for the current worker.
@@ -73,6 +115,29 @@ pub trait Scanning<VM: VMBinding> {
         edge_visitor: &mut EV,
     );
 
+    /// Delegated scanning of a object, visiting each reference field encountered, and trace the
+    /// objects pointed by each field.
+    ///
+    /// The VM shall call `object_tracer.trace_object` on the value held in each reference field,
+    /// and assign the returned value back to the field.  If the VM uses tagged references, the
+    /// value passed to `object_tracer.trace_object` shall be the `ObjectReference` to the object
+    /// without any tag bits.
+    ///
+    /// The VM may skip a reference field if it holds a null reference.  If the VM supports tagged
+    /// references, it must skip tagged reference fields which are not holding references.
+    ///
+    /// Arguments:
+    /// * `tls`: The VM-specific thread-local storage for the current worker.
+    /// * `object`: The object to be scanned.
+    /// * `object_tracer`: Called back for the content of each edge.
+    fn scan_object_and_trace_edges<OT: ObjectTracer>(
+        _tls: VMWorkerThread,
+        _object: ObjectReference,
+        _object_tracer: &mut OT,
+    ) {
+        unreachable!("scan_object_and_trace_edges() will not be called when support_edge_enqueue() is always true.")
+    }
+
     /// MMTk calls this method at the first time during a collection that thread's stacks
     /// have been scanned. This can be used (for example) to clean up
     /// obsolete compiled methods that are no longer being executed.
@@ -81,22 +146,6 @@ pub trait Scanning<VM: VMBinding> {
     /// * `partial_scan`: Whether the scan was partial or full-heap.
     /// * `tls`: The GC thread that is performing the thread scan.
     fn notify_initial_thread_scan_complete(partial_scan: bool, tls: VMWorkerThread);
-
-    /// Bulk scanning of objects, processing each pointer field for each object.
-    ///
-    /// Arguments:
-    /// * `tls`: The VM-specific thread-local storage for the current worker.
-    /// * `objects`: The slice of object references to be scanned.
-    /// * `edge_visitor`: Called back for each edge in each object in `objects`.
-    fn scan_objects<EV: EdgeVisitor>(
-        tls: VMWorkerThread,
-        objects: &[ObjectReference],
-        edge_visitor: &mut EV,
-    ) {
-        for object in objects.iter() {
-            Self::scan_object(tls, *object, edge_visitor);
-        }
-    }
 
     /// Scan all the mutators for roots.
     ///


### PR DESCRIPTION
This commit implements node-enqueuing tracing.  This is mainly for
supporting VMs that does not support edge-enqueuing for some or all
objects.

I made minimum change to the overall structure of the current tracing framework.  I reused the `ScanObjects` work packet as the node-processing work packet, and added logic for processing the edges of objects that do not support edge enqueuing.

Existing VMs which do not use node-enqueuing tracing should still work, and the performance impact should be negligible.  I'll do experiments to compare the performance.