### PR TITLE
Generate two API docs (full/public API). Add public API check.

### DIFF
--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -6,8 +6,8 @@
 # Check cargo doc
 # We generate two versions of docs: one with only public items for binding developers for our API, and
 # the other with both public and private items for MMTk developers (GC implementers).
-cargo doc --features $non_exclusive_features --no-deps --document-private-items --target-dir target/mmtk-internal
-cargo doc --features $non_exclusive_features --no-deps --target-dir target/mmtk-external
+cargo doc --features $non_exclusive_features --no-deps --target-dir target/mmtk-public
+cargo doc --features $non_exclusive_features --no-deps --document-private-items --target-dir target/mmtk-full
 
 # Check tutorial code
 tutorial_code_dir=$project_root/docs/tutorial/code/mygc_semispace

--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -1,11 +1,13 @@
 . $(dirname "$0")/ci-common.sh
 
+# rustdoc.yml will copy the docs from respective directories to a directory for publishing.
+# If the output path is changed in this script, we need to update rustdoc.yml as well.
+
 # Check cargo doc
-# We generate docs including private items so it would be easier for MMTk developers (GC implementers). However,
-# this could be confusing to MMTk users (binding implementers), as they may find items in the doc which
-# are not visible to a binding. If we exclude private items, the doc would be easier for the users, but would hide
-# implementation details for developers.
-cargo doc --features $non_exclusive_features --no-deps --document-private-items
+# We generate two versions of docs: one with only public items for binding developers for our API, and
+# the other with both public and private items for MMTk developers (GC implementers).
+cargo doc --features $non_exclusive_features --no-deps --document-private-items --target-dir target/mmtk-internal
+cargo doc --features $non_exclusive_features --no-deps --target-dir target/mmtk-external
 
 # Check tutorial code
 tutorial_code_dir=$project_root/docs/tutorial/code/mygc_semispace

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -1,0 +1,25 @@
+name: Public API Check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  deny-public-api-changes:
+    runs-on: ubuntu-latest
+    steps:
+      # Full git history needed
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Install nightly (stable is already installed)
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+
+      # Install and run cargo public-api and deny any API diff
+      - run: cargo install cargo-public-api
+      - run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF} --deny=all

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - master
 
+# The follow workflow is from https://github.com/Enselic/cargo-public-api/blob/main/docs/CI-EXAMPLES.md
+
+# The workflow may fail if we change the public API in a pull request.
+# We allow fail on this action. But we should manually check if the changes are reasonable when we see a failed action.
+# It would be good if the workflow returns a neutral status when we find API changes. But it is currently not
+# possible with Github actions.
 jobs:
-  deny-public-api-changes:
+  check-public-api-changes:
     runs-on: ubuntu-latest
     steps:
       # Full git history needed

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -26,15 +26,15 @@ jobs:
       - name: Copy docs
         # docs/ is the root for github pages.
         # The generated docs are put to docs/ (i.e. root for github pages)
