### PR TITLE
Remove Plan.gc_init() and Space.init()

### DIFF
--- a/docs/tutorial/code/mygc_semispace/global.rs
+++ b/docs/tutorial/code/mygc_semispace/global.rs
@@ -14,7 +14,6 @@ use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataSanity, SideMetadataContext};
@@ -79,18 +78,14 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
     }
     // ANCHOR_END: create_copy_config
 
-    // Modify
-    // ANCHOR: gc_init
-    fn gc_init(
-        &mut self,
-        heap_size: usize,
-        vm_map: &'static VMMap,
-    ) {
-        self.common.gc_init(heap_size, vm_map);
-        self.copyspace0.init(&vm_map);
-        self.copyspace1.init(&vm_map);
+    // ANCHOR: get_spaces
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.common.get_spaces();
+        ret.push(&self.copyspace0);
+        ret.push(&self.copyspace1);
+        ret
     }
-    // ANCHOR_END: gc_init
+    // ANCHOR_EN: get_spaces
 
     // Modify
     // ANCHOR: schedule_collection

--- a/docs/tutorial/code/mygc_semispace/global.rs
+++ b/docs/tutorial/code/mygc_semispace/global.rs
@@ -182,7 +182,7 @@ impl<VM: VMBinding> MyGC<VM> {
         options: Arc<Options>,
     ) -> Self {
         // Modify
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
 
         let res = MyGC {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ mod mmtk;
 pub use mmtk::MMTKBuilder;
 pub(crate) use mmtk::MMAPPER;
 pub use mmtk::MMTK;
-pub(crate) use mmtk::VM_MAP;
 
 mod policy;
 

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -79,10 +79,6 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         self.gen.last_collection_full_heap()
     }
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.gen.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.gen.get_spaces();
         ret.push(&self.copyspace0);
@@ -172,7 +168,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
 
 impl<VM: VMBinding> GenCopy<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
         // We have no specific side metadata for copying. So just use the ones from generational.
         let global_metadata_specs =
             crate::plan::generational::new_generational_global_metadata_specs::<VM>();

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -15,7 +15,6 @@ use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataSanity;

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -81,8 +81,13 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
 
     fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         self.gen.gc_init(heap_size, vm_map);
-        self.copyspace0.init(vm_map);
-        self.copyspace1.init(vm_map);
+    }
+
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.gen.get_spaces();
+        ret.push(&self.copyspace0);
+        ret.push(&self.copyspace1);
+        ret
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -78,11 +78,6 @@ impl<VM: VMBinding> Gen<VM> {
         self.nursery.verify_side_metadata_sanity(sanity);
     }
 
-    /// Initialize Gen. This should be called by the gc_init() API call.
-    pub fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.common.gc_init(heap_size, vm_map);
-    }
-
     /// Get spaces in generation plans
     pub fn get_spaces(&self) -> Vec<&dyn Space<VM>> {
         let mut ret = self.common.get_spaces();

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -81,7 +81,13 @@ impl<VM: VMBinding> Gen<VM> {
     /// Initialize Gen. This should be called by the gc_init() API call.
     pub fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         self.common.gc_init(heap_size, vm_map);
-        self.nursery.init(vm_map);
+    }
+
+    /// Get spaces in generation plans
+    pub fn get_spaces(&self) -> Vec<&dyn Space<VM>> {
+        let mut ret = self.common.get_spaces();
+        ret.push(&self.nursery);
+        ret
     }
 
     /// Prepare Gen. This should be called by a single thread in GC prepare work.

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -103,10 +103,6 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         self.gen.collection_required(self, space_full, space)
     }
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.gen.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.gen.get_spaces();
         ret.push(&self.immix);
