### PR TITLE
Add nonmoving allocation semantic

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -94,7 +94,13 @@ pub fn bind_mutator<VM: VMBinding>(
     mmtk: &'static MMTK<VM>,
     tls: VMMutatorThread,
 ) -> Box<Mutator<VM>> {
-    crate::plan::create_mutator(tls, mmtk)
+    let mutator = crate::plan::create_mutator(tls, mmtk);
+
+    const LOG_ALLOCATOR_MAPPING: bool = false;
+    if LOG_ALLOCATOR_MAPPING {
+        info!("{:?}", mutator.config);
+    }
+    mutator
 }
 
 /// Reclaim a mutator that is no longer needed.

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -1076,7 +1076,7 @@ pub enum AllocationSemantics {
     /// The actual semantic of the default will depend on the GC plan in use.
     Default = 0,
     /// Immortal objects will not be reclaimed. MMTk still traces immortal objects, but will not
-    /// reclaim the objects even through they are dead.
+    /// reclaim the objects even if they are dead.
     Immortal = 1,
     /// Large objects. It is usually desirable to allocate large objects specially. Large objects
     /// are allocated with page granularity and will not be moved.
@@ -1093,6 +1093,6 @@ pub enum AllocationSemantics {
     ReadOnly = 4,
     /// Los + Code.
     LargeCode = 5,
-    /// Non moving objects will not moved by GC.
+    /// Non moving objects will not be moved by GC.
     NonMoving = 6,
 }

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -889,6 +889,9 @@ pub struct CommonPlan<VM: VMBinding> {
     pub immortal: ImmortalSpace<VM>,
     #[trace]
     pub los: LargeObjectSpace<VM>,
+    // TODO: We should use a marksweep space for nonmoving.
+    #[trace]
+    pub nonmoving: ImmortalSpace<VM>,
     #[fallback_trace]
     pub base: BasePlan<VM>,
 }
@@ -924,6 +927,16 @@ impl<VM: VMBinding> CommonPlan<VM> {
                 constraints,
                 false,
             ),
+            nonmoving: ImmortalSpace::new(
+                "nonmoving",
+                true,
+                VMRequest::discontiguous(),
+                global_side_metadata_specs.clone(),
+                vm_map,
+                mmapper,
+                &mut heap,
+                constraints,
+            ),
             base: BasePlan::new(
                 vm_map,
                 mmapper,
@@ -939,11 +952,15 @@ impl<VM: VMBinding> CommonPlan<VM> {
         let mut ret = self.base.get_spaces();
         ret.push(&self.immortal);
         ret.push(&self.los);
+        ret.push(&self.nonmoving);
         ret
     }
 
     pub fn get_used_pages(&self) -> usize {
-        self.immortal.reserved_pages() + self.los.reserved_pages() + self.base.get_used_pages()
+        self.immortal.reserved_pages()
+            + self.los.reserved_pages()
+            + self.nonmoving.reserved_pages()
+            + self.base.get_used_pages()
     }
 
     pub fn trace_object<Q: ObjectQueue>(
@@ -960,18 +977,24 @@ impl<VM: VMBinding> CommonPlan<VM> {
             trace!("trace_object: object in los");
             return self.los.trace_object(queue, object);
         }
+        if self.nonmoving.in_space(object) {
+            trace!("trace_object: object in nonmoving space");
+            return self.nonmoving.trace_object(queue, object);
+        }
         self.base.trace_object::<Q>(queue, object, worker)
     }
 
     pub fn prepare(&mut self, tls: VMWorkerThread, full_heap: bool) {
         self.immortal.prepare();
         self.los.prepare(full_heap);
+        self.nonmoving.prepare();
         self.base.prepare(tls, full_heap)
     }
 
     pub fn release(&mut self, tls: VMWorkerThread, full_heap: bool) {
         self.immortal.release();
         self.los.release(full_heap);
+        self.nonmoving.release();
         self.base.release(tls, full_heap)
     }
 
@@ -987,6 +1010,10 @@ impl<VM: VMBinding> CommonPlan<VM> {
         &self.los
     }
 
+    pub fn get_nonmoving(&self) -> &ImmortalSpace<VM> {
+        &self.nonmoving
+    }
+
     pub(crate) fn verify_side_metadata_sanity(
         &self,
         side_metadata_sanity_checker: &mut SideMetadataSanity,
@@ -996,6 +1023,8 @@ impl<VM: VMBinding> CommonPlan<VM> {
         self.immortal
             .verify_side_metadata_sanity(side_metadata_sanity_checker);
         self.los
+            .verify_side_metadata_sanity(side_metadata_sanity_checker);
+        self.nonmoving
             .verify_side_metadata_sanity(side_metadata_sanity_checker);
     }
 }
@@ -1043,10 +1072,27 @@ use enum_map::Enum;
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Enum, PartialEq, Eq)]
 pub enum AllocationSemantics {
+    /// The default semantic. This means there is no specific requirement for the allocation.
+    /// The actual semantic of the default will depend on the GC plan in use.
     Default = 0,
+    /// Immortal objects will not be reclaimed. MMTk still traces immortal objects, but will not
+    /// reclaim the objects even through they are dead.
     Immortal = 1,
+    /// Large objects. It is usually desirable to allocate large objects specially. Large objects
+    /// are allocated with page granularity and will not be moved.
+    /// Each plan provides `max_non_los_default_alloc_bytes` (see [`crate::plan::plan_constraints::PlanConstraints`]),
+    /// which defines a threshold for objects that can be allocated with the default semantic. Any object that is larger than the
+    /// threshold must be allocated with the `Los` semantic.
+    /// This semantic may get removed and MMTk will transparently allocate into large object space for large objects.
     Los = 2,
+    /// Code objects have execution permission.
+    /// Note that this is a place holder for now. Currently all the memory MMTk allocates has execution permission.
     Code = 3,
+    /// Read-only objects cannot be mutated once it is initialized.
+    /// Note that this is a place holder for now. It does not provide read only semantic.
     ReadOnly = 4,
+    /// Los + Code.
     LargeCode = 5,
+    /// Non moving objects will not moved by GC.
+    NonMoving = 6,
 }

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -245,6 +245,11 @@ pub(crate) fn create_allocator_mapping(
 
         map[AllocationSemantics::Los] = AllocatorSelector::LargeObject(reserved.n_large_object);
         reserved.n_large_object += 1;
+
+        // TODO: This should be freelist allocator once we use marksweep for nonmoving space.
+        map[AllocationSemantics::NonMoving] =
+            AllocatorSelector::BumpPointer(reserved.n_bump_pointer);
+        reserved.n_bump_pointer += 1;
     }
 
     reserved.validate();
