### PR TITLE
Introduce Bounded and Fixed nurseries

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.6.6"
+          ref: "0.6.8"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -101,7 +101,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.6.6"
+              ref: "0.6.8"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -203,7 +203,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.6.6"
+                ref: "0.6.8"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-jikesrvm-baseline.yml
+++ b/.github/workflows/perf-jikesrvm-baseline.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.8"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-openjdk-baseline.yml
+++ b/.github/workflows/perf-openjdk-baseline.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.8"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.8"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.8"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.6"
+          ref: "0.6.8"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -14,12 +14,13 @@ use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataSanity;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::options::Options;
+use crate::util::statistics::counter::EventCounter;
 use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
-use crate::vm::VMBinding;
+use crate::vm::{ObjectModel, VMBinding};
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use mmtk_macros::PlanTraceObject;
 
@@ -37,6 +38,7 @@ pub struct Gen<VM: VMBinding> {
     pub gc_full_heap: AtomicBool,
     /// Is next GC full heap?
     pub next_gc_full_heap: AtomicBool,
+    pub full_heap_gc_count: Arc<Mutex<EventCounter>>,
 }
 
 impl<VM: VMBinding> Gen<VM> {
@@ -48,27 +50,33 @@ impl<VM: VMBinding> Gen<VM> {
         mmapper: &'static Mmapper,
         options: Arc<Options>,
     ) -> Self {
+        let nursery = CopySpace::new(
+            "nursery",
+            false,
+            true,
+            VMRequest::fixed_extent(options.get_max_nursery(), false),
+            global_metadata_specs.clone(),
+            vm_map,
+            mmapper,
+            &mut heap,
+        );
+        let common = CommonPlan::new(
+            vm_map,
+            mmapper,
+            options,
+            heap,
+            constraints,
+            global_metadata_specs,
+        );
+
+        let full_heap_gc_count = common.base.stats.new_event_counter("majorGC", true, true);
+
         Gen {
-            nursery: CopySpace::new(
-                "nursery",
-                false,
-                true,
-                VMRequest::fixed_extent(crate::util::options::NURSERY_SIZE, false),
-                global_metadata_specs.clone(),
-                vm_map,
-                mmapper,
-                &mut heap,
-            ),
-            common: CommonPlan::new(
-                vm_map,
-                mmapper,
-                options,
-                heap,
-                constraints,
-                global_metadata_specs,
-            ),
+            nursery,
+            common,
             gc_full_heap: AtomicBool::default(),
             next_gc_full_heap: AtomicBool::new(false),
+            full_heap_gc_count,
         }
     }
 
@@ -88,6 +96,9 @@ impl<VM: VMBinding> Gen<VM> {
     /// Prepare Gen. This should be called by a single thread in GC prepare work.
     pub fn prepare(&mut self, tls: VMWorkerThread) {
         let full_heap = !self.is_current_gc_nursery();
+        if full_heap {
+            self.full_heap_gc_count.lock().unwrap().inc();
+        }
         self.common.prepare(tls, full_heap);
         self.nursery.prepare(true);
         self.nursery
@@ -101,6 +112,18 @@ impl<VM: VMBinding> Gen<VM> {
         self.nursery.release();
     }
 
+    /// Independent of how many pages remain in the page budget (a function of heap size), we must
+    /// ensure we never exhaust virtual memory. Therefore we must never let the nursery grow to the
+    /// extent that it can't be copied into the mature space.
+    ///
+    /// Returns `true` if the nursery has grown to the extent that it may not be able to be copied
+    /// into the mature space.
+    fn virtual_memory_exhausted<P: Plan>(&self, plan: &P) -> bool {
+        ((plan.get_collection_reserved_pages() as f64
+            * VM::VMObjectModel::VM_WORST_CASE_COPY_EXPANSION) as usize)
+            > plan.get_mature_physical_pages_available()
+    }
+
     /// Check if we need a GC based on the nursery space usage. This method may mark
     /// the following GC as a full heap GC.
     pub fn collection_required<P: Plan>(
@@ -110,8 +133,13 @@ impl<VM: VMBinding> Gen<VM> {
         space: Option<&dyn Space<VM>>,
     ) -> bool {
         let nursery_full = self.nursery.reserved_pages()
-            >= (conversions::bytes_to_pages_up(*self.common.base.options.max_nursery));
+            >= (conversions::bytes_to_pages_up(self.common.base.options.get_max_nursery()));
+
         if nursery_full {
+            return true;
+        }
+
+        if self.virtual_memory_exhausted(plan) {
             return true;
         }
 
@@ -139,7 +167,7 @@ impl<VM: VMBinding> Gen<VM> {
 
     /// Check if we should do a full heap GC. It returns true if we should have a full heap GC.
     /// It also sets gc_full_heap based on the result.
-    pub fn request_full_heap_collection(&self, total_pages: usize, reserved_pages: usize) -> bool {
+    pub fn requires_full_heap_collection<P: Plan>(&self, plan: &P) -> bool {
         // Allow the same 'true' block for if-else.
         // The conditions are complex, and it is easier to read if we put them to separate if blocks.
         #[allow(clippy::if_same_then_else)]
@@ -165,8 +193,10 @@ impl<VM: VMBinding> Gen<VM> {
         {
             // Forces full heap collection
             true
+        } else if self.virtual_memory_exhausted(plan) {
+            true
         } else {
-            total_pages <= reserved_pages
+            plan.get_total_pages() <= plan.get_reserved_pages()
         };
 
         self.gc_full_heap.store(is_full_heap, Ordering::SeqCst);
@@ -176,7 +206,7 @@ impl<VM: VMBinding> Gen<VM> {
             if is_full_heap {
                 "Full heap GC"
             } else {
-                "nursery GC"
+                "Nursery GC"
             }
         );
 
@@ -230,9 +260,13 @@ impl<VM: VMBinding> Gen<VM> {
     }
 
     /// Check a plan to see if the next GC should be a full heap GC.
+    ///
+    /// Note that this function should be called after all spaces have been released. This is
+    /// required as we may get incorrect values since this function uses [`get_available_pages`]
+    /// whose value depends on which spaces have been released.
     pub fn should_next_gc_be_full_heap(plan: &dyn Plan<VM = VM>) -> bool {
         plan.get_available_pages()
-            < conversions::bytes_to_pages_up(*plan.base().options.min_nursery)
+            < conversions::bytes_to_pages_up(plan.base().options.get_min_nursery())
     }
 
     /// Set next_gc_full_heap to the given value.

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -539,8 +539,24 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         // If this is not a new chunk, the SFT for [start, start + bytes) should alreayd be initialized.
         #[cfg(debug_assertions)]
         if !new_chunk {
-            debug_assert!(SFT_MAP.get(start).name() != EMPTY_SFT_NAME, "In grow_space(start = {}, bytes = {}, new_chunk = {}), we have empty SFT entries (chunk for {} = {})", start, bytes, new_chunk, start, SFT_MAP.get(start).name());
-            debug_assert!(SFT_MAP.get(start + bytes - 1).name() != EMPTY_SFT_NAME, "In grow_space(start = {}, bytes = {}, new_chunk = {}), we have empty SFT entries (chunk for {} = {}", start, bytes, new_chunk, start + bytes - 1, SFT_MAP.get(start + bytes - 1).name());
+            debug_assert!(
+                SFT_MAP.get(start).name() != EMPTY_SFT_NAME,
+                "In grow_space(start = {}, bytes = {}, new_chunk = {}), we have empty SFT entries (chunk for {} = {})",
+                start,
+                bytes,
+                new_chunk,
+                start,
+                SFT_MAP.get(start).name()
+            );
+            debug_assert!(
+                SFT_MAP.get(start + bytes - 1).name() != EMPTY_SFT_NAME,
+                "In grow_space(start = {}, bytes = {}, new_chunk = {}), we have empty SFT entries (chunk for {} = {})",
+                start,
+                bytes,
+                new_chunk,
+                start + bytes - 1,
+                SFT_MAP.get(start + bytes - 1).name()
+            );
         }
 
         if new_chunk {
@@ -571,6 +587,11 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         let data_pages = self.get_page_resource().reserved_pages();
         let meta_pages = self.common().metadata.calculate_reserved_pages(data_pages);
         data_pages + meta_pages
+    }
+
+    /// Return the number of physical pages available.
+    fn available_physical_pages(&self) -> usize {
+        self.get_page_resource().get_available_physical_pages()
     }
 
     fn get_name(&self) -> &'static str {

--- a/src/util/heap/layout/map.rs
+++ b/src/util/heap/layout/map.rs
@@ -32,6 +32,14 @@ pub trait Map: Sized {
 
     fn get_contiguous_region_size(&self, start: Address) -> usize;
 
+    /// Return the total number of chunks available (unassigned) within the range of virtual memory
+    /// apportioned to discontiguous spaces.
+    fn get_available_discontiguous_chunks(&self) -> usize;
+
+    /// Return the total number of clients contending for chunks. This is useful when establishing
+    /// conservative bounds on the number of remaining chunks.
+    fn get_chunk_consumer_count(&self) -> usize;
+
     fn free_all_chunks(&self, any_chunk: Address);
 
     fn free_contiguous_chunks(&self, start: Address) -> usize;

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -133,6 +133,14 @@ impl Map for Map32 {
         self.get_contiguous_region_chunks(start) << LOG_BYTES_IN_CHUNK
     }
 
+    fn get_available_discontiguous_chunks(&self) -> usize {
+        self.total_available_discontiguous_chunks
+    }
+
+    fn get_chunk_consumer_count(&self) -> usize {
+        self.shared_discontig_fl_count
+    }
+
     fn free_all_chunks(&self, any_chunk: Address) {
         debug!("free_all_chunks: {}", any_chunk);
         let (_sync, self_mut) = self.mut_self_with_sync();

--- a/src/util/heap/layout/map64.rs
+++ b/src/util/heap/layout/map64.rs
@@ -152,6 +152,14 @@ impl Map for Map64 {
         unreachable!()
     }
 
+    fn get_available_discontiguous_chunks(&self) -> usize {
+        panic!("We don't use discontiguous chunks for 64-bit!");
+    }
+
+    fn get_chunk_consumer_count(&self) -> usize {
+        panic!("We don't use discontiguous chunks for 64-bit!");
+    }
+
     fn free_all_chunks(&self, _any_chunk: Address) {
         unreachable!()
     }

--- a/src/util/heap/pageresource.rs
+++ b/src/util/heap/pageresource.rs
@@ -91,6 +91,20 @@ pub trait PageResource<VM: VMBinding>: 'static {
         self.common().accounting.get_committed_pages()
     }
 
+    /// Return the number of available physical pages by this resource. This includes all pages
+    /// currently unused by this resource. If the resource is using a discontiguous space, it also
+    /// includes the currently unassigned discontiguous space.
+    ///
+    /// Note: This just considers physical pages (i.e. virtual memory pages allocated for use by
+    /// this resource). This calculation is orthogonal to and does not consider any restrictions on
+    /// the number of pages this resource may actually use at any time (i.e. the number of
+    /// committed and reserved pages).
+    ///
+    /// Note: The calculation is made on the assumption that all space that could be assigned to
+    /// this resource would be assigned to this resource (i.e. the unused discontiguous space could
+    /// just as likely be assigned to another competing resource).
+    fn get_available_physical_pages(&self) -> usize;
+
     fn common(&self) -> &CommonPageResource;
     fn common_mut(&mut self) -> &mut CommonPageResource;
     fn vm_map(&self) -> &'static VMMap {
@@ -111,7 +125,7 @@ pub struct CommonPageResource {
     pub contiguous: bool,
     pub growable: bool,
 
-    vm_map: &'static VMMap,
+    pub vm_map: &'static VMMap,
     head_discontiguous_region: Mutex<Address>,
 }
 

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -239,7 +239,10 @@ impl Stats {
         self.shared.set_gathering_stats(true);
 
         for c in &(*counters) {
-            c.lock().unwrap().start();
+            let mut ctr = c.lock().unwrap();
+            if ctr.implicitly_start() {
+                ctr.start();
+            }
         }
     }
 

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -248,6 +248,11 @@ pub trait ObjectModel<VM: VMBinding> {
     /// * `reference`: The object to be queried.
     fn get_type_descriptor(reference: ObjectReference) -> &'static [i8];
 
+    /// This is the worst case expansion that can occur due to object size increasing while
+    /// copying. This constant is used to calculate whether a nursery has grown larger than the
+    /// mature space for generational plans.
+    const VM_WORST_CASE_COPY_EXPANSION: f64 = 1.5;
+
     /// For our allocation result `[cell, cell + bytes)`, if a binding's
     /// definition of `ObjectReference` may point outside the cell (i.e. `object_ref >= cell + bytes`),
     /// the binding needs to provide a `Some` value for this constant and


### PR DESCRIPTION
Introduce Bounded and Fixed nurseries

This commit adds Bounded and Fixed nursery types and changes how the
nursery size is set. A Bounded nursery has a lower bound of 2 MB but a
variable upper bound (set to be 1 TB on 64-bit by default), whereas a
Fixed nursery controls both the upper and lower bound of the nursery and
sets them to be the same value. By default, MMTk uses a Bounded nursery.
The nursery size and type can be set via command line arguments or
environment variables, for example, setting MMTK_NURSERY="Fixed:8192"
will create a Fixed nursery of size 8192 bytes.

This commit also changes how minor and major GCs are triggered to be
more in line with the Java MMTk.

**Note**: VM bindings may want to change the
`ObjectModel::VM_WORST_CASE_COPY_EXPANSION` constant depending on the
worst case expansion that can occur due to object sizes changing when
copied.