@@ -215,7 +211,7 @@ impl<VM: VMBinding> GenImmix<VM> {
         options: Arc<Options>,
         scheduler: Arc<GCWorkScheduler<VM>>,
     ) -> Self {
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
         // We have no specific side metadata for copying. So just use the ones from generational.
         let global_metadata_specs =
             crate::plan::generational::new_generational_global_metadata_specs::<VM>();

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -15,7 +15,6 @@ use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::options::Options;
 use crate::util::VMWorkerThread;

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -105,7 +105,12 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
 
     fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         self.gen.gc_init(heap_size, vm_map);
-        self.immix.init(vm_map);
+    }
+
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.gen.get_spaces();
+        ret.push(&self.immix);
+        ret
     }
 
     // GenImmixMatureProcessEdges<VM, { TraceKind::Defrag }> and GenImmixMatureProcessEdges<VM, { TraceKind::Fast }>

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -13,11 +13,9 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 #[cfg(feature = "analysis")]
 use crate::util::analysis::AnalysisManager;
-use crate::util::conversions::bytes_to_pages;
 use crate::util::copy::{CopyConfig, GCWorkerCopyContext};
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::map::Map;
 use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataSanity;
@@ -71,7 +69,8 @@ pub fn create_plan<VM: VMBinding>(
     scheduler: Arc<GCWorkScheduler<VM>>,
 ) -> Box<dyn Plan<VM = VM>> {
     let plan = match plan {
-        PlanSelector::NoGC => Box::new(crate::plan::nogc::NoGC::new(vm_map, mmapper, options)) as Box<dyn Plan<VM = VM>>,
+        PlanSelector::NoGC => Box::new(crate::plan::nogc::NoGC::new(vm_map, mmapper, options))
+            as Box<dyn Plan<VM = VM>>,
         PlanSelector::SemiSpace => Box::new(crate::plan::semispace::SemiSpace::new(
             vm_map, mmapper, options,
         )) as Box<dyn Plan<VM = VM>>,
@@ -94,7 +93,9 @@ pub fn create_plan<VM: VMBinding>(
             vm_map, mmapper, options,
         )) as Box<dyn Plan<VM = VM>>,
     };
-    plan.get_spaces().into_iter().for_each(|s| s.initialize_sft());
+    plan.get_spaces()
+        .into_iter()
+        .for_each(|s| s.initialize_sft());
     plan
 }
 
@@ -544,7 +545,7 @@ impl<VM: VMBinding> BasePlan<VM> {
     }
 
     pub fn get_spaces(&self) -> Vec<&dyn Space<VM>> {
-        return vec![
+        vec![
             #[cfg(feature = "code_space")]
             &self.code_space,
             #[cfg(feature = "code_space")]

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -93,9 +93,13 @@ pub fn create_plan<VM: VMBinding>(
             vm_map, mmapper, options,
         )) as Box<dyn Plan<VM = VM>>,
     };
+
+    // We have created Plan in the heap, and we won't explicitly move it. So each space
+    // now has a fixed address for its lifetime. It is safe now to initialize SFT.
     plan.get_spaces()
         .into_iter()
         .for_each(|s| s.initialize_sft());
+
     plan
 }
 
@@ -450,7 +454,10 @@ pub fn create_vm_space<VM: VMBinding>(
         heap,
         constraints,
     );
+
+    // The space is mapped externally by the VM. We need to update our mmapper to mark the range as mapped.
     space.ensure_mapped();
+
     space
 }
 

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -13,7 +13,6 @@ use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::metadata::side_metadata::SideMetadataSanity;

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -77,7 +77,12 @@ impl<VM: VMBinding> Plan for Immix<VM> {
 
     fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         self.common.gc_init(heap_size, vm_map);
-        self.immix_space.init(vm_map);
+    }
+
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.common.get_spaces();
+        ret.push(&self.immix_space);
+        ret
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -75,10 +75,6 @@ impl<VM: VMBinding> Plan for Immix<VM> {
         }
     }
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.common.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.common.get_spaces();
         ret.push(&self.immix_space);
