### PR TITLE
Remove the <VM as VMBinding>::Foo::bar bullsh*t.

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -26,7 +26,7 @@ const DEBUG_MACRO_OUTPUT: bool = false;
 ///   For example, `GenImmix` is composed with `Gen`, `Gen` is composed with `CommonPlan`, `CommonPlan` is composed
 ///   with `BasePlan`.
 /// * add `#[post_scan]` to any space field that has some policy-specific post_scan_object(). For objects in those spaces,
-///   `post_scan_object()` in the policy will be called after `VM::VMScanning::scan_object()`.
+///   `post_scan_object()` in the policy will be called after `VM::scan_object()`.
 #[proc_macro_error]
 #[proc_macro_derive(PlanTraceObject, attributes(trace, post_scan, fallback_trace))]
 pub fn derive_plan_trace_object(input: TokenStream) -> TokenStream {

--- a/macros/src/plan_trace_object_impl.rs
+++ b/macros/src/plan_trace_object_impl.rs
@@ -48,7 +48,7 @@ pub(crate) fn generate_trace_object<'a>(
         }
     } else {
         quote! {
-            <VM::VMActivePlan as crate::vm::ActivePlan<VM>>::vm_trace_object::<Q>(__mmtk_queue, __mmtk_objref, __mmtk_worker)
+            VM::vm_trace_object::<Q>(__mmtk_queue, __mmtk_objref, __mmtk_worker)
         }
     };
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -24,7 +24,6 @@ use crate::util::heap::layout::vm_layout_constants::HEAP_END;
 use crate::util::heap::layout::vm_layout_constants::HEAP_START;
 use crate::util::opaque_pointer::*;
 use crate::util::{Address, ObjectReference};
-use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 use std::sync::atomic::Ordering;
 