-        # mmtk public API: docs/public-api
-        # mmtk full API: docs/full-api
+        # mmtk public doc: docs/public-doc
+        # mmtk full doc: docs/full-doc
         # porting guide: docs/portingguide
         # tutorial: docs/tutorial
         run: |
           mkdir -p to_publish/docs
           cp -r target/mmtk-full/doc/* to_publish/docs/
-          mv to_publish/docs/mmtk to_publish/docs/full-api
-          cp -r target/mmtk-public/doc/mmtk to_publish/docs/public-api
+          mv to_publish/docs/mmtk to_publish/docs/full-doc
+          cp -r target/mmtk-public/doc/mmtk to_publish/docs/public-doc
           cp -r docs/portingguide/book to_publish/docs/portingguide
           cp -r docs/tutorial/book to_publish/docs/tutorial
       - name: Deploy to Github Page

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,7 +2,10 @@ name: Generate doc
 
 # Triggerred when a new commit is pushed to master
 on:
-  push:
+  # push:
+  #   branches:
+  #     - master
+  pull_request:
     branches:
       - master
 
@@ -24,9 +27,17 @@ jobs:
       - name: Generate rustdoc
         run: ./.github/scripts/ci-doc.sh
       - name: Copy docs
+        # docs/ is the root for github pages.
+        # The generated docs are put to docs/ (i.e. root for github pages)
+        # mmtk external API: /external
+        # mmtk internal API: /internal
+        # porting guide: /portingguide
+        # tutorial: /tutorial
         run: |
           mkdir -p to_publish/docs
-          cp -r target/doc/* to_publish/docs/
+          cp -r target/mmtk-internal/doc/* to_publish/docs/
+          mv to_publish/docs/mmtk to_publish/docs/internal
+          cp -r target/mmtk-external/doc/mmtk to_publish/docs/external
           cp -r docs/portingguide/book to_publish/docs/portingguide
           cp -r docs/tutorial/book to_publish/docs/tutorial
       - name: Deploy to Github Page

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -29,15 +29,15 @@ jobs:
       - name: Copy docs
         # docs/ is the root for github pages.
         # The generated docs are put to docs/ (i.e. root for github pages)
-        # mmtk external API: /external
-        # mmtk internal API: /internal
-        # porting guide: /portingguide
-        # tutorial: /tutorial
+        # mmtk public API: docs/public-api
+        # mmtk full API: docs/full-api
+        # porting guide: docs/portingguide
+        # tutorial: docs/tutorial
         run: |
           mkdir -p to_publish/docs
-          cp -r target/mmtk-internal/doc/* to_publish/docs/
-          mv to_publish/docs/mmtk to_publish/docs/internal
-          cp -r target/mmtk-external/doc/mmtk to_publish/docs/external
+          cp -r target/mmtk-full/doc/* to_publish/docs/
+          mv to_publish/docs/mmtk to_publish/docs/full-api
+          cp -r target/mmtk-public/doc/mmtk to_publish/docs/public-api
           cp -r docs/portingguide/book to_publish/docs/portingguide
           cp -r docs/tutorial/book to_publish/docs/tutorial
       - name: Deploy to Github Page

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,10 +2,7 @@ name: Generate doc
 
 # Triggerred when a new commit is pushed to master
 on:
-  # push:
-  #   branches:
-  #     - master
-  pull_request:
+  push:
     branches:
       - master
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ The artefact produced produced by the build process can be found under
 MMTk does not run standalone. You would need to integrate MMTk with a language implementation.
 You can either try out one of the VM bindings we have been working on, or implement your own binding in your VM for MMTk.
 You can also implement your own GC algorithm in MMTk, and run it with supported VMs.
-You can find an up-to-date API document for mmtk-core here: https://www.mmtk.io/mmtk-core/mmtk.
+You can find an up-to-date API document for mmtk-core here:
+* If you are trying to port MMTk to your language, check our public API: https://www.mmtk.io/mmtk-core/external
+* If you are trying to develop in MMTk (e.g. a new GC algorithm), check our internal API: https://www.mmtk.io/mmtk-core/internal
 
 ### Try out our current bindings
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ MMTk does not run standalone. You would need to integrate MMTk with a language i
 You can either try out one of the VM bindings we have been working on, or implement your own binding in your VM for MMTk.
 You can also implement your own GC algorithm in MMTk, and run it with supported VMs.
 You can find an up-to-date API document for mmtk-core here:
-* If you are trying to port MMTk to your language, check our public API: https://www.mmtk.io/mmtk-core/external
-* If you are trying to develop in MMTk (e.g. a new GC algorithm), check our internal API: https://www.mmtk.io/mmtk-core/internal
+* If you are trying to port MMTk to your language, check our public API: https://www.mmtk.io/mmtk-core/public-api
+* If you are trying to develop in MMTk (e.g. a new GC algorithm), check our full API: https://www.mmtk.io/mmtk-core/full-api
 
 ### Try out our current bindings
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The artefact produced produced by the build process can be found under
 MMTk does not run standalone. You would need to integrate MMTk with a language implementation.
 You can either try out one of the VM bindings we have been working on, or implement your own binding in your VM for MMTk.
 You can also implement your own GC algorithm in MMTk, and run it with supported VMs.
-You can find an up-to-date API document for mmtk-core here:
-* If you are trying to port MMTk to your language, check our public API: https://www.mmtk.io/mmtk-core/public-api
-* If you are trying to develop in MMTk (e.g. a new GC algorithm), check our full API: https://www.mmtk.io/mmtk-core/full-api
+You can find up-to-date API documentation for mmtk-core here:
+* If you are trying to port MMTk to your language, check our public documentation: https://www.mmtk.io/mmtk-core/public-doc
+* If you are trying to develop in MMTk (e.g. a new GC algorithm), check our full documentation: https://www.mmtk.io/mmtk-core/full-doc
 
 ### Try out our current bindings
 


### PR DESCRIPTION
With this pull request, we will generate two API docs (one for full MMTk API including private items `--document-private-items`, and one for public API). They will be hosted in:
* https://www.mmtk.io/mmtk-core/public-doc/
* https://www.mmtk.io/mmtk-core/full-doc/

This pull request also adds a public API check for pull requests. If a pull request changes the public API, the action will fail. Ideally the action returns a neutral status. However, that is not supported by Github action yet.