### PR TITLE
Turn `SFTMap` into trait object

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -659,7 +659,6 @@ pub fn is_mmtk_object(addr: Address) -> bool {
 /// * `object`: The object reference to query.
 pub fn is_in_mmtk_spaces<VM: VMBinding>(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
-    use crate::policy::sft_map::SFTMap;
     if object.is_null() {
         return false;
     }

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -625,7 +625,6 @@ pub fn is_live_object(object: ObjectReference) -> bool {
 #[cfg(feature = "is_mmtk_object")]
 pub fn is_mmtk_object(addr: Address) -> bool {
     use crate::mmtk::SFT_MAP;
-    use crate::policy::sft_map::SFTMap;
     SFT_MAP.get_checked(addr).is_mmtk_object(addr)
 }
 
@@ -770,7 +769,6 @@ pub fn add_finalizer<VM: VMBinding>(
 #[cfg(feature = "object_pinning")]
 pub fn pin_object<VM: VMBinding>(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
-    use crate::policy::sft_map::SFTMap;
     SFT_MAP
         .get_checked(object.to_address::<VM>())
         .pin_object(object)
@@ -785,7 +783,6 @@ pub fn pin_object<VM: VMBinding>(object: ObjectReference) -> bool {
 #[cfg(feature = "object_pinning")]
 pub fn unpin_object<VM: VMBinding>(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
-    use crate::policy::sft_map::SFTMap;
     SFT_MAP
         .get_checked(object.to_address::<VM>())
         .unpin_object(object)
@@ -798,7 +795,6 @@ pub fn unpin_object<VM: VMBinding>(object: ObjectReference) -> bool {
 #[cfg(feature = "object_pinning")]
 pub fn is_pinned<VM: VMBinding>(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
-    use crate::policy::sft_map::SFTMap;
     SFT_MAP
         .get_checked(object.to_address::<VM>())
         .is_object_pinned(object)

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -1,6 +1,6 @@
 ///! MMTk instance.
 use crate::plan::Plan;
-use crate::policy::sft_map::SFTMapType;
+use crate::policy::sft_map::{create_sft_map, SFTMap};
 use crate::scheduler::GCWorkScheduler;
 
 #[cfg(feature = "extreme_assertions")]
@@ -40,7 +40,7 @@ lazy_static! {
 use crate::util::rust_util::InitializeOnce;
 
 // A global space function table that allows efficient dispatch space specific code for addresses in our heap.
-pub static SFT_MAP: InitializeOnce<SFTMapType<'static>> = InitializeOnce::new();
+pub static SFT_MAP: InitializeOnce<Box<dyn SFTMap>> = InitializeOnce::new();
 
 // MMTk builder. This is used to set options before actually creating an MMTk instance.
 pub struct MMTKBuilder {
@@ -99,7 +99,7 @@ impl<VM: VMBinding> MMTK<VM> {
     pub fn new(options: Arc<Options>) -> Self {
         // Initialize SFT first in case we need to use this in the constructor.
         // The first call will initialize SFT map. Other calls will be blocked until SFT map is initialized.
-        SFT_MAP.initialize_once(&SFTMapType::new);
+        SFT_MAP.initialize_once(&create_sft_map);
 
         let num_workers = if cfg!(feature = "single_worker") {
             1

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -6,7 +6,6 @@ use crate::util::heap::PageResource;
 use crate::util::ObjectReference;
 
 use crate::policy::sft::GCWorkerMutRef;
-use crate::policy::sft_map::SFTMap;
 use crate::util::conversions;
 use crate::util::heap::layout::vm_layout_constants::{AVAILABLE_BYTES, AVAILABLE_START};
 use crate::util::metadata::side_metadata::SideMetadataSanity;

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -350,7 +350,6 @@ impl<VM: VMBinding> MallocSpace<VM> {
 
             // If the side metadata for the address has not yet been mapped, we will map all the side metadata for the range [address, address + actual_size).
             if !is_meta_space_mapped(address, actual_size) {
-                use crate::policy::sft_map::SFTMap;
                 // Map the metadata space for the associated chunk
                 self.map_metadata_and_update_bound(address, actual_size);
                 // Update SFT
@@ -531,7 +530,6 @@ impl<VM: VMBinding> MallocSpace<VM> {
 
     /// Clean up for an empty chunk
     fn clean_up_empty_chunk(&self, chunk_start: Address) {
-        use crate::policy::sft_map::SFTMap;
         // Since the chunk mark metadata is a byte, we don't need synchronization
         unsafe { unset_chunk_mark_unsafe(chunk_start) };
         // Clear the SFT entry

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -16,7 +16,6 @@ use crate::mmtk::SFT_MAP;
 #[cfg(debug_assertions)]
 use crate::policy::sft::EMPTY_SFT_NAME;
 use crate::policy::sft::SFT;
-use crate::policy::sft_map::SFTMap;
 use crate::util::copy::*;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -516,7 +516,6 @@ impl<VM: VMBinding> ProcessEdgesWork for SFTProcessEdges<VM> {
     #[inline]
     fn trace_object(&mut self, object: ObjectReference) -> ObjectReference {
         use crate::policy::sft::GCWorkerMutRef;
-        use crate::policy::sft_map::SFTMap;
 
         if object.is_null() {
             return object;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -5,7 +5,6 @@ use std::ops::*;
 use std::sync::atomic::Ordering;
 
 use crate::mmtk::{MMAPPER, SFT_MAP};
-use crate::policy::sft_map::SFTMap;
 use crate::util::heap::layout::mmapper::Mmapper;
 
 /// size in bytes

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -1,6 +1,5 @@
 use super::map::Map;
 use crate::mmtk::SFT_MAP;
-use crate::policy::sft_map::SFTMap;
 use crate::util::conversions;
 use crate::util::generic_freelist::GenericFreeList;
 use crate::util::heap::freelistpageresource::CommonFreeListPageResource;

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -832,12 +832,9 @@ impl SideMetadataContext {
         #[cfg(feature = "global_alloc_bit")]
         ret.push(ALLOC_SIDE_METADATA_SPEC);
 
-        {
-            use crate::policy::sft_map::SFTMap;
-            if let Some(spec) = crate::mmtk::SFT_MAP.get_side_metadata() {
-                if spec.is_global {
-                    ret.push(*spec);
-                }
+        if let Some(spec) = crate::mmtk::SFT_MAP.get_side_metadata() {
+            if spec.is_global {
+                ret.push(*spec);
             }
         }
 


### PR DESCRIPTION

This PR makes MMTk use `dyn SFTMap` instead of defining multiple `type SFTMapType<'a>` based on compiler flags.

This is part of the necessary refactoring to make MMTk able to select address space at runtime. For 35-bit address space (pointer compression), MMTk should use `SFTSparseChunkMap` instead of `SFTSpaceMap`.

## Performance:

Dynamic dispatch on `dyn SFTMap` will be slower than static dispatch. But in practice, no performance drop is observed:

http://squirrel.anu.edu.au/plotty-public/wenyuz/v8/p/DkTpwP