### PR TITLE
Change LAST_CLOSURE_BUCKET to FIRST_REF_CLOSURE_BUCKET

### DIFF
--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -92,12 +92,12 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                         move |scheduler: &GCWorkScheduler<VM>| {
                             let should_open = scheduler.are_buckets_drained(&cur_stages);
                             // Additional check before the `RefClosure` bucket opens.
-                            if should_open && stage == LAST_CLOSURE_BUCKET {
+                            if should_open && stage == FIRST_REF_CLOSURE_BUCKET {
                                 if let Some(closure_end) =
                                     scheduler.closure_end.lock().unwrap().as_ref()
                                 {
                                     if closure_end() {
-                                        // Don't open `LAST_CLOSURE_BUCKET` if `closure_end` added more works to `Closure`.
+                                        // Don't open `FIRST_REF_CLOSURE_BUCKET` if `closure_end` added more works to `Closure`.
                                         return false;
                                     }
                                 }

--- a/src/scheduler/work_bucket.rs
+++ b/src/scheduler/work_bucket.rs
@@ -229,4 +229,6 @@ impl WorkBucketStage {
     }
 }
 
-pub const LAST_CLOSURE_BUCKET: WorkBucketStage = WorkBucketStage::PhantomRefClosure;
+/// This constant tracks the first ref closure bucket. We allow bindings to implement their own
+/// weak reference processing before this bucket is opened and before MMTk's weak reference processing.
+pub const FIRST_REF_CLOSURE_BUCKET: WorkBucketStage = WorkBucketStage::SoftRefClosure;


### PR DESCRIPTION
This PR fixes a bug that was introduced in https://github.com/mmtk/mmtk-core/pull/564. See the discussion here: https://github.com/mmtk/mmtk-core/pull/564. In short, we should allow the bindings to do their own weak reference processing after we finish the normal transitive closure and before we start our weak reference processing.