### PR TITLE
Remove the cirulcar dependency between CommonFreeListPageResource and VMMap

### DIFF
--- a/src/util/heap/freelistpageresource.rs
+++ b/src/util/heap/freelistpageresource.rs
@@ -18,7 +18,6 @@ use crate::util::memory;
 use crate::util::opaque_pointer::*;
 use crate::vm::*;
 use std::marker::PhantomData;
-use std::mem::MaybeUninit;
 
 const UNINITIALIZED_WATER_MARK: i32 = -1;
 
@@ -152,19 +151,17 @@ impl<VM: VMBinding> PageResource<VM> for FreeListPageResource<VM> {
 impl<VM: VMBinding> FreeListPageResource<VM> {
     pub fn new_contiguous(start: Address, bytes: usize, vm_map: &'static VMMap) -> Self {
         let pages = conversions::bytes_to_pages(bytes);
-        // We use MaybeUninit::uninit().assume_init(), which is nul, for a Box value, which cannot be null.
-        // FIXME: We should try either remove this kind of circular dependency or use MaybeUninit<T> instead of Box<T>
-        #[allow(invalid_value)]
-        #[allow(clippy::uninit_assumed_init)]
-        let common_flpr = unsafe {
-            let mut common_flpr = Box::new(CommonFreeListPageResource {
-                free_list: MaybeUninit::uninit().assume_init(),
+        let common_flpr = {
+            let common_flpr = Box::new(CommonFreeListPageResource {
+                free_list: vm_map.create_parent_freelist(start, pages, PAGES_IN_REGION as _),
                 start,
             });
-            ::std::ptr::write(
-                &mut common_flpr.free_list,
-                vm_map.create_parent_freelist(&common_flpr, pages, PAGES_IN_REGION as _),
-            );
+            // `CommonFreeListPageResource` lives as a member in space instances.
+            // Since `Space` instances are always stored as global variables, so it is okay here
+            // to turn `&CommonFreeListPageResource` into `&'static CommonFreeListPageResource`
+            vm_map.bind_freelist(unsafe {
+                &*(&common_flpr as &CommonFreeListPageResource as *const _)
+            });
             common_flpr
         };
         let growable = cfg!(target_pointer_width = "64");
@@ -181,19 +178,18 @@ impl<VM: VMBinding> FreeListPageResource<VM> {
     }
 
     pub fn new_discontiguous(vm_map: &'static VMMap) -> Self {
-        // We use MaybeUninit::uninit().assume_init(), which is nul, for a Box value, which cannot be null.
-        // FIXME: We should try either remove this kind of circular dependency or use MaybeUninit<T> instead of Box<T>
-        #[allow(invalid_value)]
-        #[allow(clippy::uninit_assumed_init)]
-        let common_flpr = unsafe {
-            let mut common_flpr = Box::new(CommonFreeListPageResource {
-                free_list: MaybeUninit::uninit().assume_init(),
-                start: AVAILABLE_START,
+        let common_flpr = {
+            let start = AVAILABLE_START;
+            let common_flpr = Box::new(CommonFreeListPageResource {
+                free_list: vm_map.create_freelist(start),
+                start,
             });
-            ::std::ptr::write(
-                &mut common_flpr.free_list,
-                vm_map.create_freelist(&common_flpr),
-            );
+            // `CommonFreeListPageResource` lives as a member in space instances.
+            // Since `Space` instances are always stored as global variables, so it is okay here
+            // to turn `&CommonFreeListPageResource` into `&'static CommonFreeListPageResource`
+            vm_map.bind_freelist(unsafe {
+                &*(&common_flpr as &CommonFreeListPageResource as *const _)
+            });
             common_flpr
         };
         FreeListPageResource {

--- a/src/util/heap/freelistpageresource.rs
+++ b/src/util/heap/freelistpageresource.rs
@@ -22,7 +22,7 @@ use std::marker::PhantomData;
 const UNINITIALIZED_WATER_MARK: i32 = -1;
 
 pub struct CommonFreeListPageResource {
-    free_list: Box<<VMMap as Map>::FreeList>,
+    pub(crate) free_list: Box<<VMMap as Map>::FreeList>,
     start: Address,
 }
 

--- a/src/util/heap/layout/map.rs
+++ b/src/util/heap/layout/map.rs
@@ -10,14 +10,22 @@ pub trait Map: Sized {
 
     fn insert(&self, start: Address, extent: usize, descriptor: SpaceDescriptor);
 
-    fn create_freelist(&self, pr: &CommonFreeListPageResource) -> Box<Self::FreeList>;
+    /// Create a free-list for a discontiguous space. Must only be called at boot time.
+    /// bind_freelist() must be called by the caller after this method.
+    fn create_freelist(&self, start: Address) -> Box<Self::FreeList>;
 
+    /// Create a free-list for a contiguous space. Must only be called at boot time.
+    /// bind_freelist() must be called by the caller after this method.
     fn create_parent_freelist(
         &self,
-        pr: &CommonFreeListPageResource,
+        start: Address,
         units: usize,
         grain: i32,
     ) -> Box<Self::FreeList>;
+
+    /// Bind a created freelist with the page resource.
+    /// This must called after create_freelist() or create_parent_freelist().
+    fn bind_freelist(&self, pr: &'static CommonFreeListPageResource);
 
     fn allocate_contiguous_chunks(
         &self,

--- a/src/util/heap/layout/map.rs
+++ b/src/util/heap/layout/map.rs
@@ -58,8 +58,6 @@ pub trait Map: Sized {
 
     fn is_finalized(&self) -> bool;
 
-    fn get_discontig_freelist_pr_ordinal(&self, pr: &CommonFreeListPageResource) -> usize;
-
     fn get_descriptor_for_address(&self, address: Address) -> SpaceDescriptor;
 
     fn add_to_cumulative_committed_pages(&self, pages: usize);

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -89,7 +89,7 @@ impl Map for Map32 {
     }
 
     fn bind_freelist(&self, pr: &'static CommonFreeListPageResource) {
-        let ordinal = pr.free_list.get_ordinal();
+        let ordinal: usize = pr.free_list.get_ordinal() as usize;
         let self_mut: &mut Self = unsafe { self.mut_self() };
         self_mut.shared_fl_map[ordinal] = Some(pr);
     }
@@ -239,13 +239,6 @@ impl Map for Map32 {
         self.finalized
     }
 
-    fn get_discontig_freelist_pr_ordinal(&self) -> usize {
-        // This is only called during creating a page resource/space/plan/mmtk instance, which is single threaded.
-        let self_mut: &mut Self = unsafe { self.mut_self() };
-        self_mut.shared_discontig_fl_count += 1;
-        self.shared_discontig_fl_count
-    }
-
     fn get_descriptor_for_address(&self, address: Address) -> SpaceDescriptor {
         let index = address.chunk_index();
         self.descriptor_map[index]
@@ -295,6 +288,13 @@ impl Map32 {
             unsafe { SFT_MAP.clear(chunk_start) };
         }
         chunks as _
+    }
+
+    fn get_discontig_freelist_pr_ordinal(&self) -> usize {
+        // This is only called during creating a page resource/space/plan/mmtk instance, which is single threaded.
+        let self_mut: &mut Self = unsafe { self.mut_self() };
+        self_mut.shared_discontig_fl_count += 1;
+        self.shared_discontig_fl_count
     }
 }
 

--- a/src/util/heap/layout/map64.rs
+++ b/src/util/heap/layout/map64.rs
@@ -202,10 +202,6 @@ impl Map for Map64 {
         self.finalized
     }
 
-    fn get_discontig_freelist_pr_ordinal(&self, _pr: &CommonFreeListPageResource) -> usize {
-        unreachable!()
-    }
-
     #[inline]
     fn get_descriptor_for_address(&self, address: Address) -> SpaceDescriptor {
         let index = Self::space_index(address).unwrap();

--- a/src/util/int_array_freelist.rs
+++ b/src/util/int_array_freelist.rs
@@ -48,6 +48,9 @@ impl IntArrayFreeList {
         debug_assert!(-iafl.head <= iafl.heads);
         iafl
     }
+    pub(crate) fn get_ordinal(&self) -> i32 {
+        -self.head - 1
+    }
     fn table(&self) -> &Vec<i32> {
         match self.parent {
             Some(p) => p.table(),


### PR DESCRIPTION
This PR removes the circular dependency between `CommonFreeListPageResource` and `VMMap`. With this PR, we do not need to use unsafe code to deal with the circular dependency. This PR fixes https://github.com/mmtk/mmtk-core/issues/691.

Changes:
* `create_freelist()` and `create_parent_freelist()` in `Map` no longer requires a parameter for `CommonFreeListPageResource`.
* `bind_freelist()` is added to `Map`, which needs to be called after a freelist is created by the two methods above.