@@ -582,10 +581,7 @@ pub fn harness_end<VM: VMBinding>(mmtk: &'static MMTK<VM>) {
 /// Arguments:
 /// * `mmtk`: A reference to an MMTk instance
 /// * `object`: The object that has a finalizer
-pub fn add_finalizer<VM: VMBinding>(
-    mmtk: &'static MMTK<VM>,
-    object: <VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType,
-) {
+pub fn add_finalizer<VM: VMBinding>(mmtk: &'static MMTK<VM>, object: VM::FinalizableType) {
     if *mmtk.options.no_finalizer {
         warn!("add_finalizer() is called when no_finalizer = true");
     }
@@ -601,9 +597,7 @@ pub fn add_finalizer<VM: VMBinding>(
 ///
 /// Arguments:
 /// * `mmtk`: A reference to an MMTk instance.
-pub fn get_finalized_object<VM: VMBinding>(
-    mmtk: &'static MMTK<VM>,
-) -> Option<<VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType> {
+pub fn get_finalized_object<VM: VMBinding>(mmtk: &'static MMTK<VM>) -> Option<VM::FinalizableType> {
     if *mmtk.options.no_finalizer {
         warn!("get_finalized_object() is called when no_finalizer = true");
     }
@@ -621,9 +615,7 @@ pub fn get_finalized_object<VM: VMBinding>(
 ///
 /// Arguments:
 /// * `mmtk`: A reference to an MMTk instance.
-pub fn get_all_finalizers<VM: VMBinding>(
-    mmtk: &'static MMTK<VM>,
-) -> Vec<<VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType> {
+pub fn get_all_finalizers<VM: VMBinding>(mmtk: &'static MMTK<VM>) -> Vec<VM::FinalizableType> {
     if *mmtk.options.no_finalizer {
         warn!("get_all_finalizers() is called when no_finalizer = true");
     }
@@ -643,7 +635,7 @@ pub fn get_all_finalizers<VM: VMBinding>(
 pub fn get_finalizers_for<VM: VMBinding>(
     mmtk: &'static MMTK<VM>,
     object: ObjectReference,
-) -> Vec<<VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType> {
+) -> Vec<VM::FinalizableType> {
     if *mmtk.options.no_finalizer {
         warn!("get_finalizers() is called when no_finalizer = true");
     }

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -251,7 +251,7 @@ pub fn free_with_size<VM: VMBinding>(mmtk: &MMTK<VM>, addr: Address, old_size: u
 /// However, if a binding uses counted malloc (which won't poll for GC), they may want to poll for GC manually.
 /// This function should only be used by mutator threads.
 pub fn gc_poll<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMMutatorThread) {
-    use crate::vm::{ActivePlan, Collection};
+    use crate::vm::ActivePlan;
     debug_assert!(
         VM::VMActivePlan::is_mutator(tls.0),
         "gc_poll() can only be called by a mutator thread."
@@ -261,7 +261,7 @@ pub fn gc_poll<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMMutatorThread) {
     if plan.should_trigger_gc_when_heap_is_full() && plan.poll(false, None) {
         debug!("Collection required");
         assert!(plan.is_initialized(), "GC is not allowed here: collection is not initialized (did you call initialize_collection()?).");
-        VM::VMCollection::block_for_gc(tls);
+        VM::block_for_gc(tls);
     }
 }
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -251,9 +251,8 @@ pub fn free_with_size<VM: VMBinding>(mmtk: &MMTK<VM>, addr: Address, old_size: u
 /// However, if a binding uses counted malloc (which won't poll for GC), they may want to poll for GC manually.
 /// This function should only be used by mutator threads.
 pub fn gc_poll<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMMutatorThread) {
-    use crate::vm::ActivePlan;
     debug_assert!(
-        VM::VMActivePlan::is_mutator(tls.0),
+        VM::is_mutator(tls.0),
         "gc_poll() can only be called by a mutator thread."
     );
 

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -11,7 +11,6 @@ use crate::util::options::Options;
 use crate::util::reference_processor::ReferenceProcessors;
 #[cfg(feature = "sanity")]
 use crate::util::sanity::sanity_checker::SanityChecker;
-use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 use std::default::Default;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -82,8 +81,7 @@ pub struct MMTK<VM: VMBinding> {
     pub(crate) options: Arc<Options>,
     pub(crate) plan: Box<dyn Plan<VM = VM>>,
     pub(crate) reference_processors: ReferenceProcessors,
-    pub(crate) finalizable_processor:
-        Mutex<FinalizableProcessor<<VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType>>,
+    pub(crate) finalizable_processor: Mutex<FinalizableProcessor<VM::FinalizableType>>,
     pub(crate) scheduler: Arc<GCWorkScheduler<VM>>,
     #[cfg(feature = "sanity")]
     pub(crate) sanity_checker: Mutex<SanityChecker>,
@@ -123,9 +121,7 @@ impl<VM: VMBinding> MMTK<VM> {
             options,
             plan,
             reference_processors: ReferenceProcessors::new(),
-            finalizable_processor: Mutex::new(FinalizableProcessor::<
-                <VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType,
-            >::new()),
+            finalizable_processor: Mutex::new(FinalizableProcessor::<VM::FinalizableType>::new()),
             scheduler,
             #[cfg(feature = "sanity")]
             sanity_checker: Mutex::new(SanityChecker::new()),

--- a/src/plan/generational/copying/mutator.rs
+++ b/src/plan/generational/copying/mutator.rs
@@ -9,7 +9,7 @@ use crate::plan::AllocationSemantics;
 use crate::util::alloc::allocators::Allocators;
 use crate::util::alloc::BumpAllocator;
 use crate::util::{VMMutatorThread, VMWorkerThread};
-use crate::vm::{ObjectModel, VMBinding};
+use crate::vm::VMBinding;
 use crate::MMTK;
 
 pub fn gencopy_mutator_prepare<VM: VMBinding>(_mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {
@@ -44,7 +44,7 @@ pub fn create_gencopy_mutator<VM: VMBinding>(
         allocators: Allocators::<VM>::new(mutator_tls, &*mmtk.plan, &config.space_mapping),
         barrier: Box::new(ObjectRememberingBarrier::<GenNurseryProcessEdges<VM>>::new(
             mmtk,
-            *VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC,
+            *VM::GLOBAL_LOG_BIT_SPEC,
         )),
         mutator_tls,
         config,

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -17,7 +17,7 @@ use crate::util::options::Options;
 use crate::util::statistics::counter::EventCounter;
 use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
-use crate::vm::{ObjectModel, VMBinding};
+use crate::vm::VMBinding;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
@@ -119,8 +119,7 @@ impl<VM: VMBinding> Gen<VM> {
     /// Returns `true` if the nursery has grown to the extent that it may not be able to be copied
     /// into the mature space.
     fn virtual_memory_exhausted<P: Plan>(&self, plan: &P) -> bool {
-        ((plan.get_collection_reserved_pages() as f64
-            * VM::VMObjectModel::VM_WORST_CASE_COPY_EXPANSION) as usize)
+        ((plan.get_collection_reserved_pages() as f64 * VM::VM_WORST_CASE_COPY_EXPANSION) as usize)
             > plan.get_mature_physical_pages_available()
     }
 

--- a/src/plan/generational/immix/mutator.rs
+++ b/src/plan/generational/immix/mutator.rs
@@ -9,7 +9,7 @@ use crate::plan::AllocationSemantics;
 use crate::util::alloc::allocators::Allocators;
 use crate::util::alloc::BumpAllocator;
 use crate::util::{VMMutatorThread, VMWorkerThread};
-use crate::vm::{ObjectModel, VMBinding};
+use crate::vm::VMBinding;
 use crate::MMTK;
 
 pub fn genimmix_mutator_prepare<VM: VMBinding>(_mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {}
@@ -42,7 +42,7 @@ pub fn create_genimmix_mutator<VM: VMBinding>(
         allocators: Allocators::<VM>::new(mutator_tls, &*mmtk.plan, &config.space_mapping),
         barrier: Box::new(ObjectRememberingBarrier::<GenNurseryProcessEdges<VM>>::new(
             mmtk,
-            *VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC,
+            *VM::GLOBAL_LOG_BIT_SPEC,
         )),
         mutator_tls,
         config,

--- a/src/plan/generational/mod.rs
+++ b/src/plan/generational/mod.rs
@@ -10,7 +10,6 @@ use crate::policy::space::Space;
 use crate::util::alloc::AllocatorSelector;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
-use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use crate::Plan;
 
@@ -58,7 +57,7 @@ pub const GEN_CONSTRAINTS: PlanConstraints = PlanConstraints {
 /// So if a plan calls this, it should not call SideMetadataContext::new_global_specs() again.
 pub fn new_generational_global_metadata_specs<VM: VMBinding>() -> Vec<SideMetadataSpec> {
     let specs = if ACTIVE_BARRIER == BarrierSelector::ObjectBarrier {
-        crate::util::metadata::extract_side_metadata(&[*VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC])
+        crate::util::metadata::extract_side_metadata(&[*VM::GLOBAL_LOG_BIT_SPEC])
     } else {
         vec![]
     };

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -577,7 +577,7 @@ impl<VM: VMBinding> BasePlan<VM> {
             self.user_triggered_collection
                 .store(true, Ordering::Relaxed);
             self.gc_requester.request();
-            VM::VMCollection::block_for_gc(tls);
+            VM::block_for_gc(tls);
         }
     }
 

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -25,7 +25,6 @@ use crate::util::options::PlanSelector;
 use crate::util::statistics::stats::Stats;
 use crate::util::ObjectReference;
 use crate::util::{VMMutatorThread, VMWorkerThread};
-use crate::vm::*;
 use downcast_rs::Downcast;
 use enum_map::EnumMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -663,7 +662,7 @@ impl<VM: VMBinding> BasePlan<VM> {
             return self.vm_space.trace_object(queue, object);
         }
 
-        VM::VMActivePlan::vm_trace_object::<Q>(queue, object, worker)
+        VM::vm_trace_object::<Q>(queue, object, worker)
     }
 
     pub fn prepare(&mut self, _tls: VMWorkerThread, _full_heap: bool) {

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -1025,8 +1025,8 @@ pub trait PlanTraceObject<VM: VMBinding> {
         worker: &mut GCWorker<VM>,
     ) -> ObjectReference;
 
-    /// Post-scan objects in the plan. Each object is scanned by `VM::VMScanning::scan_object()`, and this function
-    /// will be called after the `VM::VMScanning::scan_object()` as a hook to invoke possible policy post scan method.
+    /// Post-scan objects in the plan. Each object is scanned by `VM::scan_object()`, and this function
+    /// will be called after the `VM::scan_object()` as a hook to invoke possible policy post scan method.
     /// If a plan does not have any policy that needs post scan, this method can be implemented as empty.
     /// If a plan has a policy that has some policy specific behaviors for scanning (e.g. mark lines in Immix),
     /// this method should also invoke those policy specific methods for objects in that space.

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -7,7 +7,6 @@ use crate::scheduler::GCWork;
 use crate::scheduler::GCWorker;
 use crate::scheduler::WorkBucketStage;
 use crate::vm::ActivePlan;
-use crate::vm::Scanning;
 use crate::vm::VMBinding;
 use crate::MMTK;
 use std::marker::PhantomData;
@@ -40,7 +39,7 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
     #[inline]
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
         // The following needs to be done right before the second round of root scanning
-        VM::VMScanning::prepare_for_roots_re_scanning();
+        VM::prepare_for_roots_re_scanning();
         mmtk.plan.base().prepare_for_stack_scanning();
         #[cfg(feature = "extreme_assertions")]
         crate::util::edge_logger::reset();

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -6,7 +6,6 @@ use crate::scheduler::gc_work::*;
 use crate::scheduler::GCWork;
 use crate::scheduler::GCWorker;
 use crate::scheduler::WorkBucketStage;
-use crate::vm::ActivePlan;
 use crate::vm::VMBinding;
 use crate::MMTK;
 use std::marker::PhantomData;
@@ -47,7 +46,7 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         // TODO investigate why the following will create duplicate edges
         // scheduler.work_buckets[WorkBucketStage::RefForwarding]
         //     .add(ScanStackRoots::<ForwardingProcessEdges<VM>>::new());
-        for mutator in VM::VMActivePlan::mutators() {
+        for mutator in VM::mutators() {
             mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
                 .add(ScanStackRoot::<ForwardingProcessEdges<VM>>(mutator));
         }

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -138,8 +138,8 @@ impl<VM: VMBinding> CopySpace<VM> {
         heap: &mut HeapMeta,
     ) -> Self {
         let local_specs = extract_side_metadata(&[
-            *VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC,
-            *VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC,
+            *VM::LOCAL_FORWARDING_BITS_SPEC,
+            *VM::LOCAL_FORWARDING_POINTER_SPEC,
         ]);
         let common = CommonSpace::new(
             SpaceOptions {
@@ -179,8 +179,7 @@ impl<VM: VMBinding> CopySpace<VM> {
         // Clear the metadata if we are using side forwarding status table. Otherwise
         // objects may inherit forwarding status from the previous GC.
         // TODO: Fix performance.
-        if let MetadataSpec::OnSide(side_forwarding_status_table) =
-            *<VM::VMObjectModel as ObjectModel<VM>>::LOCAL_FORWARDING_BITS_SPEC
+        if let MetadataSpec::OnSide(side_forwarding_status_table) = *VM::LOCAL_FORWARDING_BITS_SPEC
         {
             side_metadata::bzero_metadata(
                 &side_forwarding_status_table,

--- a/src/policy/immix/defrag.rs
+++ b/src/policy/immix/defrag.rs
@@ -110,9 +110,8 @@ impl Defrag {
 
         // Calculate available free space for defragmentation.
 
-        let mut available_clean_pages_for_defrag = VM::VMActivePlan::global().get_total_pages()
-            as isize
-            - VM::VMActivePlan::global().get_reserved_pages() as isize
+        let mut available_clean_pages_for_defrag = VM::global().get_total_pages() as isize
+            - VM::global().get_reserved_pages() as isize
             + self.defrag_headroom_pages(space) as isize;
         if available_clean_pages_for_defrag < 0 {
             available_clean_pages_for_defrag = 0
@@ -127,7 +126,7 @@ impl Defrag {
 
         self.available_clean_pages_for_defrag.store(
             available_clean_pages_for_defrag as usize
-                + VM::VMActivePlan::global().get_collection_reserved_pages(),
+                + VM::global().get_collection_reserved_pages(),
             Ordering::Release,
         );
     }

--- a/src/policy/immix/line.rs
+++ b/src/policy/immix/line.rs
@@ -75,8 +75,8 @@ impl Line {
     #[inline]
     pub fn mark_lines_for_object<VM: VMBinding>(object: ObjectReference, state: u8) -> usize {
         debug_assert!(!super::BLOCK_ONLY);
-        let start = VM::VMObjectModel::object_start_ref(object);
-        let end = start + VM::VMObjectModel::get_current_size(object);
+        let start = VM::object_start_ref(object);
+        let end = start + VM::get_current_size(object);
         let start_line = Line::from(Line::align(start));
         let mut end_line = Line::from(Line::align(end));
         if !Line::is_aligned(end) {

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -14,7 +14,6 @@ use crate::util::opaque_pointer::*;
 use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::util::{conversions, metadata};
-use crate::vm::ActivePlan;
 use crate::vm::VMBinding;
 use crate::{policy::space::Space, util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK};
 use std::marker::PhantomData;
@@ -237,8 +236,8 @@ impl<VM: VMBinding> MallocSpace<VM> {
 
     pub fn alloc(&self, tls: VMThread, size: usize, align: usize, offset: isize) -> Address {
         // TODO: Should refactor this and Space.acquire()
-        if VM::VMActivePlan::global().poll(false, Some(self)) {
-            assert!(VM::VMActivePlan::is_mutator(tls), "Polling in GC worker");
+        if VM::global().poll(false, Some(self)) {
+            assert!(VM::is_mutator(tls), "Polling in GC worker");
             VM::block_for_gc(VMMutatorThread(tls));
             return unsafe { Address::zero() };
         }

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -14,8 +14,8 @@ use crate::util::opaque_pointer::*;
 use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::util::{conversions, metadata};
+use crate::vm::ActivePlan;
 use crate::vm::VMBinding;
-use crate::vm::{ActivePlan, Collection};
 use crate::{policy::space::Space, util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK};
 use std::marker::PhantomData;
 #[cfg(debug_assertions)]
@@ -239,7 +239,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         // TODO: Should refactor this and Space.acquire()
         if VM::VMActivePlan::global().poll(false, Some(self)) {
             assert!(VM::VMActivePlan::is_mutator(tls), "Polling in GC worker");
-            VM::VMCollection::block_for_gc(VMMutatorThread(tls));
+            VM::block_for_gc(VMMutatorThread(tls));
             return unsafe { Address::zero() };
         }
 

--- a/src/policy/mallocspace/metadata.rs
+++ b/src/policy/mallocspace/metadata.rs
@@ -8,7 +8,7 @@ use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::metadata::store_metadata;
 use crate::util::Address;
 use crate::util::ObjectReference;
-use crate::vm::{ObjectModel, VMBinding};
+use crate::vm::VMBinding;
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 
@@ -168,12 +168,7 @@ pub fn has_object_alloced_by_malloc(addr: Address) -> bool {
 }
 
 pub fn is_marked<VM: VMBinding>(object: ObjectReference, ordering: Option<Ordering>) -> bool {
-    load_metadata::<VM>(
-        &VM::VMObjectModel::LOCAL_MARK_BIT_SPEC,
-        object,
-        None,
-        ordering,
-    ) == 1
+    load_metadata::<VM>(&VM::LOCAL_MARK_BIT_SPEC, object, None, ordering) == 1
 }
 
 #[allow(unused)]
@@ -212,13 +207,7 @@ pub fn set_alloc_bit(object: ObjectReference) {
 }
 
 pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Option<Ordering>) {
-    store_metadata::<VM>(
-        &VM::VMObjectModel::LOCAL_MARK_BIT_SPEC,
-        object,
-        1,
-        None,
-        ordering,
-    );
+    store_metadata::<VM>(&VM::LOCAL_MARK_BIT_SPEC, object, 1, None, ordering);
 }
 
 #[allow(unused)]
@@ -257,13 +246,7 @@ pub unsafe fn unset_alloc_bit_unsafe(object: ObjectReference) {
 
 #[allow(unused)]
 pub fn unset_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Option<Ordering>) {
-    store_metadata::<VM>(
-        &VM::VMObjectModel::LOCAL_MARK_BIT_SPEC,
-        object,
-        0,
-        None,
-        ordering,
-    );
+    store_metadata::<VM>(&VM::LOCAL_MARK_BIT_SPEC, object, 0, None, ordering);
 }
 
 pub(super) unsafe fn unset_page_mark_unsafe(page_addr: Address) {

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -7,7 +7,7 @@ use crate::util::ObjectReference;
 use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_BYTES, LOG_BYTES_IN_CHUNK};
 use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_END, AVAILABLE_START};
 use crate::util::heap::{PageResource, VMRequest};
-use crate::vm::{ActivePlan, Collection, ObjectModel};
+use crate::vm::{ActivePlan, Collection};
 
 use crate::util::constants::LOG_BYTES_IN_MBYTE;
 use crate::util::conversions;
@@ -360,7 +360,7 @@ impl<'a> SFTMap<'a> {
     #[cfg(debug_assertions)]
     pub fn assert_valid_entries_for_object<VM: VMBinding>(&self, object: ObjectReference) {
         let object_sft = self.get(object.to_address());
-        let object_start_sft = self.get(VM::VMObjectModel::object_start_ref(object));
+        let object_start_sft = self.get(VM::object_start_ref(object));
 
         debug_assert!(
             object_sft.name() != EMPTY_SFT_NAME,
@@ -515,7 +515,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
     }
 
     fn in_space(&self, object: ObjectReference) -> bool {
-        let start = VM::VMObjectModel::ref_to_address(object);
+        let start = VM::ref_to_address(object);
         self.address_in_space(start)
     }
 

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -7,7 +7,7 @@ use crate::util::ObjectReference;
 use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_BYTES, LOG_BYTES_IN_CHUNK};
 use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_END, AVAILABLE_START};
 use crate::util::heap::{PageResource, VMRequest};
-use crate::vm::{ActivePlan, Collection};
+use crate::vm::ActivePlan;
 
 use crate::util::constants::LOG_BYTES_IN_MBYTE;
 use crate::util::conversions;
@@ -409,7 +409,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
             debug!("Collection required");
             assert!(allow_gc, "GC is not allowed here: collection is not initialized (did you call initialize_collection()?).");
             pr.clear_request(pages_reserved);
-            VM::VMCollection::block_for_gc(VMMutatorThread(tls)); // We have checked that this is mutator
+            VM::block_for_gc(VMMutatorThread(tls)); // We have checked that this is mutator
             unsafe { Address::zero() }
         } else {
             debug!("Collection not required");
@@ -499,7 +499,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                     let gc_performed = VM::VMActivePlan::global().poll(true, Some(self.as_space()));
                     debug_assert!(gc_performed, "GC not performed when forced.");
                     pr.clear_request(pages_reserved);
-                    VM::VMCollection::block_for_gc(VMMutatorThread(tls)); // We asserted that this is mutator.
+                    VM::block_for_gc(VMMutatorThread(tls)); // We asserted that this is mutator.
                     unsafe { Address::zero() }
                 }
             }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -4,7 +4,6 @@ use super::worker::{GCWorker, GCWorkerShared, WorkerGroup};
 use super::*;
 use crate::mmtk::MMTK;
 use crate::util::opaque_pointer::*;
-use crate::vm::Collection;
 use crate::vm::{GCThreadContext, VMBinding};
 use crossbeam::deque::{self, Steal};
 use enum_map::Enum;
@@ -146,7 +145,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             receiver,
             coordinator_worker,
         );
-        VM::VMCollection::spawn_gc_thread(tls, GCThreadContext::<VM>::Controller(gc_controller));
+        VM::spawn_gc_thread(tls, GCThreadContext::<VM>::Controller(gc_controller));
 
         self.worker_group.spawn(mmtk, sender, tls)
     }

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::mmtk::MMTK;
 use crate::util::copy::GCWorkerCopyContext;
 use crate::util::opaque_pointer::*;
-use crate::vm::{Collection, GCThreadContext, VMBinding};
+use crate::vm::{GCThreadContext, VMBinding};
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use crossbeam::deque::{self, Stealer};
 use crossbeam::queue::ArrayQueue;
@@ -228,7 +228,7 @@ impl<VM: VMBinding> WorkerGroup<VM> {
                 shared.clone(),
                 unspawned_local_work_queues.pop().unwrap(),
             ));
-            VM::VMCollection::spawn_gc_thread(tls, GCThreadContext::<VM>::Worker(worker));
+            VM::spawn_gc_thread(tls, GCThreadContext::<VM>::Worker(worker));
         }
         debug_assert!(unspawned_local_work_queues.is_empty());
     }

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -5,7 +5,6 @@ use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::util::constants::*;
 use crate::util::opaque_pointer::*;
-use crate::vm::ActivePlan;
 use crate::vm::VMBinding;
 use downcast_rs::Downcast;
 
@@ -188,7 +187,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     fn alloc_slow_inline(&mut self, size: usize, align: usize, offset: isize) -> Address {
         let tls = self.get_tls();
         let plan = self.get_plan().base();
-        let is_mutator = VM::VMActivePlan::is_mutator(tls);
+        let is_mutator = VM::is_mutator(tls);
         let stress_test = plan.is_stress_test_gc_enabled();
 
         // Information about the previous collection.

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -5,8 +5,8 @@ use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::util::constants::*;
 use crate::util::opaque_pointer::*;
+use crate::vm::ActivePlan;
 use crate::vm::VMBinding;
-use crate::vm::{ActivePlan, Collection};
 use downcast_rs::Downcast;
 
 #[repr(C)]
@@ -273,7 +273,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 if fail_with_oom {
                     // Note that we throw a `HeapOutOfMemory` error here and return a null ptr back to the VM
                     trace!("Throw HeapOutOfMemory!");
-                    VM::VMCollection::out_of_memory(tls, AllocationError::HeapOutOfMemory);
+                    VM::out_of_memory(tls, AllocationError::HeapOutOfMemory);
                     plan.allocation_success.swap(false, Ordering::SeqCst);
                     return result;
                 }

--- a/src/util/analysis/obj_size.rs
+++ b/src/util/analysis/obj_size.rs
@@ -51,7 +51,7 @@ impl<VM: VMBinding> RtAnalysis<VM> for PerSizeClassObjectCounter {
             return;
         }
 
-        let stats = &(VM::VMActivePlan::global().base()).stats;
+        let stats = &(VM::global().base()).stats;
         let size_class = format!("size{}", self.size_class(size));
         let mut size_classes = self.size_classes.lock().unwrap();
         let c = size_classes.get_mut(&size_class);

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -11,7 +11,6 @@ use crate::policy::space::Space;
 use crate::util::object_forwarding;
 use crate::util::opaque_pointer::VMWorkerThread;
 use crate::util::{Address, ObjectReference};
-use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use std::sync::atomic::Ordering;
 
@@ -105,7 +104,7 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
         // If we are copying objects in mature space, we would need to mark the object as mature.
         if semantics.is_mature() && self.config.constraints.needs_log_bit {
             // If the plan uses unlogged bit, we set the unlogged bit (the object is unlogged/mature)
-            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
+            VM::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
         // Policy specific post copy.
         match self.config.copy_mapping[semantics] {

--- a/src/util/finalizable_processor.rs
+++ b/src/util/finalizable_processor.rs
@@ -2,8 +2,8 @@ use crate::scheduler::gc_work::ProcessEdgesWork;
 use crate::scheduler::{GCWork, GCWorker};
 use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
+use crate::vm::Collection;
 use crate::vm::Finalizable;
-use crate::vm::{Collection, VMBinding};
 use crate::MMTK;
 use std::marker::PhantomData;
 
@@ -73,7 +73,7 @@ impl<F: Finalizable> FinalizableProcessor<F> {
 
         self.nursery_index = self.candidates.len();
 
-        <<E as ProcessEdgesWork>::VM as VMBinding>::VMCollection::schedule_finalization(tls);
+        E::VM::schedule_finalization(tls);
     }
 
     pub fn forward_candidate<E: ProcessEdgesWork>(&mut self, e: &mut E, _nursery: bool) {

--- a/src/util/heap/pageresource.rs
+++ b/src/util/heap/pageresource.rs
@@ -1,7 +1,6 @@
 use crate::util::address::Address;
 use crate::util::conversions;
 use crate::util::opaque_pointer::*;
-use crate::vm::ActivePlan;
 use std::sync::Mutex;
 
 use super::layout::map::Map;
@@ -77,7 +76,7 @@ pub trait PageResource<VM: VMBinding>: 'static {
         let delta = actual_pages - reserved_pages;
         self.common().accounting.reserve(delta);
         self.common().accounting.commit(actual_pages);
-        if VM::VMActivePlan::is_mutator(tls) {
+        if VM::is_mutator(tls) {
             self.vm_map()
                 .add_to_cumulative_committed_pages(actual_pages);
         }

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -1,7 +1,6 @@
 use crate::util::alloc_bit;
 use crate::util::Address;
 use crate::util::ObjectReference;
-use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use std::marker::PhantomData;
 
@@ -70,7 +69,7 @@ pub struct DefaultObjectSize<VM: VMBinding>(PhantomData<VM>);
 impl<VM: VMBinding> LinearScanObjectSize for DefaultObjectSize<VM> {
     #[inline(always)]
     fn size(object: ObjectReference) -> usize {
-        VM::VMObjectModel::get_current_size(object)
+        VM::get_current_size(object)
     }
 }
 
@@ -114,7 +113,7 @@ pub trait Region: Copy + PartialEq + PartialOrd + From<Address> + Into<Address> 
     /// Return the region that contains the object (by its cell address).
     #[inline(always)]
     fn containing<VM: VMBinding>(object: ObjectReference) -> Self {
-        Self::from(VM::VMObjectModel::ref_to_address(object).align_down(Self::BYTES))
+        Self::from(VM::ref_to_address(object).align_down(Self::BYTES))
     }
 }
 

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -1,7 +1,7 @@
 use crate::util::alloc::AllocationError;
 use crate::util::opaque_pointer::*;
 use crate::util::Address;
-use crate::vm::{Collection, VMBinding};
+use crate::vm::VMBinding;
 use libc::{PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
 use std::io::{Error, Result};
 
@@ -93,7 +93,7 @@ pub fn handle_mmap_error<VM: VMBinding>(error: Error, tls: VMThread) -> ! {
         ErrorKind::OutOfMemory => {
             // Signal `MmapOutOfMemory`. Expect the VM to abort immediately.
             trace!("Signal MmapOutOfMemory!");
-            VM::VMCollection::out_of_memory(tls, AllocationError::MmapOutOfMemory);
+            VM::out_of_memory(tls, AllocationError::MmapOutOfMemory);
             unreachable!()
         }
         // Before Rust had ErrorKind::OutOfMemory, this is how we capture OOM from OS calls.
@@ -105,7 +105,7 @@ pub fn handle_mmap_error<VM: VMBinding>(error: Error, tls: VMThread) -> ! {
                 if os_errno == libc::ENOMEM {
                     // Signal `MmapOutOfMemory`. Expect the VM to abort immediately.
                     trace!("Signal MmapOutOfMemory!");
-                    VM::VMCollection::out_of_memory(tls, AllocationError::MmapOutOfMemory);
+                    VM::out_of_memory(tls, AllocationError::MmapOutOfMemory);
                     unreachable!()
                 }
             }

--- a/src/util/metadata/global.rs
+++ b/src/util/metadata/global.rs
@@ -1,7 +1,6 @@
 use crate::util::metadata::side_metadata;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::ObjectReference;
-use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use atomic::Ordering;
 
@@ -60,7 +59,7 @@ pub fn load_metadata<VM: VMBinding>(
             }
         }
         MetadataSpec::InHeader(metadata_spec) => {
-            VM::VMObjectModel::load_metadata(metadata_spec, object, mask, atomic_ordering)
+            VM::load_metadata(metadata_spec, object, mask, atomic_ordering)
         }
     }
 }
@@ -94,7 +93,7 @@ pub fn store_metadata<VM: VMBinding>(
             }
         }
         MetadataSpec::InHeader(metadata_spec) => {
-            VM::VMObjectModel::store_metadata(metadata_spec, object, val, mask, atomic_ordering);
+            VM::store_metadata(metadata_spec, object, val, mask, atomic_ordering);
         }
     }
 }
@@ -132,7 +131,7 @@ pub fn compare_exchange_metadata<VM: VMBinding>(
             success_order,
             failure_order,
         ),
-        MetadataSpec::InHeader(metadata_spec) => VM::VMObjectModel::compare_exchange_metadata(
+        MetadataSpec::InHeader(metadata_spec) => VM::compare_exchange_metadata(
             metadata_spec,
             object,
             old_val,
@@ -167,7 +166,7 @@ pub fn fetch_add_metadata<VM: VMBinding>(
             side_metadata::fetch_add_atomic(metadata_spec, object.to_address(), val, order)
         }
         MetadataSpec::InHeader(metadata_spec) => {
-            VM::VMObjectModel::fetch_add_metadata(metadata_spec, object, val, order)
+            VM::fetch_add_metadata(metadata_spec, object, val, order)
         }
     }
 }
@@ -195,7 +194,7 @@ pub fn fetch_sub_metadata<VM: VMBinding>(
             side_metadata::fetch_sub_atomic(metadata_spec, object.to_address(), val, order)
         }
         MetadataSpec::InHeader(metadata_spec) => {
-            VM::VMObjectModel::fetch_sub_metadata(metadata_spec, object, val, order)
+            VM::fetch_sub_metadata(metadata_spec, object, val, order)
         }
     }
 }

--- a/src/util/reference_processor.rs
+++ b/src/util/reference_processor.rs
@@ -299,7 +299,7 @@ impl ReferenceProcessor {
                 trace!(
                     "Forwarding reference: {} (size: {})",
                     reference,
-                    <E::VM as VMBinding>::VMObjectModel::get_current_size(reference)
+                    E::VM::get_current_size(reference)
                 );
                 trace!(
                     " referent: {} (forwarded to {})",

--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -20,19 +20,21 @@ impl<'a, VM: VMBinding> Iterator for SynchronizedMutatorIterator<'a, VM> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.start {
             self.start = false;
-            VM::VMActivePlan::reset_mutator_iterator();
+            VM::reset_mutator_iterator();
         }
-        VM::VMActivePlan::get_next_mutator()
+        VM::get_next_mutator()
     }
 }
 
 /// VM-specific methods for the current plan.
-pub trait ActivePlan<VM: VMBinding> {
+pub trait ActivePlan {
+    type VM: VMBinding;
+
     /// Return a reference to the current plan.
     // TODO: I don't know how this can be implemented when we have multiple MMTk instances.
     // This function is used by space and phase to refer to the current plan.
     // Possibly we should remove the use of this function, and remove this function?
-    fn global() -> &'static dyn Plan<VM = VM>;
+    fn global() -> &'static dyn Plan<VM = Self::VM>;
 
     /// Return whether there is a mutator created and associated with the thread.
     ///
@@ -50,7 +52,7 @@ pub trait ActivePlan<VM: VMBinding> {
     ///
     /// # Safety
     /// The caller needs to make sure that the thread is a mutator thread.
-    fn mutator(tls: VMMutatorThread) -> &'static mut Mutator<VM>;
+    fn mutator(tls: VMMutatorThread) -> &'static mut Mutator<Self::VM>;
 
     /// Reset the mutator iterator so that `get_next_mutator()` returns the first mutator.
     fn reset_mutator_iterator();
@@ -58,10 +60,10 @@ pub trait ActivePlan<VM: VMBinding> {
     /// Return the next mutator if there is any. This method assumes that the VM implements stateful type
     /// to remember which mutator is returned and guarantees to return the next when called again. This does
     /// not need to be thread safe.
-    fn get_next_mutator() -> Option<&'static mut Mutator<VM>>;
+    fn get_next_mutator() -> Option<&'static mut Mutator<Self::VM>>;
 
     /// A utility method to provide a thread-safe mutator iterator from `reset_mutator_iterator()` and `get_next_mutator()`.
-    fn mutators<'a>() -> SynchronizedMutatorIterator<'a, VM> {
+    fn mutators<'a>() -> SynchronizedMutatorIterator<'a, Self::VM> {
         SynchronizedMutatorIterator {
             _guard: Self::global().base().mutator_iterator_lock.lock().unwrap(),
             start: true,
@@ -93,7 +95,7 @@ pub trait ActivePlan<VM: VMBinding> {
     fn vm_trace_object<Q: ObjectQueue>(
         _queue: &mut Q,
         object: ObjectReference,
-        _worker: &mut GCWorker<VM>,
+        _worker: &mut GCWorker<Self::VM>,
     ) -> ObjectReference {
         panic!("MMTk cannot trace object {:?} as it does not belong to any MMTk space. If the object is known to the VM, the binding can override this method and handle its tracing.", object)
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -36,12 +36,14 @@ pub use self::scanning::Scanning;
 
 /// The `VMBinding` trait associates with each trait, and provides VM-specific constants.
 pub trait VMBinding:
-    ObjectModel<VM = Self> + Scanning<VM = Self> + Collection<VM = Self> + ActivePlan<VM = Self>
+    ObjectModel<VM = Self>
+    + Scanning<VM = Self>
+    + Collection<VM = Self>
+    + ActivePlan<VM = Self>
+    + ReferenceGlue<VM = Self>
 where
     Self: Sized + 'static + Send + Sync + Default,
 {
-    type VMReferenceGlue: ReferenceGlue<Self>;
-
     /// A value to fill in alignment gaps. This value can be used for debugging.
     const ALIGNMENT_VALUE: usize = 0xdead_beef;
     /// Allowed minimal alignment.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -35,11 +35,10 @@ pub use self::scanning::RootsWorkFactory;
 pub use self::scanning::Scanning;
 
 /// The `VMBinding` trait associates with each trait, and provides VM-specific constants.
-pub trait VMBinding: ObjectModel<VM = Self>
+pub trait VMBinding: ObjectModel<VM = Self> + Scanning<VM = Self>
 where
     Self: Sized + 'static + Send + Sync + Default,
 {
-    type VMScanning: Scanning<Self>;
     type VMCollection: Collection<Self>;
     type VMActivePlan: ActivePlan<Self>;
     type VMReferenceGlue: ReferenceGlue<Self>;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -35,11 +35,10 @@ pub use self::scanning::RootsWorkFactory;
 pub use self::scanning::Scanning;
 
 /// The `VMBinding` trait associates with each trait, and provides VM-specific constants.
-pub trait VMBinding
+pub trait VMBinding: ObjectModel<VM = Self>
 where
     Self: Sized + 'static + Send + Sync + Default,
 {
-    type VMObjectModel: ObjectModel<Self>;
     type VMScanning: Scanning<Self>;
     type VMCollection: Collection<Self>;
     type VMActivePlan: ActivePlan<Self>;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -35,11 +35,10 @@ pub use self::scanning::RootsWorkFactory;
 pub use self::scanning::Scanning;
 
 /// The `VMBinding` trait associates with each trait, and provides VM-specific constants.
-pub trait VMBinding: ObjectModel<VM = Self> + Scanning<VM = Self>
+pub trait VMBinding: ObjectModel<VM = Self> + Scanning<VM = Self> + Collection<VM = Self>
 where
     Self: Sized + 'static + Send + Sync + Default,
 {
-    type VMCollection: Collection<Self>;
     type VMActivePlan: ActivePlan<Self>;
     type VMReferenceGlue: ReferenceGlue<Self>;
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -35,11 +35,11 @@ pub use self::scanning::RootsWorkFactory;
 pub use self::scanning::Scanning;
 
 /// The `VMBinding` trait associates with each trait, and provides VM-specific constants.
-pub trait VMBinding: ObjectModel<VM = Self> + Scanning<VM = Self> + Collection<VM = Self>
+pub trait VMBinding:
+    ObjectModel<VM = Self> + Scanning<VM = Self> + Collection<VM = Self> + ActivePlan<VM = Self>
 where
     Self: Sized + 'static + Send + Sync + Default,
 {
-    type VMActivePlan: ActivePlan<Self>;
     type VMReferenceGlue: ReferenceGlue<Self>;
 
     /// A value to fill in alignment gaps. This value can be used for debugging.

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -63,7 +63,9 @@ use crate::util::copy::*;
 /// [`header_metadata`]:    ../util/metadata/header_metadata/index.html
 /// [`GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS`]: ../util/metadata/side_metadata/constant.GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS.html
 /// [`LOCAL_SIDE_METADATA_VM_BASE_ADDRESS`]:  ../util/metadata/side_metadata/constant.LOCAL_SIDE_METADATA_VM_BASE_ADDRESS.html
-pub trait ObjectModel<VM: VMBinding> {
+pub trait ObjectModel {
+    type VM: VMBinding;
+
     // Per-object Metadata Spec definitions go here
     //
     // Note a number of Global and PolicySpecific side metadata specifications are already reserved by mmtk-core.
@@ -191,7 +193,7 @@ pub trait ObjectModel<VM: VMBinding> {
     fn copy(
         from: ObjectReference,
         semantics: CopySemantics,
-        copy_context: &mut GCWorkerCopyContext<VM>,
+        copy_context: &mut GCWorkerCopyContext<Self::VM>,
     ) -> ObjectReference;
 
     /// Copy an object. This is required

--- a/src/vm/reference_glue.rs
+++ b/src/vm/reference_glue.rs
@@ -13,7 +13,9 @@ use crate::vm::VMBinding;
 ///   from MMTk, the specified type is used for the finalizable objects. For most languages,
 ///   they can just use `ObjectReference` for the finalizable type, meaning that they are registering
 ///   and popping a normal object reference as finalizable objects.
-pub trait ReferenceGlue<VM: VMBinding> {
+pub trait ReferenceGlue {
+    type VM: VMBinding;
+
     /// The type of finalizable objects. This type is used when the binding registers and pops finalizable objects.
     type FinalizableType: Finalizable;
 

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -71,7 +71,9 @@ pub trait RootsWorkFactory: Clone + Send + 'static {
 }
 
 /// VM-specific methods for scanning roots/objects.
-pub trait Scanning<VM: VMBinding> {
+pub trait Scanning {
+    type VM: VMBinding;
+
     /// Scan stack roots after all mutators are paused.
     const SCAN_MUTATORS_IN_SAFEPOINT: bool = true;
 
@@ -162,7 +164,7 @@ pub trait Scanning<VM: VMBinding> {
     /// * `factory`: The VM uses it to create work packets for scanning roots.
     fn scan_thread_root(
         tls: VMWorkerThread,
-        mutator: &'static mut Mutator<VM>,
+        mutator: &'static mut Mutator<Self::VM>,
         factory: impl RootsWorkFactory,
     );
 

--- a/vmbindings/dummyvm/src/active_plan.rs
+++ b/vmbindings/dummyvm/src/active_plan.rs
@@ -5,9 +5,9 @@ use mmtk::Mutator;
 use crate::DummyVM;
 use crate::SINGLETON;
 
-pub struct VMActivePlan<> {}
+impl ActivePlan for DummyVM {
+    type VM = Self;
 
-impl ActivePlan<DummyVM> for VMActivePlan {
     fn global() -> &'static dyn Plan<VM=DummyVM> {
         SINGLETON.get_plan()
     }

--- a/vmbindings/dummyvm/src/collection.rs
+++ b/vmbindings/dummyvm/src/collection.rs
@@ -5,9 +5,9 @@ use mmtk::vm::GCThreadContext;
 use mmtk::Mutator;
 use mmtk::MutatorContext;
 
-pub struct VMCollection {}
+impl Collection for DummyVM {
+    type VM = Self;
 
-impl Collection<DummyVM> for VMCollection {
     fn stop_all_mutators<F>(_tls: VMWorkerThread, _mutator_visitor: F)
     where
         F: FnMut(&'static mut Mutator<DummyVM>),

--- a/vmbindings/dummyvm/src/lib.rs
+++ b/vmbindings/dummyvm/src/lib.rs
@@ -21,12 +21,6 @@ mod tests;
 pub struct DummyVM;
 
 impl VMBinding for DummyVM {
-    type VMObjectModel = object_model::VMObjectModel;
-    type VMScanning = scanning::VMScanning;
-    type VMCollection = collection::VMCollection;
-    type VMActivePlan = active_plan::VMActivePlan;
-    type VMReferenceGlue = reference_glue::VMReferenceGlue;
-
     /// Allowed maximum alignment as shift by min alignment.
     const MAX_ALIGNMENT_SHIFT: usize = 6_usize - Self::LOG_MIN_ALIGNMENT as usize;
 

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -5,8 +5,6 @@ use mmtk::vm::*;
 use std::sync::atomic::Ordering;
 use crate::DummyVM;
 
-pub struct VMObjectModel {}
-
 // This is intentionally set to a non-zero value to see if it breaks.
 // Change this if you want to test other values.
 #[cfg(target_pointer_width = "64")]
@@ -14,7 +12,9 @@ pub const OBJECT_REF_OFFSET: usize = 6;
 #[cfg(target_pointer_width = "32")]
 pub const OBJECT_REF_OFFSET: usize = 2;
 
-impl ObjectModel<DummyVM> for VMObjectModel {
+impl ObjectModel for DummyVM {
+    type VM = Self;
+
     const GLOBAL_LOG_BIT_SPEC: VMGlobalLogBitSpec = VMGlobalLogBitSpec::in_header(0);
     const LOCAL_FORWARDING_POINTER_SPEC: VMLocalForwardingPointerSpec = VMLocalForwardingPointerSpec::in_header(0);
     const LOCAL_FORWARDING_BITS_SPEC: VMLocalForwardingBitsSpec = VMLocalForwardingBitsSpec::in_header(0);

--- a/vmbindings/dummyvm/src/reference_glue.rs
+++ b/vmbindings/dummyvm/src/reference_glue.rs
@@ -5,7 +5,9 @@ use crate::DummyVM;
 
 pub struct VMReferenceGlue {}
 
-impl ReferenceGlue<DummyVM> for VMReferenceGlue {
+impl ReferenceGlue for DummyVM {
+    type VM = Self;
+
     type FinalizableType = ObjectReference;
 
     fn set_referent(_reference: ObjectReference, _referent: ObjectReference) {

--- a/vmbindings/dummyvm/src/scanning.rs
+++ b/vmbindings/dummyvm/src/scanning.rs
@@ -8,7 +8,9 @@ use mmtk::Mutator;
 
 pub struct VMScanning {}
 
-impl Scanning<DummyVM> for VMScanning {
+impl Scanning for DummyVM {
+    type VM = Self;
+
     fn scan_thread_roots(_tls: VMWorkerThread, _factory: impl RootsWorkFactory) {
         unimplemented!()
     }


### PR DESCRIPTION
A VM binding has many aspects, and we represent them as several different traits:  `ObjectModel`, `Scanning`, `Collection`, `ActivePlan` and `ReferenceGlue`.

Currently, we combine them into one `VMBinding` by making them member types of the `VMBinding` trait, namely:
```rust
trait VMBinding {
    type VMObjectModel: ObjectModel<Self>;
    type VMScanning: Scanning<Self>;
    type VMCollection: Collection<Self>;
    type VMActivePlan: ActivePlan<Self>;
    type VMReferenceGlue: ReferenceGlue<Self>;
    // ...
}
```

This has some drawbacks.

One obvious drawback is that sometimes we have write `<VM as VMBinding>::SomeType::some_function`.  This is ugly, because the Rust complier is sometimes not smart enough to figure out `VM` implements `VMBinding`, and `SomeType` is a member of `VMBinding`.

To solve this problem, we make those traits "trait bounds" of the `VMBinding` trait. Namely:
```rust
pub trait VMBinding:
    ObjectModel<VM = Self>
    + Scanning<VM = Self>
    + Collection<VM = Self>
    + ActivePlan<VM = Self>
    + ReferenceGlue<VM = Self>
{
    // members go here.
}
```

By doing this, A binding instance (such as `OpenJDK`) directly implements `ObjectModel`, `Scanning`, `Collection`, ..., instead of aggregating them into member types.  So instead of `<VM as VMBinding>::Foo::bar`, we only need to write `VM::bar`.

-   Instead of `VM::VMObjectModel::copy`, we write `VM::copy`
-   Instead of `<VM as VMBinding>::VMCollection::resume_mutators`, we write `VM::resume_mutators`
-   Instead of `<E::VM as VMBinding>::VMScanning::scan_thread_roots`, we write `E::VM::scan_thread_roots`
-   Instead of `<<E as ProcessEdgesWork>::VM as VMBinding>::VMCollection::schedule_finalization`, we write `E::VM::schedule_finalization`.