### PR TITLE
Rename alloc bit to valid-object bit (VO-bit)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,11 +78,11 @@ ro_space = []
 # TODO: This is not properly implemented yet. We currently use an immortal space instead, and all our spaces have execution permission at the moment.
 code_space  = []
 
-# metadata
-global_alloc_bit = []
+# Valid-object bit.
+vo_bit = []
 
 # conservative garbage collection support
-is_mmtk_object = ["global_alloc_bit"]
+is_mmtk_object = ["vo_bit"]
 
 # The following two features are useful for using Immix for VMs that do not support moving GC.
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -578,20 +578,20 @@ pub fn is_live_object(object: ObjectReference) -> bool {
 /// 2.  Also return true if there exists an `objref: ObjectReference` such that
 ///     -   `objref` is a valid object reference to an object in any space in MMTk, and
 ///     -   `lo <= objref.to_address() < hi`, where
-///         -   `lo = addr.align_down(ALLOC_BIT_REGION_SIZE)` and
-///         -   `hi = lo + ALLOC_BIT_REGION_SIZE` and
-///         -   `ALLOC_BIT_REGION_SIZE` is [`crate::util::is_mmtk_object::ALLOC_BIT_REGION_SIZE`].
-///             It is the byte granularity of the alloc bit.
+///         -   `lo = addr.align_down(VO_BIT_REGION_SIZE)` and
+///         -   `hi = lo + VO_BIT_REGION_SIZE` and
+///         -   `VO_BIT_REGION_SIZE` is [`crate::util::is_mmtk_object::VO_BIT_REGION_SIZE`].
+///             It is the byte granularity of the VO-bit.
 /// 3.  Return false otherwise.  This function never panics.
 ///
 /// Case 2 means **this function is imprecise for misaligned addresses**.
-/// This function uses the "alloc bits" side metadata, i.e. a bitmap.
+/// This function uses the VO-bit side metadata, i.e. a bitmap.
 /// For space efficiency, each bit of the bitmap governs a small region of memory.
 /// The size of a region is currently defined as the [minimum object size](crate::util::constants::MIN_OBJECT_SIZE),
 /// which is currently defined as the [word size](crate::util::constants::BYTES_IN_WORD),
 /// which is 4 bytes on 32-bit systems or 8 bytes on 64-bit systems.
 /// The alignment of a region is also the region size.
-/// If an alloc bit is `1`, the bitmap cannot tell which address within the 4-byte or 8-byte region
+/// If a VO-bit is `1`, the bitmap cannot tell which address within the 4-byte or 8-byte region
 /// is the valid object reference.
 /// Therefore, if the input `addr` is not properly aligned, but is close to a valid object
 /// reference, this function may still return true.
@@ -599,7 +599,7 @@ pub fn is_live_object(object: ObjectReference) -> bool {
 /// For the reason above, the VM **must check if `addr` is properly aligned** before calling this
 /// function.  For most VMs, valid object references are always aligned to the word size, so
 /// checking `addr.is_aligned_to(BYTES_IN_WORD)` should usually work.  If you are paranoid, you can
-/// always check against [`crate::util::is_mmtk_object::ALLOC_BIT_REGION_SIZE`].
+/// always check against [`crate::util::is_mmtk_object::VO_BIT_REGION_SIZE`].
 ///
 /// This function is useful for conservative root scanning.  The VM can iterate through all words in
 /// a stack, filter out zeros, misaligned words, obviously out-of-range words (such as addresses

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -422,7 +422,7 @@ pub struct BasePlan<VM: VMBinding> {
     /// If VM space is present, it has some special interaction with the
     /// `memory_manager::is_mmtk_object` and the `memory_manager::is_in_mmtk_spaces` functions.
     ///
-    /// -   The `is_mmtk_object` funciton requires the alloc_bit side metadata to identify objects,
+    /// -   The `is_mmtk_object` function requires the VO-bit side metadata to identify objects,
     ///     but currently we do not require the boot image to provide it, so it will not work if the
     ///     address argument is in the VM space.
     ///

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -15,8 +15,8 @@ use crate::policy::space::Space;
 use crate::scheduler::gc_work::*;
 use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
-#[cfg(not(feature = "global_alloc_bit"))]
-use crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC;
+#[cfg(not(feature = "vo_bit"))]
+use crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC;
 use crate::util::copy::CopySemantics;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
@@ -181,11 +181,11 @@ impl<VM: VMBinding> MarkCompact<VM> {
         let mut heap = HeapMeta::new(&options);
         // if global_alloc_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
         // SideMetadataContext by default, so we don't need to add it here.
-        #[cfg(feature = "global_alloc_bit")]
+        #[cfg(feature = "vo_bit")]
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
         // if global_alloc_bit is NOT enabled,
         // we need to add ALLOC_SIDE_METADATA_SPEC to SideMetadataContext here.
-        #[cfg(not(feature = "global_alloc_bit"))]
+        #[cfg(not(feature = "vo_bit"))]
         let global_metadata_specs =
             SideMetadataContext::new_global_specs(&[ALLOC_SIDE_METADATA_SPEC]);
 

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -16,7 +16,7 @@ use crate::scheduler::gc_work::*;
 use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 #[cfg(not(feature = "vo_bit"))]
-use crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC;
+use crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC;
 use crate::util::copy::CopySemantics;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -179,11 +179,11 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
 impl<VM: VMBinding> MarkCompact<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
         let mut heap = HeapMeta::new(&options);
-        // if global_alloc_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
+        // if vo_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
         // SideMetadataContext by default, so we don't need to add it here.
         #[cfg(feature = "vo_bit")]
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
-        // if global_alloc_bit is NOT enabled,
+        // if vo_bit is NOT enabled,
         // we need to add ALLOC_SIDE_METADATA_SPEC to SideMetadataContext here.
         #[cfg(not(feature = "vo_bit"))]
         let global_metadata_specs =

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -12,7 +12,7 @@ use crate::policy::space::Space;
 use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 #[cfg(not(feature = "vo_bit"))]
-use crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC;
+use crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::HeapMeta;

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -11,8 +11,8 @@ use crate::policy::mallocspace::MallocSpace;
 use crate::policy::space::Space;
 use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
-#[cfg(not(feature = "global_alloc_bit"))]
-use crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC;
+#[cfg(not(feature = "vo_bit"))]
+use crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::HeapMeta;
@@ -99,12 +99,12 @@ impl<VM: VMBinding> MarkSweep<VM> {
         let heap = HeapMeta::new(&options);
         // if global_alloc_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
         // SideMetadataContext by default, so we don't need to add it here.
-        #[cfg(feature = "global_alloc_bit")]
+        #[cfg(feature = "vo_bit")]
         let global_metadata_specs =
             SideMetadataContext::new_global_specs(&[ACTIVE_CHUNK_METADATA_SPEC]);
         // if global_alloc_bit is NOT enabled,
         // we need to add ALLOC_SIDE_METADATA_SPEC to SideMetadataContext here.
-        #[cfg(not(feature = "global_alloc_bit"))]
+        #[cfg(not(feature = "vo_bit"))]
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[
             ALLOC_SIDE_METADATA_SPEC,
             ACTIVE_CHUNK_METADATA_SPEC,

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -97,12 +97,12 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
 impl<VM: VMBinding> MarkSweep<VM> {
     pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
         let heap = HeapMeta::new(&options);
-        // if global_alloc_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
+        // if vo_bit is enabled, ALLOC_SIDE_METADATA_SPEC will be added to
         // SideMetadataContext by default, so we don't need to add it here.
         #[cfg(feature = "vo_bit")]
         let global_metadata_specs =
             SideMetadataContext::new_global_specs(&[ACTIVE_CHUNK_METADATA_SPEC]);
-        // if global_alloc_bit is NOT enabled,
+        // if vo_bit is NOT enabled,
         // we need to add ALLOC_SIDE_METADATA_SPEC to SideMetadataContext here.
         #[cfg(not(feature = "vo_bit"))]
         let global_metadata_specs = SideMetadataContext::new_global_specs(&[

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -194,7 +194,7 @@ impl<VM: VMBinding> CopySpace<VM> {
     unsafe fn reset_vo_bit(&self) {
         let current_chunk = self.pr.get_current_chunk();
         if self.common.contiguous {
-            // If we have allocated something into this space, we need to clear its alloc bit.
+            // If we have allocated something into this space, we need to clear its VO-bit.
             if current_chunk != self.common.start {
                 crate::util::vo_bit::bzero_vo_bit(
                     self.common.start,
@@ -232,7 +232,7 @@ impl<VM: VMBinding> CopySpace<VM> {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
             crate::util::vo_bit::is_vo_bit_set(object),
-            "{:x}: alloc bit not set",
+            "{:x}: VO-bit not set",
             object
         );
 

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -47,7 +47,7 @@ impl<VM: VMBinding> SFT for CopySpace<VM> {
 
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
         #[cfg(feature = "vo_bit")]
-        crate::util::vo_bit::set_alloc_bit(_object);
+        crate::util::vo_bit::set_vo_bit(_object);
     }
 
     #[inline(always)]
@@ -183,7 +183,7 @@ impl<VM: VMBinding> CopySpace<VM> {
     pub fn release(&self) {
         unsafe {
             #[cfg(feature = "vo_bit")]
-            self.reset_alloc_bit();
+            self.reset_vo_bit();
             self.pr.reset();
         }
         self.common.metadata.reset();
@@ -191,12 +191,12 @@ impl<VM: VMBinding> CopySpace<VM> {
     }
 
     #[cfg(feature = "vo_bit")]
-    unsafe fn reset_alloc_bit(&self) {
+    unsafe fn reset_vo_bit(&self) {
         let current_chunk = self.pr.get_current_chunk();
         if self.common.contiguous {
             // If we have allocated something into this space, we need to clear its alloc bit.
             if current_chunk != self.common.start {
-                crate::util::vo_bit::bzero_alloc_bit(
+                crate::util::vo_bit::bzero_vo_bit(
                     self.common.start,
                     current_chunk + BYTES_IN_CHUNK - self.common.start,
                 );
@@ -231,7 +231,7 @@ impl<VM: VMBinding> CopySpace<VM> {
 
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::vo_bit::is_alloced(object),
+            crate::util::vo_bit::is_vo_bit_set(object),
             "{:x}: alloc bit not set",
             object
         );

--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -183,8 +183,8 @@ impl Block {
     /// Deinitalize a block before releasing.
     #[inline]
     pub fn deinit(&self) {
-        #[cfg(feature = "global_alloc_bit")]
-        crate::util::alloc_bit::bzero_alloc_bit(self.start(), Self::BYTES);
+        #[cfg(feature = "vo_bit")]
+        crate::util::vo_bit::bzero_alloc_bit(self.start(), Self::BYTES);
         self.set_state(BlockState::Unallocated);
     }
 

--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -184,7 +184,7 @@ impl Block {
     #[inline]
     pub fn deinit(&self) {
         #[cfg(feature = "vo_bit")]
-        crate::util::vo_bit::bzero_alloc_bit(self.start(), Self::BYTES);
+        crate::util::vo_bit::bzero_vo_bit(self.start(), Self::BYTES);
         self.set_state(BlockState::Unallocated);
     }
 

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -391,7 +391,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
             crate::util::vo_bit::is_vo_bit_set(object),
-            "{:x}: alloc bit not set",
+            "{:x}: VO-bit not set",
             object
         );
         if Block::containing::<VM>(object).is_defrag_source() {

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -77,7 +77,7 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
     }
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
         #[cfg(feature = "vo_bit")]
-        crate::util::vo_bit::set_alloc_bit(_object);
+        crate::util::vo_bit::set_vo_bit(_object);
     }
     #[inline(always)]
     fn sft_trace_object(
@@ -390,7 +390,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
     ) -> ObjectReference {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::vo_bit::is_alloced(object),
+            crate::util::vo_bit::is_vo_bit_set(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -483,7 +483,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 object
             } else {
                 #[cfg(feature = "vo_bit")]
-                crate::util::vo_bit::unset_alloc_bit(object);
+                crate::util::vo_bit::unset_vo_bit(object);
                 ForwardingWord::forward_object::<VM>(object, semantics, copy_context)
             };
             debug_assert_eq!(

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -76,8 +76,8 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
         true
     }
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
-        #[cfg(feature = "global_alloc_bit")]
-        crate::util::alloc_bit::set_alloc_bit(_object);
+        #[cfg(feature = "vo_bit")]
+        crate::util::vo_bit::set_alloc_bit(_object);
     }
     #[inline(always)]
     fn sft_trace_object(
@@ -388,9 +388,9 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         semantics: CopySemantics,
         worker: &mut GCWorker<VM>,
     ) -> ObjectReference {
-        #[cfg(feature = "global_alloc_bit")]
+        #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::alloc_bit::is_alloced(object),
+            crate::util::vo_bit::is_alloced(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -482,8 +482,8 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 Block::containing::<VM>(object).set_state(BlockState::Marked);
                 object
             } else {
-                #[cfg(feature = "global_alloc_bit")]
-                crate::util::alloc_bit::unset_alloc_bit(object);
+                #[cfg(feature = "vo_bit")]
+                crate::util::vo_bit::unset_alloc_bit(object);
                 ForwardingWord::forward_object::<VM>(object, semantics, copy_context)
             };
             debug_assert_eq!(

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -210,7 +210,7 @@ impl<VM: VMBinding> ImmortalSpace<VM> {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
             crate::util::vo_bit::is_vo_bit_set(object),
-            "{:x}: alloc bit not set",
+            "{:x}: VO-bit not set",
             object
         );
         if ImmortalSpace::<VM>::test_and_mark(object, self.mark_state) {

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -70,7 +70,7 @@ impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
         #[cfg(feature = "vo_bit")]
-        crate::util::vo_bit::set_alloc_bit(object);
+        crate::util::vo_bit::set_vo_bit(object);
     }
     #[inline(always)]
     fn sft_trace_object(
@@ -209,7 +209,7 @@ impl<VM: VMBinding> ImmortalSpace<VM> {
     ) -> ObjectReference {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::vo_bit::is_alloced(object),
+            crate::util::vo_bit::is_vo_bit_set(object),
             "{:x}: alloc bit not set",
             object
         );

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -69,8 +69,8 @@ impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
         if self.common.needs_log_bit {
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
-        #[cfg(feature = "global_alloc_bit")]
-        crate::util::alloc_bit::set_alloc_bit(object);
+        #[cfg(feature = "vo_bit")]
+        crate::util::vo_bit::set_alloc_bit(object);
     }
     #[inline(always)]
     fn sft_trace_object(
@@ -207,9 +207,9 @@ impl<VM: VMBinding> ImmortalSpace<VM> {
         queue: &mut Q,
         object: ObjectReference,
     ) -> ObjectReference {
-        #[cfg(feature = "global_alloc_bit")]
+        #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::alloc_bit::is_alloced(object),
+            crate::util::vo_bit::is_alloced(object),
             "{:x}: alloc bit not set",
             object
         );

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -73,7 +73,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
         }
 
         #[cfg(feature = "vo_bit")]
-        crate::util::vo_bit::set_alloc_bit(object);
+        crate::util::vo_bit::set_vo_bit(object);
         let cell = VM::VMObjectModel::object_start_ref(object);
         self.treadmill.add_to_treadmill(cell, alloc);
     }
@@ -205,7 +205,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
     ) -> ObjectReference {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::vo_bit::is_alloced(object),
+            crate::util::vo_bit::is_vo_bit_set(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -235,14 +235,14 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
             for cell in self.treadmill.collect_nursery() {
                 // println!("- cn {}", cell);
                 #[cfg(feature = "vo_bit")]
-                crate::util::vo_bit::unset_addr_alloc_bit(cell);
+                crate::util::vo_bit::unset_vo_bit_for_addr(cell);
                 self.pr.release_pages(get_super_page(cell));
             }
         } else {
             for cell in self.treadmill.collect() {
                 // println!("- ts {}", cell);
                 #[cfg(feature = "vo_bit")]
-                crate::util::vo_bit::unset_addr_alloc_bit(cell);
+                crate::util::vo_bit::unset_vo_bit_for_addr(cell);
                 self.pr.release_pages(get_super_page(cell));
             }
         }

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -206,7 +206,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
             crate::util::vo_bit::is_vo_bit_set(object),
-            "{:x}: alloc bit not set",
+            "{:x}: VO-bit not set",
             object
         );
         let nursery_object = self.is_in_nursery(object);

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -72,8 +72,8 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
 
-        #[cfg(feature = "global_alloc_bit")]
-        crate::util::alloc_bit::set_alloc_bit(object);
+        #[cfg(feature = "vo_bit")]
+        crate::util::vo_bit::set_alloc_bit(object);
         let cell = VM::VMObjectModel::object_start_ref(object);
         self.treadmill.add_to_treadmill(cell, alloc);
     }
@@ -203,9 +203,9 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
         queue: &mut Q,
         object: ObjectReference,
     ) -> ObjectReference {
-        #[cfg(feature = "global_alloc_bit")]
+        #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::alloc_bit::is_alloced(object),
+            crate::util::vo_bit::is_alloced(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -234,15 +234,15 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
         if sweep_nursery {
             for cell in self.treadmill.collect_nursery() {
                 // println!("- cn {}", cell);
-                #[cfg(feature = "global_alloc_bit")]
-                crate::util::alloc_bit::unset_addr_alloc_bit(cell);
+                #[cfg(feature = "vo_bit")]
+                crate::util::vo_bit::unset_addr_alloc_bit(cell);
                 self.pr.release_pages(get_super_page(cell));
             }
         } else {
             for cell in self.treadmill.collect() {
                 // println!("- ts {}", cell);
-                #[cfg(feature = "global_alloc_bit")]
-                crate::util::alloc_bit::unset_addr_alloc_bit(cell);
+                #[cfg(feature = "vo_bit")]
+                crate::util::vo_bit::unset_addr_alloc_bit(cell);
                 self.pr.release_pages(get_super_page(cell));
             }
         }

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -59,7 +59,7 @@ impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
     }
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
         #[cfg(feature = "vo_bit")]
-        crate::util::vo_bit::set_alloc_bit(_object);
+        crate::util::vo_bit::set_vo_bit(_object);
     }
     fn sft_trace_object(
         &self,

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -58,8 +58,8 @@ impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
         unimplemented!()
     }
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
-        #[cfg(feature = "global_alloc_bit")]
-        crate::util::alloc_bit::set_alloc_bit(_object);
+        #[cfg(feature = "vo_bit")]
+        crate::util::vo_bit::set_alloc_bit(_object);
     }
     fn sft_trace_object(
         &self,

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -482,7 +482,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         let chunk_end = chunk_start + BYTES_IN_CHUNK;
 
         debug_assert!(
-            crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region
+            crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC.log_bytes_in_region
                 == mark_bit_spec.log_bytes_in_region,
             "Alloc-bit and mark-bit metadata have different minimum object sizes!"
         );
@@ -490,7 +490,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         // For bulk xor'ing 128-bit vectors on architectures with vector instructions
         // Each bit represents an object of LOG_MIN_OBJ_SIZE size
         let bulk_load_size: usize =
-            128 * (1 << crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region);
+            128 * (1 << crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC.log_bytes_in_region);
 
         // The start of a possibly empty page. This will be updated during the sweeping, and always points to the next page of last live objects.
         let mut empty_page_start = Address::ZERO;
@@ -498,7 +498,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         // Scan the chunk by every 'bulk_load_size' region.
         while address < chunk_end {
             let alloc_128: u128 =
-                unsafe { load128(&crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC, address) };
+                unsafe { load128(&crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC, address) };
             let mark_128: u128 = unsafe { load128(&mark_bit_spec, address) };
 
             // Check if there are dead objects in the bulk loaded region

--- a/src/policy/mallocspace/global.rs
+++ b/src/policy/mallocspace/global.rs
@@ -482,7 +482,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         let chunk_end = chunk_start + BYTES_IN_CHUNK;
 
         debug_assert!(
-            crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region
+            crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region
                 == mark_bit_spec.log_bytes_in_region,
             "Alloc-bit and mark-bit metadata have different minimum object sizes!"
         );
@@ -490,7 +490,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         // For bulk xor'ing 128-bit vectors on architectures with vector instructions
         // Each bit represents an object of LOG_MIN_OBJ_SIZE size
         let bulk_load_size: usize =
-            128 * (1 << crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region);
+            128 * (1 << crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region);
 
         // The start of a possibly empty page. This will be updated during the sweeping, and always points to the next page of last live objects.
         let mut empty_page_start = Address::ZERO;
@@ -498,7 +498,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         // Scan the chunk by every 'bulk_load_size' region.
         while address < chunk_end {
             let alloc_128: u128 =
-                unsafe { load128(&crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC, address) };
+                unsafe { load128(&crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC, address) };
             let mark_128: u128 = unsafe { load128(&mark_bit_spec, address) };
 
             // Check if there are dead objects in the bulk loaded region

--- a/src/policy/mallocspace/metadata.rs
+++ b/src/policy/mallocspace/metadata.rs
@@ -162,6 +162,7 @@ pub fn is_alloced_by_malloc(object: ObjectReference) -> bool {
 /// This function doesn't check if `addr` is aligned.
 /// If not, it will try to load the alloc bit for the address rounded down to the metadata's granularity.
 pub fn has_object_alloced_by_malloc(addr: Address) -> bool {
+    // FIXME: MallocSpace should use a local metadata to record allocated units.
     is_meta_space_mapped_for_address(addr) && vo_bit::is_vo_bit_set_for_addr(addr)
 }
 
@@ -205,6 +206,7 @@ pub unsafe fn is_chunk_marked_unsafe(chunk_start: Address) -> bool {
 }
 
 pub fn set_alloc_bit(object: ObjectReference) {
+    // FIXME: MallocSpace should use a local metadata to record allocated units.
     vo_bit::set_vo_bit(object);
 }
 
@@ -214,6 +216,7 @@ pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Ordering) 
 
 #[allow(unused)]
 pub fn unset_alloc_bit(object: ObjectReference) {
+    // FIXME: MallocSpace should use a local metadata to record allocated units.
     vo_bit::unset_vo_bit(object);
 }
 
@@ -238,6 +241,7 @@ pub(super) unsafe fn unset_offset_malloc_bit_unsafe(address: Address) {
 }
 
 pub unsafe fn unset_alloc_bit_unsafe(object: ObjectReference) {
+    // FIXME: MallocSpace should use a local metadata to record allocated units.
     vo_bit::unset_vo_bit_unsafe(object);
 }
 

--- a/src/policy/mallocspace/metadata.rs
+++ b/src/policy/mallocspace/metadata.rs
@@ -162,7 +162,7 @@ pub fn is_alloced_by_malloc(object: ObjectReference) -> bool {
 /// This function doesn't check if `addr` is aligned.
 /// If not, it will try to load the alloc bit for the address rounded down to the metadata's granularity.
 pub fn has_object_alloced_by_malloc(addr: Address) -> bool {
-    is_meta_space_mapped_for_address(addr) && vo_bit::is_alloced_object(addr)
+    is_meta_space_mapped_for_address(addr) && vo_bit::is_vo_bit_set_for_addr(addr)
 }
 
 pub fn is_marked<VM: VMBinding>(object: ObjectReference, ordering: Ordering) -> bool {
@@ -205,7 +205,7 @@ pub unsafe fn is_chunk_marked_unsafe(chunk_start: Address) -> bool {
 }
 
 pub fn set_alloc_bit(object: ObjectReference) {
-    vo_bit::set_alloc_bit(object);
+    vo_bit::set_vo_bit(object);
 }
 
 pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Ordering) {
@@ -214,7 +214,7 @@ pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Ordering) 
 
 #[allow(unused)]
 pub fn unset_alloc_bit(object: ObjectReference) {
-    vo_bit::unset_alloc_bit(object);
+    vo_bit::unset_vo_bit(object);
 }
 
 pub(super) fn set_page_mark(page_addr: Address) {
@@ -238,7 +238,7 @@ pub(super) unsafe fn unset_offset_malloc_bit_unsafe(address: Address) {
 }
 
 pub unsafe fn unset_alloc_bit_unsafe(object: ObjectReference) {
-    vo_bit::unset_alloc_bit_unsafe(object);
+    vo_bit::unset_vo_bit_unsafe(object);
 }
 
 #[allow(unused)]

--- a/src/policy/mallocspace/metadata.rs
+++ b/src/policy/mallocspace/metadata.rs
@@ -1,4 +1,4 @@
-use crate::util::alloc_bit;
+use crate::util::vo_bit;
 use crate::util::conversions;
 use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
 use crate::util::metadata::side_metadata;
@@ -162,7 +162,7 @@ pub fn is_alloced_by_malloc(object: ObjectReference) -> bool {
 /// This function doesn't check if `addr` is aligned.
 /// If not, it will try to load the alloc bit for the address rounded down to the metadata's granularity.
 pub fn has_object_alloced_by_malloc(addr: Address) -> bool {
-    is_meta_space_mapped_for_address(addr) && alloc_bit::is_alloced_object(addr)
+    is_meta_space_mapped_for_address(addr) && vo_bit::is_alloced_object(addr)
 }
 
 pub fn is_marked<VM: VMBinding>(object: ObjectReference, ordering: Ordering) -> bool {
@@ -205,7 +205,7 @@ pub unsafe fn is_chunk_marked_unsafe(chunk_start: Address) -> bool {
 }
 
 pub fn set_alloc_bit(object: ObjectReference) {
-    alloc_bit::set_alloc_bit(object);
+    vo_bit::set_alloc_bit(object);
 }
 
 pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Ordering) {
@@ -214,7 +214,7 @@ pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Ordering) 
 
 #[allow(unused)]
 pub fn unset_alloc_bit(object: ObjectReference) {
-    alloc_bit::unset_alloc_bit(object);
+    vo_bit::unset_alloc_bit(object);
 }
 
 pub(super) fn set_page_mark(page_addr: Address) {
@@ -238,7 +238,7 @@ pub(super) unsafe fn unset_offset_malloc_bit_unsafe(address: Address) {
 }
 
 pub unsafe fn unset_alloc_bit_unsafe(object: ObjectReference) {
-    alloc_bit::unset_alloc_bit_unsafe(object);
+    vo_bit::unset_alloc_bit_unsafe(object);
 }
 
 #[allow(unused)]

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -232,7 +232,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
     ) -> ObjectReference {
         debug_assert!(
             crate::util::vo_bit::is_vo_bit_set(object),
-            "{:x}: alloc bit not set",
+            "{:x}: VO-bit not set",
             object
         );
         if MarkCompactSpace::<VM>::test_and_mark(object) {
@@ -248,7 +248,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
     ) -> ObjectReference {
         debug_assert!(
             crate::util::vo_bit::is_vo_bit_set(object),
-            "{:x}: alloc bit not set",
+            "{:x}: VO-bit not set",
             object
         );
         // from this stage and onwards, mark bit is no longer needed
@@ -376,7 +376,8 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
                 start, end,
             );
         for obj in linear_scan {
-            // clear the alloc bit
+            // clear the VO-bit
+            // FIXME: MarkCompact should use a local metadata to record allocated units.
             vo_bit::unset_vo_bit_for_addr(obj.to_address());
 
             let forwarding_pointer = Self::get_header_forwarding_pointer(obj);
@@ -390,7 +391,8 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
                 // copy object
                 trace!(" copy from {} to {}", obj, new_object);
                 let end_of_new_object = VM::VMObjectModel::copy_to(obj, new_object, Address::ZERO);
-                // update alloc_bit,
+                // update VO-bit
+                // FIXME: MarkCompact should use a local metadata to record allocated units.
                 vo_bit::set_vo_bit(new_object);
                 to = new_object.to_address() + copied_size;
                 debug_assert_eq!(end_of_new_object, to);

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -57,7 +57,7 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
     }
 
     fn initialize_object_metadata(&self, object: ObjectReference, _alloc: bool) {
-        crate::util::vo_bit::set_alloc_bit(object);
+        crate::util::vo_bit::set_vo_bit(object);
     }
 
     #[cfg(feature = "sanity")]
@@ -231,7 +231,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         object: ObjectReference,
     ) -> ObjectReference {
         debug_assert!(
-            crate::util::vo_bit::is_alloced(object),
+            crate::util::vo_bit::is_vo_bit_set(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -247,7 +247,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         object: ObjectReference,
     ) -> ObjectReference {
         debug_assert!(
-            crate::util::vo_bit::is_alloced(object),
+            crate::util::vo_bit::is_vo_bit_set(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -377,7 +377,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             );
         for obj in linear_scan {
             // clear the alloc bit
-            vo_bit::unset_addr_alloc_bit(obj.to_address());
+            vo_bit::unset_vo_bit_for_addr(obj.to_address());
 
             let forwarding_pointer = Self::get_header_forwarding_pointer(obj);
 
@@ -391,7 +391,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
                 trace!(" copy from {} to {}", obj, new_object);
                 let end_of_new_object = VM::VMObjectModel::copy_to(obj, new_object, Address::ZERO);
                 // update alloc_bit,
-                vo_bit::set_alloc_bit(new_object);
+                vo_bit::set_vo_bit(new_object);
                 to = new_object.to_address() + copied_size;
                 debug_assert_eq!(end_of_new_object, to);
             }

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -11,7 +11,7 @@ use crate::util::heap::layout::heap_layout::{Mmapper, VMMap};
 use crate::util::heap::{HeapMeta, MonotonePageResource, PageResource, VMRequest};
 use crate::util::metadata::extract_side_metadata;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSpec};
-use crate::util::{alloc_bit, Address, ObjectReference};
+use crate::util::{vo_bit, Address, ObjectReference};
 use crate::{vm::*, ObjectQueue};
 use atomic::Ordering;
 
@@ -57,7 +57,7 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
     }
 
     fn initialize_object_metadata(&self, object: ObjectReference, _alloc: bool) {
-        crate::util::alloc_bit::set_alloc_bit(object);
+        crate::util::vo_bit::set_alloc_bit(object);
     }
 
     #[cfg(feature = "sanity")]
@@ -231,7 +231,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         object: ObjectReference,
     ) -> ObjectReference {
         debug_assert!(
-            crate::util::alloc_bit::is_alloced(object),
+            crate::util::vo_bit::is_alloced(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -247,7 +247,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         object: ObjectReference,
     ) -> ObjectReference {
         debug_assert!(
-            crate::util::alloc_bit::is_alloced(object),
+            crate::util::vo_bit::is_alloced(object),
             "{:x}: alloc bit not set",
             object
         );
@@ -377,7 +377,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             );
         for obj in linear_scan {
             // clear the alloc bit
-            alloc_bit::unset_addr_alloc_bit(obj.to_address());
+            vo_bit::unset_addr_alloc_bit(obj.to_address());
 
             let forwarding_pointer = Self::get_header_forwarding_pointer(obj);
 
@@ -391,7 +391,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
                 trace!(" copy from {} to {}", obj, new_object);
                 let end_of_new_object = VM::VMObjectModel::copy_to(obj, new_object, Address::ZERO);
                 // update alloc_bit,
-                alloc_bit::set_alloc_bit(new_object);
+                vo_bit::set_alloc_bit(new_object);
                 to = new_object.to_address() + copied_size;
                 debug_assert_eq!(end_of_new_object, to);
             }

--- a/src/policy/sft.rs
+++ b/src/policy/sft.rs
@@ -1,7 +1,7 @@
 use crate::plan::VectorObjectQueue;
 use crate::scheduler::GCWorker;
 #[cfg(feature = "is_mmtk_object")]
-use crate::util::alloc_bit;
+use crate::util::vo_bit;
 use crate::util::conversions;
 use crate::util::*;
 use crate::vm::VMBinding;
@@ -78,7 +78,7 @@ pub trait SFT {
             return false;
         }
         // The `addr` is mapped. We use the global alloc bit to get the exact answer.
-        alloc_bit::is_alloced_object(addr)
+        vo_bit::is_alloced_object(addr)
     }
 
     /// Initialize object metadata (in the header, or in the side metadata).

--- a/src/policy/sft.rs
+++ b/src/policy/sft.rs
@@ -78,7 +78,7 @@ pub trait SFT {
             return false;
         }
         // The `addr` is mapped. We use the global alloc bit to get the exact answer.
-        vo_bit::is_alloced_object(addr)
+        vo_bit::is_vo_bit_set_for_addr(addr)
     }
 
     /// Initialize object metadata (in the header, or in the side metadata).

--- a/src/policy/sft.rs
+++ b/src/policy/sft.rs
@@ -77,7 +77,7 @@ pub trait SFT {
         if !addr.is_mapped() {
             return false;
         }
-        // The `addr` is mapped. We use the global alloc bit to get the exact answer.
+        // The `addr` is mapped. We use the VO-bit to get the exact answer.
         vo_bit::is_vo_bit_set_for_addr(addr)
     }
 

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -257,8 +257,8 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     end_line,
                     self.tls
                 );
-                #[cfg(feature = "global_alloc_bit")]
-                crate::util::alloc_bit::bzero_alloc_bit(self.cursor, self.limit - self.cursor);
+                #[cfg(feature = "vo_bit")]
+                crate::util::vo_bit::bzero_alloc_bit(self.cursor, self.limit - self.cursor);
                 crate::util::memory::zero(self.cursor, self.limit - self.cursor);
                 debug_assert!(
                     align_allocation_no_fill::<VM>(self.cursor, align, offset) + size <= self.limit

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -258,7 +258,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     self.tls
                 );
                 #[cfg(feature = "vo_bit")]
-                crate::util::vo_bit::bzero_alloc_bit(self.cursor, self.limit - self.cursor);
+                crate::util::vo_bit::bzero_vo_bit(self.cursor, self.limit - self.cursor);
                 crate::util::memory::zero(self.cursor, self.limit - self.cursor);
                 debug_assert!(
                     align_allocation_no_fill::<VM>(self.cursor, align, offset) + size <= self.limit

--- a/src/util/is_mmtk_object.rs
+++ b/src/util/is_mmtk_object.rs
@@ -1,4 +1,4 @@
 /// The region size (in bytes) of the `ALLOC_BIT` side metadata.
 /// The VM can use this to check if an object is properly aligned.
 pub const ALLOC_BIT_REGION_SIZE: usize =
-    1usize << crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region;
+    1usize << crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region;

--- a/src/util/is_mmtk_object.rs
+++ b/src/util/is_mmtk_object.rs
@@ -1,4 +1,4 @@
 /// The region size (in bytes) of the `ALLOC_BIT` side metadata.
 /// The VM can use this to check if an object is properly aligned.
 pub const ALLOC_BIT_REGION_SIZE: usize =
-    1usize << crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC.log_bytes_in_region;
+    1usize << crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC.log_bytes_in_region;

--- a/src/util/is_mmtk_object.rs
+++ b/src/util/is_mmtk_object.rs
@@ -1,4 +1,4 @@
-/// The region size (in bytes) of the `ALLOC_BIT` side metadata.
+/// The region size (in bytes) of the `VO_BIT` side metadata.
 /// The VM can use this to check if an object is properly aligned.
-pub const ALLOC_BIT_REGION_SIZE: usize =
+pub const VO_BIT_REGION_SIZE: usize =
     1usize << crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC.log_bytes_in_region;

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -41,6 +41,8 @@ impl<VM: VMBinding, S: LinearScanObjectSize, const ATOMIC_LOAD_ALLOC_BIT: bool> 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         while self.cursor < self.end {
             let is_object = if ATOMIC_LOAD_ALLOC_BIT {
+                // FIXME: Any space that supports linear scan (such as MarkCompact space) should
+                // introduce its own allocation bit rather than using VO-bit.
                 vo_bit::is_vo_bit_set_for_addr(self.cursor)
             } else {
                 unsafe { vo_bit::is_vo_bit_set_for_addr_unsafe(self.cursor) }

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -1,4 +1,4 @@
-use crate::util::alloc_bit;
+use crate::util::vo_bit;
 use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::vm::ObjectModel;
@@ -41,9 +41,9 @@ impl<VM: VMBinding, S: LinearScanObjectSize, const ATOMIC_LOAD_ALLOC_BIT: bool> 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         while self.cursor < self.end {
             let is_object = if ATOMIC_LOAD_ALLOC_BIT {
-                alloc_bit::is_alloced_object(self.cursor)
+                vo_bit::is_alloced_object(self.cursor)
             } else {
-                unsafe { alloc_bit::is_alloced_object_unsafe(self.cursor) }
+                unsafe { vo_bit::is_alloced_object_unsafe(self.cursor) }
             };
 
             if is_object {

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -41,9 +41,9 @@ impl<VM: VMBinding, S: LinearScanObjectSize, const ATOMIC_LOAD_ALLOC_BIT: bool> 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         while self.cursor < self.end {
             let is_object = if ATOMIC_LOAD_ALLOC_BIT {
-                vo_bit::is_alloced_object(self.cursor)
+                vo_bit::is_vo_bit_set_for_addr(self.cursor)
             } else {
-                unsafe { vo_bit::is_alloced_object_unsafe(self.cursor) }
+                unsafe { vo_bit::is_vo_bit_set_for_addr_unsafe(self.cursor) }
             };
 
             if is_object {

--- a/src/util/metadata/mod.rs
+++ b/src/util/metadata/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is designed to enable the implementation of a wide range of GC algorithms for VMs with various combinations of in-object and on-side space for GC-specific metadata (e.g. forwarding bits, marking bit, logging bit, etc.).
 //!
-//! The new metadata design differentiates per-object metadata (e.g. forwarding-bits and marking-bit) from other types of metadata including per-address (e.g. alloc-bit) and per-X (where X != object size), because the per-object metadata can optionally be kept in the object headers.
+//! The new metadata design differentiates per-object metadata (e.g. forwarding-bits and marking-bit) from other types of metadata including per-address and per-X (where X != object size), because the per-object metadata can optionally be kept in the object headers.
 //!
 //! MMTk acknowledges the VM-dependant nature of the in-object metadata, and asks the VM bindings to contribute by implementing the related parts in the ['ObjectModel'](crate::vm::ObjectModel).
 //!

--- a/src/util/metadata/side_metadata/constants.rs
+++ b/src/util/metadata/side_metadata/constants.rs
@@ -30,7 +30,7 @@ pub(crate) const GLOBAL_SIDE_METADATA_BASE_OFFSET: SideMetadataOffset =
     SideMetadataOffset::addr(GLOBAL_SIDE_METADATA_BASE_ADDRESS);
 
 // Base address of alloc bit, public to VM bindings which may need to use this.
-pub const ALLOC_SIDE_METADATA_ADDR: Address = crate::util::vo_bit::ALLOC_SIDE_METADATA_ADDR;
+pub const ALLOC_SIDE_METADATA_ADDR: Address = crate::util::vo_bit::VO_BIT_SIDE_METADATA_ADDR;
 
 /// This constant represents the worst-case ratio of source data size to global side metadata.
 /// A value of 2 means the space required for global side metadata must be less than 1/4th of the source data.

--- a/src/util/metadata/side_metadata/constants.rs
+++ b/src/util/metadata/side_metadata/constants.rs
@@ -30,7 +30,7 @@ pub(crate) const GLOBAL_SIDE_METADATA_BASE_OFFSET: SideMetadataOffset =
     SideMetadataOffset::addr(GLOBAL_SIDE_METADATA_BASE_ADDRESS);
 
 // Base address of alloc bit, public to VM bindings which may need to use this.
-pub const ALLOC_SIDE_METADATA_ADDR: Address = crate::util::alloc_bit::ALLOC_SIDE_METADATA_ADDR;
+pub const ALLOC_SIDE_METADATA_ADDR: Address = crate::util::vo_bit::ALLOC_SIDE_METADATA_ADDR;
 
 /// This constant represents the worst-case ratio of source data size to global side metadata.
 /// A value of 2 means the space required for global side metadata must be less than 1/4th of the source data.

--- a/src/util/metadata/side_metadata/constants.rs
+++ b/src/util/metadata/side_metadata/constants.rs
@@ -11,7 +11,7 @@ use crate::util::Address;
 // reserved addresses such as 0x0.
 // XXXX: I updated the base address for 32 bit to 0x1000_0000. For what I tested on, the library
 // and the malloc heap often starts at 0x800_0000. If we start the metadata from the second 4Mb chunk (i.e. the chunk `[0x40_0000, 0x80_0000)`),
-// we won't be guaranteed enough space before 0x800_0000. For example, the alloc bit is 1 bit per 4 bytes
+// we won't be guaranteed enough space before 0x800_0000. For example, the VO-bit is 1 bit per 4 bytes
 // (1 word in 32bits), and it will take the address range of [0x40_000, 0x840_0000) which clashes with
 // the library/heap. So I move this to 0x1000_0000.
 // This is made public, as VM bingdings may need to use this.
@@ -29,8 +29,8 @@ pub const GLOBAL_SIDE_METADATA_BASE_ADDRESS: Address =
 pub(crate) const GLOBAL_SIDE_METADATA_BASE_OFFSET: SideMetadataOffset =
     SideMetadataOffset::addr(GLOBAL_SIDE_METADATA_BASE_ADDRESS);
 
-// Base address of alloc bit, public to VM bindings which may need to use this.
-pub const ALLOC_SIDE_METADATA_ADDR: Address = crate::util::vo_bit::VO_BIT_SIDE_METADATA_ADDR;
+// Base address of VO-bit, public to VM bindings which may need to use this.
+pub const VO_BIT_SIDE_METADATA_ADDR: Address = crate::util::vo_bit::VO_BIT_SIDE_METADATA_ADDR;
 
 /// This constant represents the worst-case ratio of source data size to global side metadata.
 /// A value of 2 means the space required for global side metadata must be less than 1/4th of the source data.

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1,6 +1,6 @@
 use super::*;
-#[cfg(feature = "global_alloc_bit")]
-use crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC;
+#[cfg(feature = "vo_bit")]
+use crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC;
 use crate::util::constants::{BYTES_IN_PAGE, LOG_BITS_IN_BYTE};
 use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
 use crate::util::memory;
@@ -158,7 +158,7 @@ impl SideMetadataSpec {
         let _lock = sanity::SANITY_LOCK.lock().unwrap();
 
         // yiluowei: Not Sure but this assertion seems too strict for Immix recycled lines
-        #[cfg(not(feature = "global_alloc_bit"))]
+        #[cfg(not(feature = "vo_bit"))]
         debug_assert!(start.is_aligned_to(BYTES_IN_PAGE) && meta_byte_lshift(self, start) == 0);
 
         #[cfg(feature = "extreme_assertions")]
@@ -713,7 +713,7 @@ impl SideMetadataContext {
     pub fn new_global_specs(specs: &[SideMetadataSpec]) -> Vec<SideMetadataSpec> {
         let mut ret = vec![];
 
-        #[cfg(feature = "global_alloc_bit")]
+        #[cfg(feature = "vo_bit")]
         ret.push(ALLOC_SIDE_METADATA_SPEC);
 
         {

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1,6 +1,6 @@
 use super::*;
 #[cfg(feature = "vo_bit")]
-use crate::util::vo_bit::ALLOC_SIDE_METADATA_SPEC;
+use crate::util::vo_bit::VO_BIT_SIDE_METADATA_SPEC;
 use crate::util::constants::{BYTES_IN_PAGE, LOG_BITS_IN_BYTE};
 use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
 use crate::util::memory;
@@ -714,7 +714,7 @@ impl SideMetadataContext {
         let mut ret = vec![];
 
         #[cfg(feature = "vo_bit")]
-        ret.push(ALLOC_SIDE_METADATA_SPEC);
+        ret.push(VO_BIT_SIDE_METADATA_SPEC);
 
         {
             use crate::policy::sft_map::SFTMap;

--- a/src/util/metadata/side_metadata/spec_defs.rs
+++ b/src/util/metadata/side_metadata/spec_defs.rs
@@ -54,8 +54,8 @@ macro_rules! define_side_metadata_specs {
 // This defines all GLOBAL side metadata used by mmtk-core.
 define_side_metadata_specs!(
     last_spec_as LAST_GLOBAL_SIDE_METADATA_SPEC,
-    // Mark the start of an object
-    ALLOC_BIT       = (global: true, log_num_of_bits: 0, log_bytes_in_region: LOG_MIN_OBJECT_SIZE as usize),
+    // Valid object bit.
+    VO_BIT = (global: true, log_num_of_bits: 0, log_bytes_in_region: LOG_MIN_OBJECT_SIZE as usize),
     // Track chunks used by (malloc) marksweep
     MS_ACTIVE_CHUNK = (global: true, log_num_of_bits: 3, log_bytes_in_region: LOG_BYTES_IN_CHUNK as usize),
     // Track the index in SFT map for a chunk (only used for SFT sparse chunk map)

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -29,8 +29,6 @@ pub mod options;
 pub mod reference_processor;
 
 // The following modules are only public in the mmtk crate. They should only be used in MMTk core.
-/// Alloc bit
-pub(crate) mod alloc_bit;
 /// An analysis framework for collecting data and profiling in GC.
 #[cfg(feature = "analysis")]
 pub(crate) mod analysis;
@@ -65,6 +63,8 @@ pub(crate) mod statistics;
 pub(crate) mod test_util;
 /// A treadmill implementation.
 pub(crate) mod treadmill;
+/// Valid object bit
+pub(crate) mod vo_bit;
 
 // These modules are private. They are only used by other util modules.
 

--- a/src/util/object_forwarding.rs
+++ b/src/util/object_forwarding.rs
@@ -81,8 +81,8 @@ pub fn forward_object<VM: VMBinding>(
     copy_context: &mut GCWorkerCopyContext<VM>,
 ) -> ObjectReference {
     let new_object = VM::VMObjectModel::copy(object, semantics, copy_context);
-    #[cfg(feature = "global_alloc_bit")]
-    crate::util::alloc_bit::set_alloc_bit(new_object);
+    #[cfg(feature = "vo_bit")]
+    crate::util::vo_bit::set_alloc_bit(new_object);
     if let Some(shift) = forwarding_bits_offset_in_forwarding_pointer::<VM>() {
         VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC.store_atomic::<VM, usize>(
             object,

--- a/src/util/object_forwarding.rs
+++ b/src/util/object_forwarding.rs
@@ -82,7 +82,7 @@ pub fn forward_object<VM: VMBinding>(
 ) -> ObjectReference {
     let new_object = VM::VMObjectModel::copy(object, semantics, copy_context);
     #[cfg(feature = "vo_bit")]
-    crate::util::vo_bit::set_alloc_bit(new_object);
+    crate::util::vo_bit::set_vo_bit(new_object);
     if let Some(shift) = forwarding_bits_offset_in_forwarding_pointer::<VM>() {
         VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC.store_atomic::<VM, usize>(
             object,

--- a/src/util/vo_bit.rs
+++ b/src/util/vo_bit.rs
@@ -10,71 +10,60 @@
 
 use atomic::Ordering;
 
-use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;
-use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::Address;
 use crate::util::ObjectReference;
 
-/// An alloc-bit is required per min-object-size aligned address , rather than per object, and can only exist as side metadata.
-pub(crate) const ALLOC_SIDE_METADATA_SPEC: SideMetadataSpec =
-    crate::util::metadata::side_metadata::spec_defs::ALLOC_BIT;
+/// An VO-bit is required per min-object-size aligned address , rather than per object, and can only exist as side metadata.
+pub(crate) const VO_BIT_SIDE_METADATA_SPEC: SideMetadataSpec =
+    crate::util::metadata::side_metadata::spec_defs::VO_BIT;
 
-pub const ALLOC_SIDE_METADATA_ADDR: Address = ALLOC_SIDE_METADATA_SPEC.get_absolute_offset();
+pub const VO_BIT_SIDE_METADATA_ADDR: Address = VO_BIT_SIDE_METADATA_SPEC.get_absolute_offset();
 
-pub fn map_meta_space_for_chunk(metadata: &SideMetadataContext, chunk_start: Address) {
-    let mmap_metadata_result = metadata.try_map_metadata_space(chunk_start, BYTES_IN_CHUNK);
-    debug_assert!(
-        mmap_metadata_result.is_ok(),
-        "mmap sidemetadata failed for chunk_start ({})",
-        chunk_start
-    );
+pub fn set_vo_bit(object: ObjectReference) {
+    debug_assert!(!is_vo_bit_set(object), "{:x}: VO-bit already set", object);
+    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_address(), 1, Ordering::SeqCst);
 }
 
-pub fn set_alloc_bit(object: ObjectReference) {
-    debug_assert!(!is_alloced(object), "{:x}: alloc bit already set", object);
-    ALLOC_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_address(), 1, Ordering::SeqCst);
-}
-
-pub fn unset_addr_alloc_bit(address: Address) {
+pub fn unset_vo_bit_for_addr(address: Address) {
     debug_assert!(
-        is_alloced_object(address),
-        "{:x}: alloc bit not set",
+        is_vo_bit_set_for_addr(address),
+        "{:x}: VO-bit not set",
         address
     );
-    ALLOC_SIDE_METADATA_SPEC.store_atomic::<u8>(address, 0, Ordering::SeqCst);
+    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(address, 0, Ordering::SeqCst);
 }
 
-pub fn unset_alloc_bit(object: ObjectReference) {
-    debug_assert!(is_alloced(object), "{:x}: alloc bit not set", object);
-    ALLOC_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_address(), 0, Ordering::SeqCst);
+pub fn unset_vo_bit(object: ObjectReference) {
+    debug_assert!(is_vo_bit_set(object), "{:x}: VO-bit not set", object);
+    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_address(), 0, Ordering::SeqCst);
 }
 
 /// # Safety
 ///
 /// This is unsafe: check the comment on `side_metadata::store`
 ///
-pub unsafe fn unset_alloc_bit_unsafe(object: ObjectReference) {
-    debug_assert!(is_alloced(object), "{:x}: alloc bit not set", object);
-    ALLOC_SIDE_METADATA_SPEC.store::<u8>(object.to_address(), 0);
+pub unsafe fn unset_vo_bit_unsafe(object: ObjectReference) {
+    debug_assert!(is_vo_bit_set(object), "{:x}: VO-bit not set", object);
+    VO_BIT_SIDE_METADATA_SPEC.store::<u8>(object.to_address(), 0);
 }
 
-pub fn is_alloced(object: ObjectReference) -> bool {
-    is_alloced_object(object.to_address())
+pub fn is_vo_bit_set(object: ObjectReference) -> bool {
+    is_vo_bit_set_for_addr(object.to_address())
 }
 
-pub fn is_alloced_object(address: Address) -> bool {
-    ALLOC_SIDE_METADATA_SPEC.load_atomic::<u8>(address, Ordering::SeqCst) == 1
+pub fn is_vo_bit_set_for_addr(address: Address) -> bool {
+    VO_BIT_SIDE_METADATA_SPEC.load_atomic::<u8>(address, Ordering::SeqCst) == 1
 }
 
 /// # Safety
 ///
 /// This is unsafe: check the comment on `side_metadata::load`
 ///
-pub unsafe fn is_alloced_object_unsafe(address: Address) -> bool {
-    ALLOC_SIDE_METADATA_SPEC.load::<u8>(address) == 1
+pub unsafe fn is_vo_bit_set_for_addr_unsafe(address: Address) -> bool {
+    VO_BIT_SIDE_METADATA_SPEC.load::<u8>(address) == 1
 }
 
-pub fn bzero_alloc_bit(start: Address, size: usize) {
-    ALLOC_SIDE_METADATA_SPEC.bzero_metadata(start, size);
+pub fn bzero_vo_bit(start: Address, size: usize) {
+    VO_BIT_SIDE_METADATA_SPEC.bzero_metadata(start, size);
 }

--- a/src/util/vo_bit.rs
+++ b/src/util/vo_bit.rs
@@ -1,3 +1,13 @@
+//! Valid-object bit (VO-bit)
+//!
+//! The valid-object bit (VO-bit) metadata is a one-bit-per-object side metadata.  It is set for
+//! every object at allocation time (more precisely, during `post_alloc`), and cleared when either
+//! -   the object reclaims by the GC, or
+//! -   the VM explicitly clears the VO-bit of the object.
+//!
+//! The main purpose of VO-bit is supporting conservative GC.  It is the canonical source of
+//! information about whether there is an object in the MMTk heap at any given address.
+
 use atomic::Ordering;
 
 use crate::util::heap::layout::vm_layout_constants::BYTES_IN_CHUNK;

--- a/vmbindings/dummyvm/src/tests/conservatism.rs
+++ b/vmbindings/dummyvm/src/tests/conservatism.rs
@@ -5,7 +5,7 @@ use crate::api::*;
 use crate::object_model::OBJECT_REF_OFFSET;
 use crate::tests::fixtures::{Fixture, SingleObject};
 use mmtk::util::constants::LOG_BITS_IN_WORD;
-use mmtk::util::is_mmtk_object::ALLOC_BIT_REGION_SIZE;
+use mmtk::util::is_mmtk_object::VO_BIT_REGION_SIZE;
 use mmtk::util::*;
 
 lazy_static! {
@@ -13,7 +13,7 @@ lazy_static! {
 }
 
 fn basic_filter(addr: Address) -> bool {
-    !addr.is_zero() && addr.as_usize() % ALLOC_BIT_REGION_SIZE == (OBJECT_REF_OFFSET % ALLOC_BIT_REGION_SIZE)
+    !addr.is_zero() && addr.as_usize() % VO_BIT_REGION_SIZE == (OBJECT_REF_OFFSET % VO_BIT_REGION_SIZE)
 }
 
 fn assert_filter_pass(addr: Address) {


### PR DESCRIPTION
We currently have a so-called "allocation bit", or "alloc bit" metadata.  This name is misleading, because the name suggests it is used to identify allocated units in spaces, which is not true.  It is actually a global one-bit-per-minimum-alignment bitmap that indicates whether there is a valid object at any given address.  It is primarily designed to help conservative GC to filter potential object references on the stack or in objects.  This PR gives it a proper name, **valid-object bit** or **VO-bit** for short.

Some existing spaces use VO-bit to identify allocated units.  Currently they are `MallocSpace` and `MarkCompactSpace`.
-   `MallocSpace` uses VO-bit to record all the memory returned by `malloc`.
-   `MarkCompactSpace` uses VO-bit to iterate through all allocation units in the space.
These two spaces should switch to local metadata.
