### PR TITLE
Fix API check for PRs from a forked repo

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -18,39 +18,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # # Install nightly
-      # # The nightly version needs to match the cargo-public-api version.
-      # # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: nightly-2022-09-06
-      #     profile: minimal
-
-      # # Install a specific version of cargo-public-api
-      # - name: Install cargo-public-api
-      #   run: cargo install cargo-public-api --version 0.17.0
-      # # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
-      # # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
-      # # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
-      # # So we get API dumped to text files, and diff the text files.
-      # - name: Dump public API for PR
-      #   run: |
-      #     cargo +nightly-2022-09-06 public-api > pr-api.txt
-      # - name: Dump public API for trunk
-      #   run: |
-      #     git checkout ${GITHUB_BASE_REF}
-      #     cargo +nightly-2022-09-06 public-api > trunk-api.txt
-      # - name: Save dumped API files as artifacts
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: public-api
-      #     path: |
-      #       trunk-api.txt
-      #       pr-api.txt
-      # # If there is any difference, this will fail
-      # - name: API diff
-      #   run: diff trunk-api.txt pr-api.txt
-
       # Install nightly
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -18,35 +18,47 @@ jobs:
         with:
           fetch-depth: 0
 
+      # # Install nightly
+      # # The nightly version needs to match the cargo-public-api version.
+      # # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
+      # - uses: actions-rs/toolchain@v1
+      #   with:
+      #     toolchain: nightly-2022-09-06
+      #     profile: minimal
+
+      # # Install a specific version of cargo-public-api
+      # - name: Install cargo-public-api
+      #   run: cargo install cargo-public-api --version 0.17.0
+      # # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
+      # # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
+      # # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
+      # # So we get API dumped to text files, and diff the text files.
+      # - name: Dump public API for PR
+      #   run: |
+      #     cargo +nightly-2022-09-06 public-api > pr-api.txt
+      # - name: Dump public API for trunk
+      #   run: |
+      #     git checkout ${GITHUB_BASE_REF}
+      #     cargo +nightly-2022-09-06 public-api > trunk-api.txt
+      # - name: Save dumped API files as artifacts
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: public-api
+      #     path: |
+      #       trunk-api.txt
+      #       pr-api.txt
+      # # If there is any difference, this will fail
+      # - name: API diff
+      #   run: diff trunk-api.txt pr-api.txt
+
       # Install nightly
-      # The nightly version needs to match the cargo-public-api version.
-      # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-06
+          toolchain: nightly
           profile: minimal
 
-      # Install a specific version of cargo-public-api
+      # Install cargo-public-api
       - name: Install cargo-public-api
-        run: cargo install cargo-public-api --version 0.17.0
-      # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
-      # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
-      # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
-      # So we get API dumped to text files, and diff the text files.
-      - name: Dump public API for PR
-        run: |
-          cargo +nightly-2022-09-06 public-api > pr-api.txt
-      - name: Dump public API for trunk
-        run: |
-          git checkout ${GITHUB_BASE_REF}
-          cargo +nightly-2022-09-06 public-api > trunk-api.txt
-      - name: Save dumped API files as artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: public-api
-          path: |
-            trunk-api.txt
-            pr-api.txt
-      # If there is any difference, this will fail
-      - name: API diff
-        run: diff trunk-api.txt pr-api.txt
+        run: cargo install cargo-public-api
+      - name: API Diff
+        run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} HEAD --deny=all

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -28,4 +28,8 @@ jobs:
 
       # Install and run cargo public-api and deny any API diff
       - run: cargo install cargo-public-api
-      - run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF} --deny=all
+      - run: cargo public-api > pr-api.txt
+      - run: |
+          git checkout ${GITHUB_BASE_REF}
+          cargo public-api > trunk-api.txt
+      - run: diff trunk-api.txt pr-api.txt

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -27,16 +27,26 @@ jobs:
           profile: minimal
 
       # Install a specific version of cargo-public-api
-      - run: cargo install cargo-public-api --version 0.17.0
+      - name: Install cargo-public-api
+        run: cargo install cargo-public-api --version 0.17.0
       # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
