### PR TITLE
Fix fetch_and_atomic and fetch_or_atomic

### DIFF
--- a/src/util/metadata/header_metadata.rs
+++ b/src/util/metadata/header_metadata.rs
@@ -402,12 +402,12 @@ impl HeaderMetadataSpec {
         #[cfg(debug_assertions)]
         self.assert_spec::<T>();
         if self.num_of_bits < 8 {
-            let (_, mask) = self.get_shift_and_mask_for_bits();
-            let new_val = val.to_u8().unwrap() | !mask;
+            let (lshift, mask) = self.get_shift_and_mask_for_bits();
+            let new_val = (val.to_u8().unwrap() | !mask) << lshift;
             // We do not need to use fetch_ops_on_bits(), we can just set irrelavent bits to 1, and do fetch_and
             let old_raw_byte =
                 unsafe { <u8 as MetadataValue>::fetch_and(self.meta_addr(object), new_val, order) };
-            let old_val = self.get_bits_from_u8(old_raw_byte);
+            let old_val = (old_raw_byte >> lshift) & mask;
             FromPrimitive::from_u8(old_val).unwrap()
         } else {
             unsafe { T::fetch_and(self.meta_addr(object), val, order) }
@@ -425,12 +425,12 @@ impl HeaderMetadataSpec {
         #[cfg(debug_assertions)]
         self.assert_spec::<T>();
         if self.num_of_bits < 8 {
-            let (_, mask) = self.get_shift_and_mask_for_bits();
-            let new_val = val.to_u8().unwrap() & mask;
+            let (lshift, mask) = self.get_shift_and_mask_for_bits();
+            let new_val = (val.to_u8().unwrap() & mask) << lshift;
             // We do not need to use fetch_ops_on_bits(), we can just set irrelavent bits to 1, and do fetch_and
             let old_raw_byte =
                 unsafe { <u8 as MetadataValue>::fetch_or(self.meta_addr(object), new_val, order) };
-            let old_val = self.get_bits_from_u8(old_raw_byte);
+            let old_val = (old_raw_byte >> lshift) & mask;
             FromPrimitive::from_u8(old_val).unwrap()
         } else {
             unsafe { T::fetch_or(self.meta_addr(object), val, order) }

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -536,12 +536,12 @@ impl SideMetadataSpec {
                 let meta_addr = address_to_meta_address(self, data_addr);
                 if self.log_num_of_bits < 3 {
                     let lshift = meta_byte_lshift(self, data_addr);
-                    let mask = meta_byte_mask(self) << lshift;
+                    let mask = meta_byte_mask(self);
                     // We do not need to use fetch_ops_on_bits(), we can just set irrelavent bits to 1, and do fetch_and
-                    let new_val = val.to_u8().unwrap() | !mask;
+                    let rhs = (val.to_u8().unwrap() | !mask) << lshift;
                     let old_raw_byte =
-                        unsafe { <u8 as MetadataValue>::fetch_and(meta_addr, new_val, order) };
-                    let old_val = (old_raw_byte & mask) >> lshift;
+                        unsafe { <u8 as MetadataValue>::fetch_and(meta_addr, rhs, order) };
+                    let old_val = (old_raw_byte >> lshift) & mask;
                     FromPrimitive::from_u8(old_val).unwrap()
                 } else {
                     unsafe { T::fetch_and(meta_addr, val, order) }
@@ -568,12 +568,12 @@ impl SideMetadataSpec {
                 let meta_addr = address_to_meta_address(self, data_addr);
                 if self.log_num_of_bits < 3 {
                     let lshift = meta_byte_lshift(self, data_addr);
-                    let mask = meta_byte_mask(self) << lshift;
+                    let mask = meta_byte_mask(self);
                     // We do not need to use fetch_ops_on_bits(), we can just set irrelavent bits to 0, and do fetch_or
-                    let new_val = val.to_u8().unwrap() & mask;
+                    let rhs = (val.to_u8().unwrap() & mask) << lshift;
                     let old_raw_byte =
-                        unsafe { <u8 as MetadataValue>::fetch_or(meta_addr, new_val, order) };
-                    let old_val = (old_raw_byte & mask) >> lshift;
+                        unsafe { <u8 as MetadataValue>::fetch_or(meta_addr, rhs, order) };
+                    let old_val = (old_raw_byte >> lshift) & mask;
                     FromPrimitive::from_u8(old_val).unwrap()
                 } else {
                     unsafe { T::fetch_or(meta_addr, val, order) }


### PR DESCRIPTION
The bit operations of sub-byte fetch_and_atomic and fetch_or_atomic was incorrect, and is fixed in this commit.