### PR TITLE
Fix broken links in docs

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -460,7 +460,7 @@ pub fn is_live_object(object: ObjectReference) -> bool {
 /// word is really a reference.
 ///
 /// Note: This function has special behaviors if the VM space (enabled by the `vm_space` feature)
-/// is present.  See [`crate::plan::global::BasePlan::vm_space`].
+/// is present.  See `crate::plan::global::BasePlan::vm_space`.
 ///
 /// Argument:
 /// * `addr`: An arbitrary address.
@@ -493,7 +493,7 @@ pub fn is_mmtk_object(addr: Address) -> bool {
 /// function can distinguish between MMTk-allocated objects and other objects.
 ///
 /// Note: This function has special behaviors if the VM space (enabled by the `vm_space` feature)
-/// is present.  See [`crate::plan::global::BasePlan::vm_space`].
+/// is present.  See `crate::plan::global::BasePlan::vm_space`.
 ///
 /// Arguments:
 /// * `object`: The object reference to query.

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -262,7 +262,8 @@ impl<VM: VMBinding> Gen<VM> {
     /// Check a plan to see if the next GC should be a full heap GC.
     ///
     /// Note that this function should be called after all spaces have been released. This is
-    /// required as we may get incorrect values since this function uses [`get_available_pages`]
+    /// required as we may get incorrect values since this function uses
+    /// [`get_available_pages`](crate::plan::Plan::get_available_pages)
     /// whose value depends on which spaces have been released.
     pub fn should_next_gc_be_full_heap(plan: &dyn Plan<VM = VM>) -> bool {
         plan.get_available_pages()

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -30,7 +30,7 @@ use mmtk_macros::PlanTraceObject;
 /// Generational immix. This implements the functionality of a two-generation copying
 /// collector where the higher generation is an immix space.
 /// See the PLDI'08 paper by Blackburn and McKinley for a description
-/// of the algorithm: http://doi.acm.org/10.1145/1375581.137558.
+/// of the algorithm: <http://doi.acm.org/10.1145/1375581.1375586>.
 #[derive(PlanTraceObject)]
 pub struct GenImmix<VM: VMBinding> {
     /// Generational plan, which includes a nursery space and operations related with nursery.

--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -89,7 +89,7 @@ pub trait ActivePlan<VM: VMBinding> {
     /// * `queue`: The object queue. If an object is encountered for the first time in this GC, we expect the implementation to call `queue.enqueue()`
     ///            for the object. If the object is moved during the tracing, the new object reference (after copying) should be enqueued instead.
     /// * `object`: The object to trace.
-    /// * `worker`: The GC worker that is doing this tracing. This is used to copy object (see [vm::ObjectModel::copy])
+    /// * `worker`: The GC worker that is doing this tracing. This is used to copy object (see [`crate::vm::ObjectModel::copy`])
     fn vm_trace_object<Q: ObjectQueue>(
         _queue: &mut Q,
         object: ObjectReference,


### PR DESCRIPTION
Some hyperlinks in doc comments are making the Public API Check in CI fail.

-   `vm_space` is only enabled in a feature, and the module `crate::plan::global` is private.  I changed it to non-link text.
-   Use fully-qualified names for other broken links.
-   Fixed the URL of the DOI link of GenImmix.