### PR TITLE
Feature to turn Immix into non-moving GC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,13 @@ global_alloc_bit = []
 # conservative garbage collection support
 is_mmtk_object = ["global_alloc_bit"]
 
+# The following two features are useful for using Immix for VMs that do not support moving GC.
+
+# Disable defragmentation for ImmixSpace.  This makes Immix a non-moving plan.
+immix_no_defrag = []
+# Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.
+immix_smaller_block = []
+
 # Run sanity GC
 sanity = []
 # Run analysis

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -38,7 +38,7 @@ pub struct Immix<VM: VMBinding> {
 }
 
 pub const IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
-    moves_objects: true,
+    moves_objects: crate::policy::immix::DEFRAG,
     gc_header_bits: 2,
     gc_header_words: 0,
     num_specialized_scans: 1,

--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -84,7 +84,10 @@ impl From<Block> for Address {
 }
 
 impl Region for Block {
+    #[cfg(not(feature = "immix_smaller_block"))]
     const LOG_BYTES: usize = 15;
+    #[cfg(feature = "immix_smaller_block")]
+    const LOG_BYTES: usize = 13;
 }
 
 impl Block {

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -185,6 +185,13 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         scheduler: Arc<GCWorkScheduler<VM>>,
         global_side_metadata_specs: Vec<SideMetadataSpec>,
     ) -> Self {
+        #[cfg(feature = "immix_no_defrag")]
+        info!(
+            "Creating non-moving ImmixSpace: {}. Block size: 2^{}",
+            name,
+            Block::LOG_BYTES
+        );
+
         super::validate_features();
         let common = CommonSpace::new(
             SpaceOptions {

--- a/src/policy/immix/mod.rs
+++ b/src/policy/immix/mod.rs
@@ -16,7 +16,7 @@ pub const MAX_IMMIX_OBJECT_SIZE: usize = Block::BYTES >> 1;
 pub const BLOCK_ONLY: bool = false;
 
 /// Opportunistic copying
-pub const DEFRAG: bool = true;
+pub const DEFRAG: bool = !cfg!(feature = "immix_no_defrag");
 
 /// Mark lines when scanning objects.
 /// Otherwise, do it at mark time.

--- a/src/util/metadata/side_metadata/constants.rs
+++ b/src/util/metadata/side_metadata/constants.rs
@@ -17,9 +17,14 @@ use crate::util::Address;
 // This is made public, as VM bingdings may need to use this.
 #[cfg(target_pointer_width = "32")]
 pub const GLOBAL_SIDE_METADATA_BASE_ADDRESS: Address = unsafe { Address::from_usize(0x1000_0000) };
+
+// FIXME: The 64-bit base address is changed from 0x0600_0000_0000 to 0x0c00_0000_0000 so that it
+// is less likely to overlap with any space.  But it does not solve the problem completely.
+// If there are more spaces, it will still overlap with some spaces.
+// See: https://github.com/mmtk/mmtk-core/issues/458
 #[cfg(target_pointer_width = "64")]
 pub const GLOBAL_SIDE_METADATA_BASE_ADDRESS: Address =
-    unsafe { Address::from_usize(0x0000_0600_0000_0000usize) };
+    unsafe { Address::from_usize(0x0000_0c00_0000_0000usize) };
 
 pub(crate) const GLOBAL_SIDE_METADATA_BASE_OFFSET: SideMetadataOffset =
     SideMetadataOffset::addr(GLOBAL_SIDE_METADATA_BASE_ADDRESS);


### PR DESCRIPTION
1.  [X] We should rebase it after https://github.com/mmtk/mmtk-core/pull/629 is merged.
2.  [X] Ruby crashes with segmentation fault when using the non-moving Immix.  The stack trace indicates there are some issues with the alloc bit when using Immix.
        -   The problem was caused by the metadata overlapping with the large object space.  I added a workaround to temporarily solve this problem.
        -   Related issue: https://github.com/mmtk/mmtk-core/issues/458

Added some features to disable defragmentation and make Immix a
non-moving GC.  It is useful during developing new VM bindings so that
the VM can use Immix before the VM fully supports object moving.

The `immix_no_defrag` feature disables defragmentation in ImmixSpace.
The Immix Plan now reports itself as a non-moving collector
(IMMIX_CONSTRAINTS.moves_objects = false) if policy::immix::DEFRAG is
false.

The `immix_smaller_block` feature reduces the size of blocks of
ImmixSpace.  This should mitigate fragmentation when defragmentation is
disabled.

Also worked around metadata and space address clash by moving metadata to a higher address.