-      # as cargo-public-api cannot check out ${GITHUB_HEAD_REF} if the PR is from a fork.
-      # This is how Github checkout action deals with pull requests from a fork: it checks out the repo from the main repo (not the fork repo), so
-      # the branches in the forked repo are not fetched. Then the action gets a merge commit for the PR.
+      # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
+      # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
       # So we get API dumped to text files, and diff the text files.
-      - run: |
+      - name: Dump public API for PR
+        run: |
           cargo +nightly-2022-09-06 public-api > pr-api.txt
-      - run: |
+      - name: Dump public API for trunk
+        run: |
           git checkout ${GITHUB_BASE_REF}
           cargo +nightly-2022-09-06 public-api > trunk-api.txt
+      - name: Save dumped API files as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: public-api
+          path: |
+            trunk-api.txt
+            pr-api.txt
       # If there is any difference, this will fail
-      - run: diff trunk-api.txt pr-api.txt
+      - name: API diff
+        run: diff trunk-api.txt pr-api.txt

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -18,47 +18,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      # # Install nightly
-      # # The nightly version needs to match the cargo-public-api version.
-      # # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: nightly-2022-09-06
-      #     profile: minimal
-
-      # # Install a specific version of cargo-public-api
-      # - name: Install cargo-public-api
-      #   run: cargo install cargo-public-api --version 0.17.0
-      # # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
-      # # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
-      # # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
-      # # So we get API dumped to text files, and diff the text files.
-      # - name: Dump public API for PR
-      #   run: |
-      #     cargo +nightly-2022-09-06 public-api > pr-api.txt
-      # - name: Dump public API for trunk
-      #   run: |
-      #     git checkout ${GITHUB_BASE_REF}
-      #     cargo +nightly-2022-09-06 public-api > trunk-api.txt
-      # - name: Save dumped API files as artifacts
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: public-api
-      #     path: |
-      #       trunk-api.txt
-      #       pr-api.txt
-      # # If there is any difference, this will fail
-      # - name: API diff
-      #   run: diff trunk-api.txt pr-api.txt
-
       # Install nightly
+      # The nightly version needs to match the cargo-public-api version.
+      # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-09-06
           profile: minimal
 
-      # Install cargo-public-api
+      # Install a specific version of cargo-public-api
       - name: Install cargo-public-api
-        run: cargo install cargo-public-api
-      - name: API Diff
-        run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} HEAD --deny=all
+        run: cargo install cargo-public-api --version 0.17.0
+      # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
+      # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
+      # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
+      # So we get API dumped to text files, and diff the text files.
+      - name: Dump public API for PR
+        run: |
+          cargo +nightly-2022-09-06 public-api > pr-api.txt
+      - name: Dump public API for trunk
+        run: |
+          git checkout ${GITHUB_BASE_REF}
+          cargo +nightly-2022-09-06 public-api > trunk-api.txt
+      - name: Save dumped API files as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: public-api
+          path: |
+            trunk-api.txt
+            pr-api.txt
+      # If there is any difference, this will fail
+      - name: API diff
+        run: diff trunk-api.txt pr-api.txt

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -18,35 +18,47 @@ jobs:
         with:
           fetch-depth: 0
 
+      # # Install nightly
+      # # The nightly version needs to match the cargo-public-api version.
+      # # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
+      # - uses: actions-rs/toolchain@v1
+      #   with:
+      #     toolchain: nightly-2022-09-06
+      #     profile: minimal
+
+      # # Install a specific version of cargo-public-api
+      # - name: Install cargo-public-api
+      #   run: cargo install cargo-public-api --version 0.17.0
+      # # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
+      # # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
+      # # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
+      # # So we get API dumped to text files, and diff the text files.
+      # - name: Dump public API for PR
+      #   run: |
+      #     cargo +nightly-2022-09-06 public-api > pr-api.txt
+      # - name: Dump public API for trunk
+      #   run: |
+      #     git checkout ${GITHUB_BASE_REF}
+      #     cargo +nightly-2022-09-06 public-api > trunk-api.txt
+      # - name: Save dumped API files as artifacts
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: public-api
+      #     path: |
+      #       trunk-api.txt
+      #       pr-api.txt
+      # # If there is any difference, this will fail
+      # - name: API diff
+      #   run: diff trunk-api.txt pr-api.txt
+
       # Install nightly
