### PR TITLE
Remove print!/println! code from mmtk-core

### DIFF
--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -80,7 +80,7 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
     }
 
     fn handle_user_collection_request(&self, _tls: VMMutatorThread, _force: bool) {
-        println!("Warning: User attempted a collection request, but it is not supported in NoGC. The request is ignored.");
+        warn!("User attempted a collection request, but it is not supported in NoGC. The request is ignored.");
     }
 }
 

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -623,66 +623,64 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
     }
 }
 
-impl<VM: VMBinding> dyn Space<VM> {
-    /// Print the VM map for a space.
-    /// Space needs to be object-safe, so it cannot have methods that use extra generic type paramters. So this method is placed outside the Space trait.
-    /// This method can be invoked on a &dyn Space (space.as_space() will return &dyn Space).
-    #[allow(unused)]
-    pub(crate) fn print_vm_map(
-        &self,
-        out: &mut impl std::fmt::Write,
-    ) -> Result<(), std::fmt::Error> {
-        let common = self.common();
-        write!(out, "{} ", common.name)?;
-        if common.immortal {
-            write!(out, "I")?;
-        } else {
-            write!(out, " ")?;
-        }
-        if common.movable {
-            write!(out, " ")?;
-        } else {
-            write!(out, "N")?;
-        }
+/// Print the VM map for a space.
+/// Space needs to be object-safe, so it cannot have methods that use extra generic type paramters. So this method is placed outside the Space trait.
+/// This method can be invoked on a &dyn Space (space.as_space() will return &dyn Space).
+#[allow(unused)]
+pub(crate) fn print_vm_map<VM: VMBinding>(
+    space: &dyn Space<VM>,
+    out: &mut impl std::fmt::Write,
+) -> Result<(), std::fmt::Error> {
+    let common = space.common();
+    write!(out, "{} ", common.name)?;
+    if common.immortal {
+        write!(out, "I")?;
+    } else {
         write!(out, " ")?;
-        if common.contiguous {
+    }
+    if common.movable {
+        write!(out, " ")?;
+    } else {
+        write!(out, "N")?;
+    }
+    write!(out, " ")?;
+    if common.contiguous {
+        write!(
+            out,
+            "{}->{}",
+            common.start,
+            common.start + common.extent - 1
+        )?;
+        match common.vmrequest {
+            VMRequest::Extent { extent, .. } => {
+                write!(out, " E {}", extent)?;
+            }
+            VMRequest::Fraction { frac, .. } => {
+                write!(out, " F {}", frac)?;
+            }
+            _ => {}
+        }
+    } else {
+        let mut a = space
+            .get_page_resource()
+            .common()
+            .get_head_discontiguous_region();
+        while !a.is_zero() {
             write!(
                 out,
                 "{}->{}",
-                common.start,
-                common.start + common.extent - 1
+                a,
+                a + space.common().vm_map().get_contiguous_region_size(a) - 1
             )?;
-            match common.vmrequest {
-                VMRequest::Extent { extent, .. } => {
-                    write!(out, " E {}", extent)?;
-                }
-                VMRequest::Fraction { frac, .. } => {
-                    write!(out, " F {}", frac)?;
-                }
-                _ => {}
-            }
-        } else {
-            let mut a = self
-                .get_page_resource()
-                .common()
-                .get_head_discontiguous_region();
-            while !a.is_zero() {
-                write!(
-                    out,
-                    "{}->{}",
-                    a,
-                    a + self.common().vm_map().get_contiguous_region_size(a) - 1
-                )?;
-                a = self.common().vm_map().get_next_contiguous_region(a);
-                if !a.is_zero() {
-                    write!(out, " ")?;
-                }
+            a = space.common().vm_map().get_next_contiguous_region(a);
+            if !a.is_zero() {
+                write!(out, " ")?;
             }
         }
-        writeln!(out)?;
-
-        Ok(())
     }
+    writeln!(out)?;
+
+    Ok(())
 }
 
 impl_downcast!(Space<VM> where VM: VMBinding);

--- a/src/util/sanity/memory_scan.rs
+++ b/src/util/sanity/memory_scan.rs
@@ -1,6 +1,9 @@
 use crate::util::Address;
 use crate::util::ObjectReference;
 
+// This is legacy code, and no one is using this. Using gdb can achieve the same thing for debugging.
+// The JikesRVM binding still declares this method and we need to remove it from JikesRVM.
+#[deprecated]
 pub fn scan_region() {
     loop {
         let mut buf = String::new();

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -162,7 +162,7 @@ impl Stats {
             }
             self.shared.increment_phase();
         } else if !self.exceeded_phase_limit.load(Ordering::SeqCst) {
-            println!("Warning: number of GC phases exceeds MAX_PHASES");
+            eprintln!("Warning: number of GC phases exceeds MAX_PHASES");
             self.exceeded_phase_limit.store(true, Ordering::SeqCst);
         }
     }
@@ -178,7 +178,7 @@ impl Stats {
             }
             self.shared.increment_phase();
         } else if !self.exceeded_phase_limit.load(Ordering::SeqCst) {
-            println!("Warning: number of GC phases exceeds MAX_PHASES");
+            eprintln!("Warning: number of GC phases exceeds MAX_PHASES");
             self.exceeded_phase_limit.store(true, Ordering::SeqCst);
         }
     }
@@ -232,9 +232,7 @@ impl Stats {
     pub fn start_all(&self) {
         let counters = self.counters.lock().unwrap();
         if self.get_gathering_stats() {
-            println!("Error: calling Stats.startAll() while stats running");
-            println!("       verbosity > 0 and the harness mechanism may be conflicting");
-            debug_assert!(false);
+            panic!("calling Stats.startAll() while stats running");
         }
         self.shared.set_gathering_stats(true);
 


### PR DESCRIPTION
This pull request removes `print!` and `println!` from our code base. `print!/println!` are replaced with logging lines, or `eprint!/eprintln!` if we really need to report errors. This closes https://github.com/mmtk/mmtk-core/issues/654.