### PR TITLE
CopySpace should not clear alloc bit if there is no allocation into the space

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -204,10 +204,13 @@ impl<VM: VMBinding> CopySpace<VM> {
     unsafe fn reset_alloc_bit(&self) {
         let current_chunk = self.pr.get_current_chunk();
         if self.common.contiguous {
-            crate::util::alloc_bit::bzero_alloc_bit(
-                self.common.start,
-                current_chunk + BYTES_IN_CHUNK - self.common.start,
-            );
+            // If we have allocated something into this space, we need to clear its alloc bit.
+            if current_chunk != self.common.start {
+                crate::util::alloc_bit::bzero_alloc_bit(
+                    self.common.start,
+                    current_chunk + BYTES_IN_CHUNK - self.common.start,
+                );
+            }
         } else {
             unimplemented!();
         }


### PR DESCRIPTION
This PR fixes a bug in `CopySpace::release()`, that we should not clear alloc bit if we haven't allocated into the space yet. This bug can be reproduced in this scenario: use `GenCopy` and force every GC to be full heap. In this case, the first GC is a full heap GC, and we copy objects from nursery to `tospace`. At the end of the GC, `fromspace` is empty, and `CopySpace::release()` will be called on the empty space. As we never allocated in this `fromspace`, its side metadata is unmapped, and this bzero call will cause segfault.