@@ -145,7 +141,7 @@ impl<VM: VMBinding> Immix<VM> {
         options: Arc<Options>,
         scheduler: Arc<GCWorkScheduler<VM>>,
     ) -> Self {
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
         let immix = Immix {
             immix_space: ImmixSpace::new(

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -57,10 +57,6 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         &MARKCOMPACT_CONSTRAINTS
     }
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.common.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.common.get_spaces();
         ret.push(&self.mc_space);
@@ -183,7 +179,7 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
 
 impl<VM: VMBinding> MarkCompact<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
         // if global_alloc_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
         // SideMetadataContext by default, so we don't need to add it here.
         #[cfg(feature = "global_alloc_bit")]

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -59,7 +59,12 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
 
     fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         self.common.gc_init(heap_size, vm_map);
-        self.mc_space.init(vm_map);
+    }
+
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.common.get_spaces();
+        ret.push(&self.mc_space);
+        ret
     }
 
     fn base(&self) -> &BasePlan<VM> {

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -20,7 +20,6 @@ use crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC;
 use crate::util::copy::CopySemantics;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -47,10 +47,6 @@ pub const MS_CONSTRAINTS: PlanConstraints = PlanConstraints {
 impl<VM: VMBinding> Plan for MarkSweep<VM> {
     type VM = VM;
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.common.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.common.get_spaces();
         ret.push(&self.ms);
@@ -101,7 +97,7 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
 
 impl<VM: VMBinding> MarkSweep<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
-        let heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let heap = HeapMeta::new(&options);
         // if global_alloc_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
         // SideMetadataContext by default, so we don't need to add it here.
         #[cfg(feature = "global_alloc_bit")]

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -15,7 +15,6 @@ use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
 use crate::util::options::Options;

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -51,6 +51,12 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.gc_init(heap_size, vm_map);
     }
 
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.common.get_spaces();
+        ret.push(&self.ms);
+        ret
+    }
+
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
         self.base().set_collection_kind::<Self>(self);
         self.base().set_gc_status(GcStatus::GcPrepare);

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -56,4 +56,3 @@ pub use marksweep::MS_CONSTRAINTS;
 pub use nogc::NOGC_CONSTRAINTS;
 pub use pageprotect::PP_CONSTRAINTS;
 pub use semispace::SS_CONSTRAINTS;
-pub mod mygc;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -56,3 +56,4 @@ pub use marksweep::MS_CONSTRAINTS;
 pub use nogc::NOGC_CONSTRAINTS;
 pub use pageprotect::PP_CONSTRAINTS;
 pub use semispace::SS_CONSTRAINTS;
+pub mod mygc;

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -43,9 +43,14 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
 
     fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         self.base.gc_init(heap_size, vm_map);
+    }
 
-        // FIXME correctly initialize spaces based on options
-        self.nogc_space.init(vm_map);
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.base.get_spaces();
+        ret.push(&self.nogc_space);
+        ret.push(&self.immortal);
+        ret.push(&self.los);
+        ret
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -41,10 +41,6 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &NOGC_CONSTRAINTS
     }
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.base.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.base.get_spaces();
         ret.push(&self.nogc_space);
@@ -92,9 +88,9 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
 impl<VM: VMBinding> NoGC<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
         #[cfg(not(feature = "nogc_lock_free"))]
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
         #[cfg(feature = "nogc_lock_free")]
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
 
         let global_specs = SideMetadataContext::new_global_specs(&[]);
 

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -9,7 +9,6 @@ use crate::scheduler::GCWorkScheduler;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 #[allow(unused_imports)]
 use crate::util::heap::VMRequest;
