### PR TITLE
Accounting VM-specific allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ work_packet_stats = []
 # Count the malloc'd memory into the heap size
 malloc_counted_size = []
 
+# Count arbitrary VM-specific allocated memory into the heap size
+vm_alloc_counter = []
+
 # Do not modify the following line - ci-common.sh matches it
 # -- Mutally exclusive features --
 # Only one feature from each group can be provided. Otherwise build will fail.


### PR DESCRIPTION
This allows the VM to add arbitrary VM-specific allocations into the
heap size.