### PR TITLE
Add a full impl in Rust for write barrier

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -122,6 +122,7 @@ pub fn flush_mutator<VM: VMBinding>(mutator: &mut Mutator<VM>) {
 /// * `align`: Required alignment for the object.
 /// * `offset`: Offset associated with the alignment.
 /// * `semantics`: The allocation semantic required for the allocation.
+#[inline(always)]
 pub fn alloc<VM: VMBinding>(
     mutator: &mut Mutator<VM>,
     size: usize,
@@ -149,6 +150,7 @@ pub fn alloc<VM: VMBinding>(
 /// * `refer`: The newly allocated object.
 /// * `bytes`: The size of the space allocated for the object (in bytes).
 /// * `semantics`: The allocation semantics used for the allocation.
+#[inline(always)]
 pub fn post_alloc<VM: VMBinding>(
     mutator: &mut Mutator<VM>,
     refer: ObjectReference,
@@ -167,6 +169,7 @@ pub fn post_alloc<VM: VMBinding>(
 /// Arguments:
 /// * `mutator`: The mutator for the current thread.
 /// * `target`: The target for the write operation.
+#[inline(always)]
 pub fn post_write_barrier<VM: VMBinding>(mutator: &mut Mutator<VM>, target: BarrierWriteTarget) {
     mutator.barrier().post_write_barrier(target)
 }

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -167,10 +167,7 @@ pub fn post_alloc<VM: VMBinding>(
 /// Arguments:
 /// * `mutator`: The mutator for the current thread.
 /// * `target`: The target for the write operation.
-pub fn post_write_barrier<VM: VMBinding>(
-    mutator: &mut Mutator<VM>,
-    target: BarrierWriteTarget,
-) {
+pub fn post_write_barrier<VM: VMBinding>(mutator: &mut Mutator<VM>, target: BarrierWriteTarget) {
     mutator.barrier().post_write_barrier(target)
 }
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -14,6 +14,7 @@
 use crate::mmtk::MMTKBuilder;
 use crate::mmtk::MMTK;
 use crate::plan::AllocationSemantics;
+use crate::plan::BarrierWriteTarget;
 use crate::plan::{Mutator, MutatorContext};
 use crate::scheduler::WorkBucketStage;
 use crate::scheduler::{GCController, GCWork, GCWorker};
@@ -155,6 +156,22 @@ pub fn post_alloc<VM: VMBinding>(
     semantics: AllocationSemantics,
 ) {
     mutator.post_alloc(refer, bytes, semantics);
+}
+
+/// The write barrier by MMTk. This is a *post* write barrier, which we expect a binding to call
+/// *after* they modify an object. For performance reasons, a VM should implement the write barrier
+/// fast-path on their side rather than just calling this function.
+///
+/// TODO: We plan to replace this API with a subsuming barrier API.
+///
+/// Arguments:
+/// * `mutator`: The mutator for the current thread.
+/// * `target`: The target for the write operation.
+pub fn post_write_barrier<VM: VMBinding>(
+    mutator: &mut Mutator<VM>,
+    target: BarrierWriteTarget,
+) {
+    mutator.barrier().post_write_barrier(target)
 }
 
 /// Return an AllocatorSelector for the given allocation semantic. This method is provided

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -14,7 +14,9 @@
 //! For more about implementing a plan, it is recommended to read the [MMTk tutorial](/docs/tutorial/Tutorial.md).
 
 mod barriers;
+pub use barriers::Barrier;
 pub use barriers::BarrierSelector;
+pub use barriers::BarrierWriteTarget;
 
 pub(crate) mod gc_requester;
 

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -1,6 +1,6 @@
 //! Mutator context for each application thread.
 
-use crate::plan::barriers::{Barrier, WriteTarget};
+use crate::plan::barriers::Barrier;
 use crate::plan::global::Plan;
 use crate::plan::AllocationSemantics;
 use crate::policy::space::Space;
@@ -135,10 +135,6 @@ pub trait MutatorContext<VM: VMBinding>: Send + 'static {
     }
     fn get_tls(&self) -> VMMutatorThread;
     fn barrier(&mut self) -> &mut dyn Barrier;
-
-    fn record_modified_node(&mut self, obj: ObjectReference) {
-        self.barrier().post_write_barrier(WriteTarget::Object(obj));
-    }
 }
 
 /// This is used for plans to indicate the number of allocators reserved for the plan.


### PR DESCRIPTION
This pull request adds a write barrier fastpath implementation in Rust, and adds a barrier API. It closes https://github.com/mmtk/mmtk-core/issues/612.

Changes:
* rename the current `Barrier::post_write_barrier()` to `Barrier::post_write_barrier_slow()`.
* add `Barrier::post_write_barrier()` which provides a full implementation of write barrier.
* add `memory_manager::post_write_barrier()`.
* rename `WriteTarget` to `BarrierWriteTarget` as it will be exposed.
* remove `MutatorContext::record_modified_node()`.
* modify the slowpath in `ObjectRememberingBarrier` -- it attempts to do CAS first, and only check the bit after the CAS fails.

Related PRs:
* https://github.com/mmtk/mmtk-openjdk/pull/176