@@ -98,6 +97,7 @@ impl<VM: VMBinding> NoGC<VM> {
         let nogc_space = NoGCImmortalSpace::new(
             "nogc_space",
             cfg!(not(feature = "nogc_no_zeroing")),
+            &options,
             global_specs.clone(),
         );
         #[cfg(not(feature = "nogc_lock_free"))]

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -43,21 +43,6 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         &CONSTRAINTS
     }
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        // Warn users that the plan may fail due to maximum mapping allowed.
-        warn!(
-            "PageProtect uses a high volume of memory mappings. \
-            If you encounter failures in memory protect/unprotect in this plan,\
-            consider increase the maximum mapping allowed by the OS{}.",
-            if cfg!(target_os = "linux") {
-                " (e.g. sudo sysctl -w vm.max_map_count=655300)"
-            } else {
-                ""
-            }
-        );
-        self.common.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.common.get_spaces();
         ret.push(&self.space);
@@ -103,7 +88,19 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
 
 impl<VM: VMBinding> PageProtect<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        // Warn users that the plan may fail due to maximum mapping allowed.
+        warn!(
+            "PageProtect uses a high volume of memory mappings. \
+            If you encounter failures in memory protect/unprotect in this plan,\
+            consider increase the maximum mapping allowed by the OS{}.",
+            if cfg!(target_os = "linux") {
+                " (e.g. sudo sysctl -w vm.max_map_count=655300)"
+            } else {
+                ""
+            }
+        );
+
+        let mut heap = HeapMeta::new(&options);
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
 
         let ret = PageProtect {

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -56,7 +56,12 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
             }
         );
         self.common.gc_init(heap_size, vm_map);
-        self.space.init(vm_map);
+    }
+
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.common.get_spaces();
+        ret.push(&self.space);
+        ret
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -9,7 +9,6 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataContext;

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -69,10 +69,6 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         }
     }
 
-    fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
-        self.common.gc_init(heap_size, vm_map);
-    }
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.common.get_spaces();
         ret.push(&self.copyspace0);
@@ -137,7 +133,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
 
 impl<VM: VMBinding> SemiSpace<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