@@ -306,6 +311,12 @@ pub(crate) fn create_space_mapping<VM: VMBinding>(
             plan.common().get_los(),
         ));
         reserved.n_large_object += 1;
+        // TODO: This should be freelist allocator once we use marksweep for nonmoving space.
+        vec.push((
+            AllocatorSelector::BumpPointer(reserved.n_bump_pointer),
+            plan.common().get_nonmoving(),
+        ));
+        reserved.n_bump_pointer += 1;
     }
 
     reserved.validate();

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -31,17 +31,26 @@ pub struct MutatorConfig<VM: VMBinding> {
 
 impl<VM: VMBinding> std::fmt::Debug for MutatorConfig<VM> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("MutatorConfig: ").unwrap();
-        f.write_str("allocator_mapping = ").unwrap();
-        f.debug_set()
-            .entries(self.allocator_mapping.iter())
-            .finish()
-            .unwrap();
-        f.write_str(", space_mapping = ").unwrap();
-        f.debug_set()
-            .entries(self.space_mapping.iter().map(|e| (e.0, e.1.name())))
-            .finish()
-            .unwrap();
+        f.write_str("MutatorConfig:\n")?;
+        f.write_str("Semantics mapping:\n")?;
+        for (semantic, selector) in self.allocator_mapping.iter() {
+            let space_name: &str = match self
+                .space_mapping
+                .iter()
+                .find(|(selector_to_find, _)| selector_to_find == selector)
+            {
+                Some((_, space)) => space.name(),
+                None => "!!!missing space here!!!",
+            };
+            f.write_fmt(format_args!(
+                "- {:?} = {:?} ({:?})\n",
+                semantic, selector, space_name
+            ))?;
+        }
+        f.write_str("Space mapping:\n")?;
+        for (selector, space) in self.space_mapping.iter() {
+            f.write_fmt(format_args!("- {:?} = {:?}\n", selector, space.name()))?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
This PR adds `AllocationSemantics::NonMoving`. This is currently internally implemented with an immortal space. We will change to a mark sweep space once we have a proper mark sweep space with https://github.com/mmtk/mmtk-core/pull/643.