-      # The nightly version needs to match the cargo-public-api version.
-      # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-06
+          toolchain: nightly
           profile: minimal
 
-      # Install a specific version of cargo-public-api
+      # Install cargo-public-api
       - name: Install cargo-public-api
-        run: cargo install cargo-public-api --version 0.17.0
-      # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
-      # as the Github checkout action does not actually fetch the branch from the forked repo, and cargo-public-api cannot
-      # check out ${GITHUB_HEAD_REF} if the PR is from a fork.
-      # So we get API dumped to text files, and diff the text files.
-      - name: Dump public API for PR
-        run: |
-          cargo +nightly-2022-09-06 public-api > pr-api.txt
-      - name: Dump public API for trunk
-        run: |
-          git checkout ${GITHUB_BASE_REF}
-          cargo +nightly-2022-09-06 public-api > trunk-api.txt
-      - name: Save dumped API files as artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: public-api
-          path: |
-            trunk-api.txt
-            pr-api.txt
-      # If there is any difference, this will fail
-      - name: API diff
-        run: diff trunk-api.txt pr-api.txt
+        run: cargo install cargo-public-api
+      - name: API Diff
+        run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${{ github.event.pull_request.head.sha }} --deny=all

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
 
-# The follow workflow is from https://github.com/Enselic/cargo-public-api/blob/main/docs/CI-EXAMPLES.md
-
 # The workflow may fail if we change the public API in a pull request.
 # We allow fail on this action. But we should manually check if the changes are reasonable when we see a failed action.
 # It would be good if the workflow returns a neutral status when we find API changes. But it is currently not
@@ -20,16 +18,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install nightly (stable is already installed)
+      # Install nightly
+      # The nightly version needs to match the cargo-public-api version.
+      # Check here: https://github.com/Enselic/cargo-public-api#compatibility-matrix
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-09-06
           profile: minimal
 
-      # Install and run cargo public-api and deny any API diff
-      - run: cargo install cargo-public-api
-      - run: cargo public-api > pr-api.txt
+      # Install a specific version of cargo-public-api
+      - run: cargo install cargo-public-api --version 0.17.0
+      # We cannot compare two branches using 'cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF}',
+      # as cargo-public-api cannot check out ${GITHUB_HEAD_REF} if the PR is from a fork.
+      # This is how Github checkout action deals with pull requests from a fork: it checks out the repo from the main repo (not the fork repo), so
+      # the branches in the forked repo are not fetched. Then the action gets a merge commit for the PR.
+      # So we get API dumped to text files, and diff the text files.
+      - run: |
+          cargo +nightly-2022-09-06 public-api > pr-api.txt
       - run: |
           git checkout ${GITHUB_BASE_REF}
-          cargo public-api > trunk-api.txt
+          cargo +nightly-2022-09-06 public-api > trunk-api.txt
+      # If there is any difference, this will fail
       - run: diff trunk-api.txt pr-api.txt

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -161,4 +161,8 @@ impl<VM: VMBinding> MMTK<VM> {
     pub fn get_options(&self) -> &Options {
         &self.options
     }
+
+    pub fn test(&self) {
+        panic!("test only")
+    }
 }

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -161,8 +161,4 @@ impl<VM: VMBinding> MMTK<VM> {
     pub fn get_options(&self) -> &Options {
         &self.options
     }
-
-    pub fn test(&self) {
-        panic!("This is only for test")
-    }
 }

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -161,4 +161,8 @@ impl<VM: VMBinding> MMTK<VM> {
     pub fn get_options(&self) -> &Options {
         &self.options
     }
+
+    pub fn test(&self) {
+        panic!("This is only for test")
+    }
 }

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -161,8 +161,4 @@ impl<VM: VMBinding> MMTK<VM> {
     pub fn get_options(&self) -> &Options {
         &self.options
     }
-
-    pub fn test(&self) {
-        panic!("test only")
-    }
 }


### PR DESCRIPTION
This PR fixes the issue that the API check workflow will fail when a pull request is submitted from a forked repo.