### PR TITLE
Fix stale documentation about coordinator worker ordinal

### DIFF
--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -42,8 +42,8 @@ impl<VM: VMBinding> GCWorkerShared<VM> {
 pub struct GCWorker<VM: VMBinding> {
     /// The VM-specific thread-local state of the GC thread.
     pub tls: VMWorkerThread,
-    /// The ordinal of the worker, numbered from 0 to the number of workers minus one.
-    /// 0 if it is the embedded worker of the GC controller thread.
+    /// The ordinal of the worker, numbered from 0 to the number of workers minus one. The ordinal
+    /// is usize::MAX if it is the embedded worker of the GC controller thread.
     pub ordinal: usize,
     /// The reference to the scheduler.
     scheduler: Arc<GCWorkScheduler<VM>>,


### PR DESCRIPTION
See https://github.com/mmtk/mmtk-core/blob/f82848847a6392537fec6b914d7ad95fbf28b0a2/src/scheduler/scheduler.rs#L135