### PR TITLE
Remove architecture assumptions in MAX_ALIGNMENT_SHIFT

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -55,10 +55,6 @@ where
     const LOG_MIN_ALIGNMENT: usize = LOG_BYTES_IN_INT as usize;
     /// Allowed minimal alignment in bytes.
     const MIN_ALIGNMENT: usize = 1 << Self::LOG_MIN_ALIGNMENT;
-    #[cfg(target_arch = "x86")]
-    /// Allowed maximum alignment as shift by min alignment.    
-    const MAX_ALIGNMENT_SHIFT: usize = 1 + LOG_BYTES_IN_LONG as usize - LOG_BYTES_IN_INT as usize;
-    #[cfg(target_arch = "x86_64")]
     /// Allowed maximum alignment as shift by min alignment.    
     const MAX_ALIGNMENT_SHIFT: usize = LOG_BYTES_IN_LONG as usize - LOG_BYTES_IN_INT as usize;
 


### PR DESCRIPTION
This was originally ported from Java MMTk

https://github.com/mmtk/mmtk-core/blob/06cb0d16fee60eb773d9be780c5fac47df0275ff/src/util/alloc/allocator.rs#L12

However, the context of the code in JikesRVM is that the max alignment is larger on Intel (as oppose to PowerPC).

https://github.com/JikesRVM/JikesRVM/blob/5072f19761115d987b6ee162f49a03522d36c697/MMTk/ext/vm/jikesrvm/org/jikesrvm/mm/mmtk/Memory.java#L104-L108

Regardless, this doesn't make sense anymore in mmtk-core. I removed all the conditional compilation because
1. `x86` is only used by JikesRVM, and I will override the value for JikesRVM in [a separate PR](https://github.com/mmtk/mmtk-jikesrvm/pull/124)
2. The default value remains unchanged for all other bindings using x86_64.