-        let mut heap = HeapMeta::new(HEAP_START, HEAP_END);
+        let mut heap = HeapMeta::new(&options);
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
 
         let res = SemiSpace {

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -12,7 +12,6 @@ use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -71,9 +71,13 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
 
     fn gc_init(&mut self, heap_size: usize, vm_map: &'static VMMap) {
         self.common.gc_init(heap_size, vm_map);
+    }
 
-        self.copyspace0.init(vm_map);
-        self.copyspace1.init(vm_map);
+    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
+        let mut ret = self.common.get_spaces();
+        ret.push(&self.copyspace0);
+        ret.push(&self.copyspace1);
+        ret
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -94,8 +94,8 @@ impl<VM: VMBinding> Space<VM> for CopySpace<VM> {
         &self.common
     }
 
-    fn init(&mut self, _vm_map: &'static VMMap) {
-        self.common().init(self.as_space());
+    fn initialize_sft(&self) {
+        self.common().initialize_sft(self.as_sft())
     }
 
     fn release_multiple_pages(&mut self, _start: Address) {

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -104,9 +104,8 @@ impl<VM: VMBinding> Space<VM> for ImmixSpace<VM> {
     fn common(&self) -> &CommonSpace<VM> {
         &self.common
     }
-    fn init(&mut self, _vm_map: &'static VMMap) {
-        super::validate_features();
-        self.common().init(self.as_space());
+    fn initialize_sft(&self) {
+        self.common().initialize_sft(self.as_sft())
     }
     fn release_multiple_pages(&mut self, _start: Address) {
         panic!("immixspace only releases pages enmasse")
@@ -186,6 +185,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         scheduler: Arc<GCWorkScheduler<VM>>,
         global_side_metadata_specs: Vec<SideMetadataSpec>,
     ) -> Self {
+        super::validate_features();
         let common = CommonSpace::new(
             SpaceOptions {
                 name,

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -102,9 +102,10 @@ impl<VM: VMBinding> Space<VM> for ImmortalSpace<VM> {
         &self.common
     }
 
-    fn init(&mut self, _vm_map: &'static VMMap) {
-        self.common().init(self.as_space());
+    fn initialize_sft(&self) {
+        self.common().initialize_sft(self.as_sft())
     }
+
     fn release_multiple_pages(&mut self, _start: Address) {
         panic!("immortalspace only releases pages enmasse")
     }

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -102,8 +102,9 @@ impl<VM: VMBinding> Space<VM> for LargeObjectSpace<VM> {
     fn get_page_resource(&self) -> &dyn PageResource<VM> {
         &self.pr
     }
-    fn init(&mut self, _vm_map: &'static VMMap) {
-        self.common().init(self.as_space());
+
+    fn initialize_sft(&self) {
+        self.common().initialize_sft(self.as_sft())
     }
 
     fn common(&self) -> &CommonSpace<VM> {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -6,16 +6,12 @@ use crate::util::ObjectReference;
 
 use crate::policy::space::*;
 use crate::util::conversions;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::layout::vm_layout_constants::{
-    AVAILABLE_BYTES, AVAILABLE_END, AVAILABLE_START,
-};
+use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_BYTES, AVAILABLE_START};
 use crate::util::metadata::side_metadata::SideMetadataSanity;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSpec};
 use crate::util::opaque_pointer::*;
 use crate::util::options::Options;
 use crate::vm::VMBinding;
-use crate::vm::*;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -167,6 +163,8 @@ impl<VM: VMBinding> LockFreeImmortalSpace<VM> {
             AVAILABLE_BYTES
         );
 
+        // FIXME: This space assumes that it can use the entire heap range, which is definitely wrong.
+        // https://github.com/mmtk/mmtk-core/issues/314
         let space = Self {
             name,
             cursor: AtomicUsize::new(AVAILABLE_START.as_usize()),

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -123,8 +123,8 @@ impl<VM: VMBinding> Space<VM> for MallocSpace<VM> {
         unreachable!()
     }
 
-    fn init(&mut self, _vm_map: &'static VMMap) {
-        // Do nothing
+    fn initialize_sft(&self) {
+        // Do nothing - we will set sft when we get new results from malloc
     }
 
     fn release_multiple_pages(&mut self, _start: Address) {

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -4,7 +4,6 @@ use crate::plan::VectorObjectQueue;
 use crate::policy::space::CommonSpace;
 use crate::policy::space::SFT;
 use crate::util::constants::BYTES_IN_PAGE;
-use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::PageResource;
 use crate::util::malloc::malloc_ms_util::*;
 use crate::util::metadata::side_metadata::{

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -95,8 +95,8 @@ impl<VM: VMBinding> Space<VM> for MarkCompactSpace<VM> {
         &self.common
     }
 
-    fn init(&mut self, _vm_map: &'static VMMap) {
-        self.common().init(self.as_space());
+    fn initialize_sft(&self) {
+        self.common().initialize_sft(self.as_sft())
     }
 
     fn release_multiple_pages(&mut self, _start: Address) {

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -562,7 +562,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
             // TODO(Javad): handle meta space allocation failure
             panic!("failed to mmap meta memory");
         }
-        SFT_MAP.update(self.as_sft(), self.common().start, self.common().extent);
+
         use crate::util::heap::layout::mmapper::Mmapper;
         self.common()
             .mmapper

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -777,7 +777,11 @@ impl<VM: VMBinding> CommonSpace<VM> {
         vm_map.insert(start, extent, rtn.descriptor);
 
         // For contiguous space, we know its address range so we reserve metadata memory for its range.
-        if rtn.metadata.try_map_metadata_address_range(rtn.start, rtn.extent).is_err() {
+        if rtn
+            .metadata
+            .try_map_metadata_address_range(rtn.start, rtn.extent)
+            .is_err()
+        {
             // TODO(Javad): handle meta space allocation failure
             panic!("failed to mmap meta memory");
         }

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -548,10 +548,8 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         }
     }
 
-    /**
-     *  Ensure this space is marked as mapped -- used when the space is already
-     *  mapped (e.g. for a vm image which is externally mmapped.)
-     */
+    /// Ensure this space is marked as mapped -- used when the space is already
+    /// mapped (e.g. for a vm image which is externally mmapped.)
     fn ensure_mapped(&self) {
         if self
             .common()

--- a/src/util/heap/heap_meta.rs
+++ b/src/util/heap/heap_meta.rs
@@ -1,19 +1,20 @@
 use crate::util::Address;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
+use crate::util::options::Options;
+use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
+use crate::util::conversions;
 
 pub struct HeapMeta {
     pub heap_cursor: Address,
     pub heap_limit: Address,
-    pub total_pages: AtomicUsize,
+    pub total_pages: usize,
 }
 
 impl HeapMeta {
-    pub fn new(start: Address, end: Address) -> Self {
+    pub fn new(options: &Options) -> Self {
         HeapMeta {
-            heap_cursor: start,
-            heap_limit: end,
-            total_pages: AtomicUsize::new(0),
+            heap_cursor: HEAP_START,
+            heap_limit: HEAP_END,
+            total_pages: conversions::bytes_to_pages(*options.heap_size),
         }
     }
 
@@ -47,6 +48,6 @@ impl HeapMeta {
     }
 
     pub fn get_total_pages(&self) -> usize {
-        self.total_pages.load(Ordering::Relaxed)
+        self.total_pages
     }
 }

--- a/src/util/heap/heap_meta.rs
+++ b/src/util/heap/heap_meta.rs
@@ -1,7 +1,7 @@
-use crate::util::Address;
-use crate::util::options::Options;
-use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
 use crate::util::conversions;
+use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
+use crate::util::options::Options;
+use crate::util::Address;
 
 pub struct HeapMeta {
     pub heap_cursor: Address,

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -160,7 +160,7 @@ impl Map for Map32 {
     }
 
     fn finalize_static_space_map(&self, from: Address, to: Address) {
-        // This is only called during boot process by a single thread calling gc_init().
+        // This is only called during boot process by a single thread.
         // It is fine to get a mutable reference.
         let self_mut: &mut Self = unsafe { self.mut_self() };
         /* establish bounds of discontiguous space */

--- a/src/util/heap/layout/map64.rs
+++ b/src/util/heap/layout/map64.rs
@@ -161,7 +161,7 @@ impl Map for Map64 {
     }
 
     fn boot(&self) {
-        // This is only called during boot process by a single thread calling gc_init().
+        // This is only called during boot process by a single thread.
         // It is fine to get a mutable reference.
         let self_mut: &mut Self = unsafe { self.mut_self() };
         for pr in 0..MAX_SPACES {
@@ -174,7 +174,7 @@ impl Map for Map64 {
     }
 
     fn finalize_static_space_map(&self, _from: Address, _to: Address) {
-        // This is only called during boot process by a single thread calling gc_init().
+        // This is only called during boot process by a single thread.
         // It is fine to get a mutable reference.
         let self_mut: &mut Self = unsafe { self.mut_self() };
         for pr in 0..MAX_SPACES {


### PR DESCRIPTION
This pull request removes `Plan.gc_init()`, and `Space.init()`. I think this can close the issue: https://github.com/mmtk/mmtk-core/issues/57, I am not aware of any occurrences of two-step initialisation in MMTk after this PR.

Note that We eagerly set SFT for each space in their `Space.init()` if they are contiguous and SFT needs a non-moving reference to the `Space`. When we create a `Space`, the reference points to an address on the stack, and will be moved. So we cannot set SFT at creation. I added a method `Space.initialize_sft()` which is called after the `Space` has a fixed address. `initialize_sft()` is only used to set SFT, not any other post-creation initialisation.