### PR TITLE
Checking if the referent has been cleared

### DIFF
--- a/src/util/reference_processor.rs
+++ b/src/util/reference_processor.rs
@@ -250,7 +250,7 @@ impl ReferenceProcessor {
                 debug_assert!(!reff.is_null());
                 debug_assert!(reff.is_in_any_space());
                 let referent = VM::VMReferenceGlue::get_referent(*reff);
-                if !referent.is_null() {
+                if !VM::VMReferenceGlue::is_referent_cleared(referent) {
                     debug_assert!(
                         referent.is_in_any_space(),
                         "Referent {:?} (of reference {:?}) is not in any space",
@@ -264,7 +264,7 @@ impl ReferenceProcessor {
                 debug_assert!(!reff.is_null());
                 debug_assert!(reff.is_in_any_space());
                 let referent = VM::VMReferenceGlue::get_referent(*reff);
-                debug_assert!(referent.is_null());
+                debug_assert!(VM::VMReferenceGlue::is_referent_cleared(referent));
             });
         }
 
@@ -402,7 +402,7 @@ impl ReferenceProcessor {
 
             // Reference is definitely reachable.  Retain the referent.
             let referent = <E::VM as VMBinding>::VMReferenceGlue::get_referent(*reference);
-            if !referent.is_null() {
+            if !<E::VM as VMBinding>::VMReferenceGlue::is_referent_cleared(referent) {
                 Self::keep_referent_alive(trace, referent);
             }
             trace!(" ~> {:?} (retained)", referent.to_address());
@@ -446,8 +446,8 @@ impl ReferenceProcessor {
         // this does not cause the Reference object to be enqueued. We
         // simply allow the Reference object to fall out of our
         // waiting list.
-        if old_referent.is_null() {
-            trace!(" (null referent) ");
+        if <E::VM as VMBinding>::VMReferenceGlue::is_referent_cleared(old_referent) {
+            trace!(" (cleared referent) ");
             return None;
         }
 

--- a/src/vm/reference_glue.rs
+++ b/src/vm/reference_glue.rs
@@ -43,6 +43,14 @@ pub trait ReferenceGlue<VM: VMBinding> {
     /// * `referent`: The referent object reference.
     fn set_referent(reff: ObjectReference, referent: ObjectReference);
 
+     /// Check if the referent has been cleared.
+     ///
+     /// Arguments:
+     /// * `referent`: The referent object reference.
+     fn is_referent_cleared(referent: ObjectReference) -> bool {
+        referent.is_null()
+    }
+
     /// For weak reference types, if the referent is cleared during GC, the reference
     /// will be added to a queue, and MMTk will call this method to inform
     /// the VM about the changes for those references. This method is used

--- a/src/vm/reference_glue.rs
+++ b/src/vm/reference_glue.rs
@@ -43,11 +43,11 @@ pub trait ReferenceGlue<VM: VMBinding> {
     /// * `referent`: The referent object reference.
     fn set_referent(reff: ObjectReference, referent: ObjectReference);
 
-     /// Check if the referent has been cleared.
-     ///
-     /// Arguments:
-     /// * `referent`: The referent object reference.
-     fn is_referent_cleared(referent: ObjectReference) -> bool {
+    /// Check if the referent has been cleared.
+    ///
+    /// Arguments:
+    /// * `referent`: The referent object reference.
+    fn is_referent_cleared(referent: ObjectReference) -> bool {
         referent.is_null()
     }
 


### PR DESCRIPTION
In Julia referents are set to `jl_nothing` instead of `null` to indicate that a reference has been cleared. 
I have added a default method to the ReferenceGlue trait and replaced the checks in mmtk-core to call this method instead. Therefore, bindings can overwrite the method `is_referent_cleared` to do the check properly.