### PR TITLE
Allow different GC triggers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ strum = "0.24"
 strum_macros = "0.24"
 cfg-if = "1.0"
 itertools = "0.10.5"
+sys-info = "0.9"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ strum_macros = "0.24"
 cfg-if = "1.0"
 itertools = "0.10.5"
 sys-info = "0.9"
+regex = "1.7.0"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/docs/tutorial/code/mygc_semispace/global.rs
+++ b/docs/tutorial/code/mygc_semispace/global.rs
@@ -2,6 +2,7 @@
 use crate::plan::global::BasePlan; //Modify
 use crate::plan::global::CommonPlan; // Add
 use crate::plan::global::GcStatus; // Add
+use crate::plan::global::{CreateGeneralPlanArgs, CreateSpecificPlanArgs};
 use crate::plan::mygc::mutator::ALLOCATOR_MAPPING;
 use crate::plan::mygc::gc_work::MyGCWorkContext;
 use crate::plan::AllocationSemantics;
@@ -171,40 +172,21 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
 // Add
 impl<VM: VMBinding> MyGC<VM> {
     // ANCHOR: plan_new
-    fn new(
-        vm_map: &'static VMMap,
-        mmapper: &'static Mmapper,
-        options: Arc<Options>,
-    ) -> Self {
+    fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
         // Modify
-        let mut heap = HeapMeta::new(&options);
-        let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
+        let mut plan_args = CreateSpecificPlanArgs {
+            global_args: args,
+            constraints: &MYGC_CONSTRAINTS,
+            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
+        };
 
         let res = MyGC {
             hi: AtomicBool::new(false),
             // ANCHOR: copyspace_new
-            copyspace0: CopySpace::new(
-                "copyspace0",
-                false,
-                true,
-                VMRequest::discontiguous(),
-                global_metadata_specs.clone(),
-                vm_map,
-                mmapper,
-                &mut heap,
-            ),
+            copyspace0: CopySpace::new(plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()), false),
             // ANCHOR_END: copyspace_new
-            copyspace1: CopySpace::new(
-                "copyspace1",
-                true,
-                true,
-                VMRequest::discontiguous(),
-                global_metadata_specs.clone(),
-                vm_map,
-                mmapper,
-                &mut heap,
-            ),
-            common: CommonPlan::new(vm_map, mmapper, options, heap, &MYGC_CONSTRAINTS, global_metadata_specs.clone()),
+            copyspace1: CopySpace::new(plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()), true),
+            common: CommonPlan::new(plan_args),
         };
 
         // Use SideMetadataSanity to check if each spec is valid. This is also needed for check

--- a/docs/tutorial/src/mygc/create.md
+++ b/docs/tutorial/src/mygc/create.md
@@ -71,17 +71,13 @@ files.
             options: Arc<UnsafeOptionsWrapper>,
         ) -> Box<dyn Plan<VM = VM>> {
             match plan {
-                PlanSelector::NoGC => Box::new(crate::plan::nogc::NoGC::new(vm_map, mmapper, options)),
-                PlanSelector::SemiSpace => Box::new(crate::plan::semispace::SemiSpace::new(
-                    vm_map, mmapper, options,
-                )),
+                PlanSelector::NoGC => Box::new(crate::plan::nogc::NoGC::new(args)),
+                PlanSelector::SemiSpace => Box::new(crate::plan::semispace::SemiSpace::new(args)),
 
                 // ...
 
                 // Create MyGC plan based on selector
-                PlanSelector::MyGC => Box::new(crate::plan::mygc::MyGC::new(
-                    vm_map, mmapper, options,
-                ))
+                PlanSelector::MyGC => Box::new(crate::plan::mygc::MyGC::new(args))
             }
         }       
         ```

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -416,7 +416,7 @@ pub fn gc_poll<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMMutatorThread) {
     );
 
     let plan = mmtk.get_plan();
-    if plan.should_trigger_gc_when_heap_is_full() && plan.poll(false, None) {
+    if plan.should_trigger_gc_when_heap_is_full() && plan.base().gc_trigger.poll(false, None) {
         debug!("Collection required");
         assert!(plan.is_initialized(), "GC is not allowed here: collection is not initialized (did you call initialize_collection()?).");
         VM::VMCollection::block_for_gc(tls);

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -4,8 +4,8 @@ use super::mutator::ALLOCATOR_MAPPING;
 use crate::plan::generational::global::Gen;
 use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -15,17 +15,12 @@ use crate::policy::space::Space;
 use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataSanity;
-use crate::util::options::Options;
 use crate::util::VMWorkerThread;
 use crate::vm::*;
 use enum_map::EnumMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
 use mmtk_macros::PlanTraceObject;
 
@@ -181,11 +176,18 @@ impl<VM: VMBinding> GenCopy<VM> {
         let mut common_plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &GENCOPY_CONSTRAINTS,
-            global_side_metadata_specs: crate::plan::generational::new_generational_global_metadata_specs::<VM>()
+            global_side_metadata_specs:
+                crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
         };
 
-        let copyspace0 = CopySpace::new(common_plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()), false);
-        let copyspace1 = CopySpace::new(common_plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()), true);
+        let copyspace0 = CopySpace::new(
+            common_plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
+            false,
+        );
+        let copyspace1 = CopySpace::new(
+            common_plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
+            true,
+        );
 
         let res = GenCopy {
             gen: Gen::new(common_plan_args),

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -173,7 +173,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
 
 impl<VM: VMBinding> GenCopy<VM> {
     pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &GENCOPY_CONSTRAINTS,
             global_side_metadata_specs:
@@ -181,16 +181,16 @@ impl<VM: VMBinding> GenCopy<VM> {
         };
 
         let copyspace0 = CopySpace::new(
-            common_plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
+            plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
             false,
         );
         let copyspace1 = CopySpace::new(
-            common_plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
+            plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
             true,
         );
 
         let res = GenCopy {
-            gen: Gen::new(common_plan_args),
+            gen: Gen::new(plan_args),
             hi: AtomicBool::new(false),
             copyspace0,
             copyspace1,

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -1,20 +1,14 @@
 use crate::plan::global::CommonPlan;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::ObjectQueue;
 use crate::plan::Plan;
-use crate::plan::PlanConstraints;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
 use crate::scheduler::*;
 use crate::util::conversions;
 use crate::util::copy::CopySemantics;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataSanity;
-use crate::util::metadata::side_metadata::SideMetadataSpec;
-use crate::util::options::Options;
 use crate::util::statistics::counter::EventCounter;
 use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
@@ -44,7 +38,14 @@ pub struct Gen<VM: VMBinding> {
 
 impl<VM: VMBinding> Gen<VM> {
     pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> Self {
-        let nursery = CopySpace::new(args.get_space_args("nursery", true, VMRequest::fixed_extent(args.global_args.options.get_max_nursery(), false)), true);
+        let nursery = CopySpace::new(
+            args.get_space_args(
+                "nursery",
+                true,
+                VMRequest::fixed_extent(args.global_args.options.get_max_nursery(), false),
+            ),
+            true,
+        );
         let common = CommonPlan::new(args);
 
         let full_heap_gc_count = common.base.stats.new_event_counter("majorGC", true, true);

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -2,6 +2,7 @@ use crate::plan::global::CommonPlan;
 use crate::plan::ObjectQueue;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
 use crate::scheduler::*;
@@ -42,32 +43,9 @@ pub struct Gen<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> Gen<VM> {
-    pub fn new(
-        mut heap: HeapMeta,
-        global_metadata_specs: Vec<SideMetadataSpec>,
-        constraints: &'static PlanConstraints,
-        vm_map: &'static VMMap,
-        mmapper: &'static Mmapper,
-        options: Arc<Options>,
-    ) -> Self {
-        let nursery = CopySpace::new(
-            "nursery",
-            false,
-            true,
-            VMRequest::fixed_extent(options.get_max_nursery(), false),
-            global_metadata_specs.clone(),
-            vm_map,
-            mmapper,
-            &mut heap,
-        );
-        let common = CommonPlan::new(
-            vm_map,
-            mmapper,
-            options,
-            heap,
-            constraints,
-            global_metadata_specs,
-        );
+    pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> Self {
+        let nursery = CopySpace::new(args.get_space_args("nursery", true, VMRequest::fixed_extent(args.global_args.options.get_max_nursery(), false)), true);
+        let common = CommonPlan::new(args);
 
         let full_heap_gc_count = common.base.stats.new_event_counter("majorGC", true, true);
 

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -215,20 +215,20 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
 
 impl<VM: VMBinding> GenImmix<VM> {
     pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &GENIMMIX_CONSTRAINTS,
             global_side_metadata_specs:
                 crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
         };
-        let immix_space = ImmixSpace::new(common_plan_args.get_space_args(
+        let immix_space = ImmixSpace::new(plan_args.get_space_args(
             "immix_mature",
             true,
             VMRequest::discontiguous(),
         ));
 
         let genimmix = GenImmix {
-            gen: Gen::new(common_plan_args),
+            gen: Gen::new(plan_args),
             immix: immix_space,
             last_gc_was_defrag: AtomicBool::new(false),
             last_gc_was_full_heap: AtomicBool::new(false),

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -3,6 +3,8 @@ use super::gc_work::GenImmixNurseryGCWorkContext;
 use crate::plan::generational::global::Gen;
 use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
+use crate::plan::global::CreateSpecificPlanArgs;
+use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -13,6 +15,7 @@ use crate::policy::space::Space;
 use crate::scheduler::GCWorkScheduler;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
+use crate::util::heap::VMRequest;
 use crate::util::heap::layout::heap_layout::Mmapper;
 use crate::util::heap::layout::heap_layout::VMMap;
 use crate::util::heap::HeapMeta;
@@ -216,34 +219,16 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
 }
 
 impl<VM: VMBinding> GenImmix<VM> {
-    pub fn new(
-        vm_map: &'static VMMap,
-        mmapper: &'static Mmapper,
-        options: Arc<Options>,
-        scheduler: Arc<GCWorkScheduler<VM>>,
-    ) -> Self {
-        let mut heap = HeapMeta::new(&options);
-        // We have no specific side metadata for copying. So just use the ones from generational.
-        let global_metadata_specs =
-            crate::plan::generational::new_generational_global_metadata_specs::<VM>();
-        let immix_space = ImmixSpace::new(
-            "immix_mature",
-            vm_map,
-            mmapper,
-            &mut heap,
-            scheduler,
-            global_metadata_specs.clone(),
-        );
+    pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
+        let mut common_plan_args = CreateSpecificPlanArgs {
+            global_args: args,
+            constraints: &GENIMMIX_CONSTRAINTS,
+            global_side_metadata_specs: crate::plan::generational::new_generational_global_metadata_specs::<VM>()
+        };
+        let immix_space = ImmixSpace::new(common_plan_args.get_space_args("immix_mature", true, VMRequest::discontiguous()));
 
         let genimmix = GenImmix {
-            gen: Gen::new(
-                heap,
-                global_metadata_specs,
-                &GENIMMIX_CONSTRAINTS,
-                vm_map,
-                mmapper,
-                options,
-            ),
+            gen: Gen::new(common_plan_args),
             immix: immix_space,
             last_gc_was_defrag: AtomicBool::new(false),
             last_gc_was_full_heap: AtomicBool::new(false),

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -3,8 +3,8 @@ use super::gc_work::GenImmixNurseryGCWorkContext;
 use crate::plan::generational::global::Gen;
 use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -16,17 +16,12 @@ use crate::scheduler::GCWorkScheduler;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::VMRequest;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
-use crate::util::options::Options;
 use crate::util::VMWorkerThread;
 use crate::vm::*;
 
 use enum_map::EnumMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
 use mmtk_macros::PlanTraceObject;
 
@@ -223,9 +218,14 @@ impl<VM: VMBinding> GenImmix<VM> {
         let mut common_plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &GENIMMIX_CONSTRAINTS,
-            global_side_metadata_specs: crate::plan::generational::new_generational_global_metadata_specs::<VM>()
+            global_side_metadata_specs:
+                crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
         };
-        let immix_space = ImmixSpace::new(common_plan_args.get_space_args("immix_mature", true, VMRequest::discontiguous()));
+        let immix_space = ImmixSpace::new(common_plan_args.get_space_args(
+            "immix_mature",
+            true,
+            VMRequest::discontiguous(),
+        ));
 
         let genimmix = GenImmix {
             gen: Gen::new(common_plan_args),

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -259,13 +259,13 @@ pub trait Plan: 'static + Sync + Downcast {
     //     false
     // }
 
-    fn log_poll(&self, space: Option<&dyn Space<Self::VM>>, message: &'static str) {
-        if let Some(space) = space {
-            info!("  [POLL] {}: {}", space.get_name(), message);
-        } else {
-            info!("  [POLL] {}", message);
-        }
-    }
+    // fn log_poll(&self, space: Option<&dyn Space<Self::VM>>, message: &'static str) {
+    //     if let Some(space) = space {
+    //         info!("  [POLL] {}: {}", space.get_name(), message);
+    //     } else {
+    //         info!("  [POLL] {}", message);
+    //     }
+    // }
 
     /**
      * This method controls the triggering of a GC. It is called periodically

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -289,7 +289,7 @@ pub trait Plan: 'static + Sync + Downcast {
 
     /// Get the total number of pages for the heap.
     fn get_total_pages(&self) -> usize {
-        self.base().gc_trigger.get_total_pages()
+        self.base().gc_trigger.policy.get_heap_size_in_pages()
     }
 
     /// Get the number of pages that are still available for use. The available pages

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -677,7 +677,8 @@ impl<VM: VMBinding> BasePlan<VM> {
 
         let emergency_collection = !self.is_internal_triggered_collection()
             && plan.last_collection_was_exhaustive()
-            && self.cur_collection_attempts.load(Ordering::Relaxed) > 1;
+            && self.cur_collection_attempts.load(Ordering::Relaxed) > 1
+            && !self.gc_trigger.policy.can_heap_size_grow();
         self.emergency_collection
             .store(emergency_collection, Ordering::Relaxed);
 

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -133,18 +133,18 @@ impl<VM: VMBinding> Plan for Immix<VM> {
 
 impl<VM: VMBinding> Immix<VM> {
     pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &IMMIX_CONSTRAINTS,
             global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
         };
         let immix = Immix {
-            immix_space: ImmixSpace::new(common_plan_args.get_space_args(
+            immix_space: ImmixSpace::new(plan_args.get_space_args(
                 "immix",
                 true,
                 VMRequest::discontiguous(),
             )),
-            common: CommonPlan::new(common_plan_args),
+            common: CommonPlan::new(plan_args),
             last_gc_was_defrag: AtomicBool::new(false),
         };
 

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -2,8 +2,8 @@ use super::gc_work::ImmixGCWorkContext;
 use super::mutator::ALLOCATOR_MAPPING;
 use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -14,16 +14,11 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::VMRequest;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::metadata::side_metadata::SideMetadataSanity;
-use crate::util::options::Options;
 use crate::vm::VMBinding;
 use crate::{policy::immix::ImmixSpace, util::opaque_pointer::VMWorkerThread};
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
 use atomic::Ordering;
 use enum_map::EnumMap;
@@ -144,7 +139,11 @@ impl<VM: VMBinding> Immix<VM> {
             global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
         };
         let immix = Immix {
-            immix_space: ImmixSpace::new(common_plan_args.get_space_args("immix", true, VMRequest::discontiguous())),
+            immix_space: ImmixSpace::new(common_plan_args.get_space_args(
+                "immix",
+                true,
+                VMRequest::discontiguous(),
+            )),
             common: CommonPlan::new(common_plan_args),
             last_gc_was_defrag: AtomicBool::new(false),
         };

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -3,9 +3,9 @@ use super::gc_work::{
     CalculateForwardingAddress, Compact, ForwardingProcessEdges, MarkingProcessEdges,
     UpdateReferences,
 };
-use crate::plan::global::{BasePlan, CreateGeneralPlanArgs, CreateSpecificPlanArgs};
 use crate::plan::global::CommonPlan;
 use crate::plan::global::GcStatus;
+use crate::plan::global::{BasePlan, CreateGeneralPlanArgs, CreateSpecificPlanArgs};
 use crate::plan::markcompact::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -18,17 +18,12 @@ use crate::util::alloc::allocators::AllocatorSelector;
 #[cfg(not(feature = "global_alloc_bit"))]
 use crate::util::alloc_bit::ALLOC_SIDE_METADATA_SPEC;
 use crate::util::copy::CopySemantics;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
 use crate::util::opaque_pointer::*;
-use crate::util::options::Options;
 use crate::vm::VMBinding;
 
 use enum_map::EnumMap;
-use std::sync::Arc;
 
 use mmtk_macros::PlanTraceObject;
 
@@ -194,7 +189,11 @@ impl<VM: VMBinding> MarkCompact<VM> {
             global_side_metadata_specs,
         };
 
-        let mc_space = MarkCompactSpace::new(common_plan_args.get_space_args("mc", true, VMRequest::discontiguous()));
+        let mc_space = MarkCompactSpace::new(common_plan_args.get_space_args(
+            "mc",
+            true,
+            VMRequest::discontiguous(),
+        ));
 
         let res = MarkCompact {
             mc_space,

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -183,21 +183,18 @@ impl<VM: VMBinding> MarkCompact<VM> {
         let global_side_metadata_specs =
             SideMetadataContext::new_global_specs(&[ALLOC_SIDE_METADATA_SPEC]);
 
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &MARKCOMPACT_CONSTRAINTS,
             global_side_metadata_specs,
         };
 
-        let mc_space = MarkCompactSpace::new(common_plan_args.get_space_args(
-            "mc",
-            true,
-            VMRequest::discontiguous(),
-        ));
+        let mc_space =
+            MarkCompactSpace::new(plan_args.get_space_args("mc", true, VMRequest::discontiguous()));
 
         let res = MarkCompact {
             mc_space,
-            common: CommonPlan::new(common_plan_args),
+            common: CommonPlan::new(plan_args),
         };
 
         // Use SideMetadataSanity to check if each spec is valid. This is also needed for check

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -1,7 +1,7 @@
 use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::marksweep::gc_work::MSGCWorkContext;
 use crate::plan::marksweep::mutator::ALLOCATOR_MAPPING;
@@ -11,17 +11,12 @@ use crate::plan::PlanConstraints;
 use crate::policy::space::Space;
 use crate::scheduler::GCWorkScheduler;
 use crate::util::alloc::allocators::AllocatorSelector;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
-use crate::util::options::Options;
 use crate::util::VMWorkerThread;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
 use mmtk_macros::PlanTraceObject;
-use std::sync::Arc;
 
 #[cfg(feature = "malloc_mark_sweep")]
 pub type MarkSweepSpace<VM> = crate::policy::marksweepspace::malloc_ms::MallocSpace<VM>;
@@ -113,7 +108,11 @@ impl<VM: VMBinding> MarkSweep<VM> {
         };
 
         let res = MarkSweep {
-            ms: MarkSweepSpace::new(common_plan_args.get_space_args("ms", true, VMRequest::discontiguous())),
+            ms: MarkSweepSpace::new(common_plan_args.get_space_args(
+                "ms",
+                true,
+                VMRequest::discontiguous(),
+            )),
             common: CommonPlan::new(common_plan_args),
         };
 

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -101,19 +101,19 @@ impl<VM: VMBinding> MarkSweep<VM> {
         let mut global_side_metadata_specs = SideMetadataContext::new_global_specs(&[]);
         MarkSweepSpace::<VM>::extend_global_side_metadata_specs(&mut global_side_metadata_specs);
 
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &MS_CONSTRAINTS,
             global_side_metadata_specs,
         };
 
         let res = MarkSweep {
-            ms: MarkSweepSpace::new(common_plan_args.get_space_args(
+            ms: MarkSweepSpace::new(plan_args.get_space_args(
                 "ms",
                 true,
                 VMRequest::discontiguous(),
             )),
-            common: CommonPlan::new(common_plan_args),
+            common: CommonPlan::new(plan_args),
         };
 
         let mut side_metadata_sanity_checker = SideMetadataSanity::new();

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -83,29 +83,29 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
 
 impl<VM: VMBinding> NoGC<VM> {
     pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &NOGC_CONSTRAINTS,
             global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
         };
 
         let res = NoGC {
-            nogc_space: NoGCImmortalSpace::new(common_plan_args.get_space_args(
+            nogc_space: NoGCImmortalSpace::new(plan_args.get_space_args(
                 "nogc_space",
                 cfg!(not(feature = "nogc_no_zeroing")),
                 VMRequest::discontiguous(),
             )),
-            immortal: ImmortalSpace::new(common_plan_args.get_space_args(
+            immortal: ImmortalSpace::new(plan_args.get_space_args(
                 "immortal",
                 true,
                 VMRequest::discontiguous(),
             )),
-            los: ImmortalSpace::new(common_plan_args.get_space_args(
+            los: ImmortalSpace::new(plan_args.get_space_args(
                 "los",
                 true,
                 VMRequest::discontiguous(),
             )),
-            base: BasePlan::new(common_plan_args),
+            base: BasePlan::new(plan_args),
         };
 
         // Use SideMetadataSanity to check if each spec is valid. This is also needed for check

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -1,6 +1,6 @@
 use crate::plan::global::BasePlan;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::nogc::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -9,17 +9,12 @@ use crate::policy::immortalspace::ImmortalSpace;
 use crate::policy::space::Space;
 use crate::scheduler::GCWorkScheduler;
 use crate::util::alloc::allocators::AllocatorSelector;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 #[allow(unused_imports)]
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
 use crate::util::opaque_pointer::*;
-use crate::util::options::Options;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
-use std::sync::Arc;
 
 #[cfg(not(feature = "nogc_lock_free"))]
 use crate::policy::immortalspace::ImmortalSpace as NoGCImmortalSpace;
@@ -91,13 +86,25 @@ impl<VM: VMBinding> NoGC<VM> {
         let mut common_plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &NOGC_CONSTRAINTS,
-            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[])
+            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
         };
 
         let res = NoGC {
-            nogc_space: NoGCImmortalSpace::new(common_plan_args.get_space_args("nogc_space", cfg!(not(feature = "nogc_no_zeroing")), VMRequest::discontiguous())),
-            immortal: ImmortalSpace::new(common_plan_args.get_space_args("immortal", true, VMRequest::discontiguous())),
-            los: ImmortalSpace::new(common_plan_args.get_space_args("los", true, VMRequest::discontiguous())),
+            nogc_space: NoGCImmortalSpace::new(common_plan_args.get_space_args(
+                "nogc_space",
+                cfg!(not(feature = "nogc_no_zeroing")),
+                VMRequest::discontiguous(),
+            )),
+            immortal: ImmortalSpace::new(common_plan_args.get_space_args(
+                "immortal",
+                true,
+                VMRequest::discontiguous(),
+            )),
+            los: ImmortalSpace::new(common_plan_args.get_space_args(
+                "los",
+                true,
+                VMRequest::discontiguous(),
+            )),
             base: BasePlan::new(common_plan_args),
         };
 

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -96,7 +96,7 @@ impl<VM: VMBinding> PageProtect<VM> {
             }
         );
 
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &CONSTRAINTS,
             global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
@@ -104,10 +104,10 @@ impl<VM: VMBinding> PageProtect<VM> {
 
         let ret = PageProtect {
             space: LargeObjectSpace::new(
-                common_plan_args.get_space_args("pageprotect", true, VMRequest::discontiguous()),
+                plan_args.get_space_args("pageprotect", true, VMRequest::discontiguous()),
                 true,
             ),
-            common: CommonPlan::new(common_plan_args),
+            common: CommonPlan::new(plan_args),
         };
 
         // Use SideMetadataSanity to check if each spec is valid. This is also needed for check

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -1,5 +1,7 @@
 use super::gc_work::PPGCWorkContext;
 use super::mutator::ALLOCATOR_MAPPING;
+use crate::plan::global::CreateSpecificPlanArgs;
+use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -86,7 +88,7 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
 }
 
 impl<VM: VMBinding> PageProtect<VM> {
-    pub fn new(vm_map: &'static VMMap, mmapper: &'static Mmapper, options: Arc<Options>) -> Self {
+    pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
         // Warn users that the plan may fail due to maximum mapping allowed.
         warn!(
             "PageProtect uses a high volume of memory mappings. \
@@ -99,29 +101,15 @@ impl<VM: VMBinding> PageProtect<VM> {
             }
         );
 
-        let mut heap = HeapMeta::new(&options);
-        let global_metadata_specs = SideMetadataContext::new_global_specs(&[]);
+        let mut common_plan_args = CreateSpecificPlanArgs {
+            global_args: args,
+            constraints: &CONSTRAINTS,
+            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[])
+        };
 
         let ret = PageProtect {
-            space: LargeObjectSpace::new(
-                "los",
-                true,
-                VMRequest::discontiguous(),
-                global_metadata_specs.clone(),
-                vm_map,
-                mmapper,
-                &mut heap,
-                &CONSTRAINTS,
-                true,
-            ),
-            common: CommonPlan::new(
-                vm_map,
-                mmapper,
-                options,
-                heap,
-                &CONSTRAINTS,
-                global_metadata_specs,
-            ),
+            space: LargeObjectSpace::new(common_plan_args.get_space_args("pageprotect", true, VMRequest::discontiguous()), true),
+            common: CommonPlan::new(common_plan_args),
         };
 
         // Use SideMetadataSanity to check if each spec is valid. This is also needed for check

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -1,7 +1,7 @@
 use super::gc_work::PPGCWorkContext;
 use super::mutator::ALLOCATOR_MAPPING;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -9,19 +9,14 @@ use crate::plan::PlanConstraints;
 use crate::policy::space::Space;
 use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataContext;
-use crate::util::options::Options;
 use crate::{plan::global::BasePlan, vm::VMBinding};
 use crate::{
     plan::global::CommonPlan, policy::largeobjectspace::LargeObjectSpace,
     util::opaque_pointer::VMWorkerThread,
 };
 use enum_map::EnumMap;
-use std::sync::Arc;
 
 use mmtk_macros::PlanTraceObject;
 
@@ -104,11 +99,14 @@ impl<VM: VMBinding> PageProtect<VM> {
         let mut common_plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &CONSTRAINTS,
-            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[])
+            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
         };
 
         let ret = PageProtect {
-            space: LargeObjectSpace::new(common_plan_args.get_space_args("pageprotect", true, VMRequest::discontiguous()), true),
+            space: LargeObjectSpace::new(
+                common_plan_args.get_space_args("pageprotect", true, VMRequest::discontiguous()),
+                true,
+            ),
             common: CommonPlan::new(common_plan_args),
         };
 

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -1,7 +1,7 @@
 use super::gc_work::SSGCWorkContext;
 use crate::plan::global::CommonPlan;
-use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::GcStatus;
 use crate::plan::semispace::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
@@ -12,16 +12,11 @@ use crate::policy::space::Space;
 use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
 use crate::util::opaque_pointer::VMWorkerThread;
-use crate::util::options::Options;
 use crate::{plan::global::BasePlan, vm::VMBinding};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
 use mmtk_macros::PlanTraceObject;
 
@@ -137,13 +132,19 @@ impl<VM: VMBinding> SemiSpace<VM> {
         let mut common_plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &SS_CONSTRAINTS,
-            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[])
+            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
         };
 
         let res = SemiSpace {
             hi: AtomicBool::new(false),
-            copyspace0: CopySpace::new(common_plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()), false),
-            copyspace1: CopySpace::new(common_plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()), true),
+            copyspace0: CopySpace::new(
+                common_plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
+                false,
+            ),
+            copyspace1: CopySpace::new(
+                common_plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
+                true,
+            ),
             common: CommonPlan::new(common_plan_args),
         };
 

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -129,7 +129,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
 
 impl<VM: VMBinding> SemiSpace<VM> {
     pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
-        let mut common_plan_args = CreateSpecificPlanArgs {
+        let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
             constraints: &SS_CONSTRAINTS,
             global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
@@ -138,14 +138,14 @@ impl<VM: VMBinding> SemiSpace<VM> {
         let res = SemiSpace {
             hi: AtomicBool::new(false),
             copyspace0: CopySpace::new(
-                common_plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
+                plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
                 false,
             ),
             copyspace1: CopySpace::new(
-                common_plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
+                plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
                 true,
             ),
-            common: CommonPlan::new(common_plan_args),
+            common: CommonPlan::new(plan_args),
         };
 
         // Use SideMetadataSanity to check if each spec is valid. This is also needed for check

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -140,7 +140,6 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for CopySpace<
 }
 
 impl<VM: VMBinding> CopySpace<VM> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>, from_space: bool) -> Self {
         let vm_map = args.vm_map;
         let is_discontiguous = args.vmrequest.is_discontiguous();

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -6,13 +6,10 @@ use crate::policy::sft::SFT;
 use crate::policy::space::{CommonSpace, Space};
 use crate::util::copy::*;
 use crate::util::heap::chunk_map::*;
-use crate::util::heap::layout::heap_layout::{Mmapper, VMMap};
 use crate::util::heap::BlockPageResource;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::PageResource;
-use crate::util::heap::VMRequest;
 use crate::util::linear_scan::{Region, RegionIterator};
-use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSpec};
+use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::metadata::{self, MetadataSpec};
 use crate::util::object_forwarding as ForwardingWord;
 use crate::util::{Address, ObjectReference};
@@ -192,20 +189,19 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         })
     }
 
-    pub fn new(
-        args: crate::policy::space::PlanCreateSpaceArgs<VM>,
-    ) -> Self {
+    pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         #[cfg(feature = "immix_no_defrag")]
         info!(
             "Creating non-moving ImmixSpace: {}. Block size: 2^{}",
-            name,
+            args.name,
             Block::LOG_BYTES
         );
 
         super::validate_features();
         let vm_map = args.vm_map;
         let scheduler = args.scheduler.clone();
-        let common = CommonSpace::new(args.into_policy_args(true, false, Self::side_metadata_specs()));
+        let common =
+            CommonSpace::new(args.into_policy_args(true, false, Self::side_metadata_specs()));
         ImmixSpace {
             pr: if common.vmrequest.is_discontiguous() {
                 BlockPageResource::new_discontiguous(

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -3,17 +3,13 @@ use atomic::Ordering;
 use crate::policy::sft::SFT;
 use crate::policy::space::{CommonSpace, Space};
 use crate::util::address::Address;
-use crate::util::heap::{MonotonePageResource, PageResource, VMRequest};
+use crate::util::heap::{MonotonePageResource, PageResource};
 
 use crate::util::{metadata, ObjectReference};
 
 use crate::plan::{ObjectQueue, VectorObjectQueue};
 
-use crate::plan::PlanConstraints;
 use crate::policy::sft::GCWorkerMutRef;
-use crate::util::heap::layout::heap_layout::{Mmapper, VMMap};
-use crate::util::heap::HeapMeta;
-use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSpec};
 use crate::vm::{ObjectModel, VMBinding};
 
 /// This type implements a simple immortal collection
@@ -144,14 +140,14 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for ImmortalSp
 
 impl<VM: VMBinding> ImmortalSpace<VM> {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        args: crate::policy::space::PlanCreateSpaceArgs<VM>,
-    ) -> Self {
+    pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         let vm_map = args.vm_map;
         let is_discontiguous = args.vmrequest.is_discontiguous();
-        let common = CommonSpace::new(args.into_policy_args(false, true, metadata::extract_side_metadata(&[
-            *VM::VMObjectModel::LOCAL_MARK_BIT_SPEC,
-        ])));
+        let common = CommonSpace::new(args.into_policy_args(
+            false,
+            true,
+            metadata::extract_side_metadata(&[*VM::VMObjectModel::LOCAL_MARK_BIT_SPEC]),
+        ));
         ImmortalSpace {
             mark_state: 0,
             pr: if is_discontiguous {

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -139,7 +139,6 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for ImmortalSp
 }
 
 impl<VM: VMBinding> ImmortalSpace<VM> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         let vm_map = args.vm_map;
         let is_discontiguous = args.vmrequest.is_discontiguous();

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -1,18 +1,13 @@
 use atomic::Ordering;
 
 use crate::plan::ObjectQueue;
-use crate::plan::PlanConstraints;
 use crate::plan::VectorObjectQueue;
 use crate::policy::sft::GCWorkerMutRef;
 use crate::policy::sft::SFT;
 use crate::policy::space::{CommonSpace, Space};
 use crate::util::constants::BYTES_IN_PAGE;
-use crate::util::heap::layout::heap_layout::{Mmapper, VMMap};
-use crate::util::heap::HeapMeta;
-use crate::util::heap::{FreeListPageResource, PageResource, VMRequest};
+use crate::util::heap::{FreeListPageResource, PageResource};
 use crate::util::metadata;
-use crate::util::metadata::side_metadata::SideMetadataContext;
-use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::opaque_pointer::*;
 use crate::util::treadmill::TreadMill;
 use crate::util::{Address, ObjectReference};
@@ -155,9 +150,11 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
     ) -> Self {
         let is_discontiguous = args.vmrequest.is_discontiguous();
         let vm_map = args.vm_map;
-        let common = CommonSpace::new(args.into_policy_args(false, false, metadata::extract_side_metadata(&[
-            *VM::VMObjectModel::LOCAL_LOS_MARK_NURSERY_SPEC,
-        ])));
+        let common = CommonSpace::new(args.into_policy_args(
+            false,
+            false,
+            metadata::extract_side_metadata(&[*VM::VMObjectModel::LOCAL_LOS_MARK_NURSERY_SPEC]),
+        ));
         let mut pr = if is_discontiguous {
             FreeListPageResource::new_discontiguous(vm_map)
         } else {

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -143,7 +143,6 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for LargeObjec
 }
 
 impl<VM: VMBinding> LargeObjectSpace<VM> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         args: crate::policy::space::PlanCreateSpaceArgs<VM>,
         protect_memory_on_release: bool,

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -169,12 +169,11 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for LockFreeIm
 impl<VM: VMBinding> LockFreeImmortalSpace<VM> {
     #[allow(dead_code)] // Only used with certain features.
     pub fn new(
-        name: &'static str,
+        args: crate::policy::space::PlanCreateSpaceArgs<VM>,
         slow_path_zeroing: bool,
-        options: &Options,
-        global_side_metadata_specs: Vec<SideMetadataSpec>,
     ) -> Self {
-        let total_bytes = *options.heap_size;
+        // let total_bytes = *options.heap_size;
+        let total_bytes = unimplemented!();
         assert!(
             total_bytes <= AVAILABLE_BYTES,
             "Initial requested memory ({} bytes) overflows the heap. Max heap size is {} bytes.",
@@ -185,14 +184,14 @@ impl<VM: VMBinding> LockFreeImmortalSpace<VM> {
         // FIXME: This space assumes that it can use the entire heap range, which is definitely wrong.
         // https://github.com/mmtk/mmtk-core/issues/314
         let space = Self {
-            name,
+            name: args.name,
             cursor: AtomicUsize::new(AVAILABLE_START.as_usize()),
             limit: AVAILABLE_START + total_bytes,
             start: AVAILABLE_START,
             extent: total_bytes,
             slow_path_zeroing,
             metadata: SideMetadataContext {
-                global: global_side_metadata_specs,
+                global: args.global_side_metadata_specs,
                 local: vec![],
             },
             phantom: PhantomData,

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -202,7 +202,6 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         );
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         let vm_map = args.vm_map;
         let is_discontiguous = args.vmrequest.is_discontiguous();

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -7,10 +7,8 @@ use crate::scheduler::GCWorker;
 use crate::util::alloc::allocator::align_allocation_no_fill;
 use crate::util::constants::LOG_BYTES_IN_WORD;
 use crate::util::copy::CopySemantics;
-use crate::util::heap::layout::heap_layout::{Mmapper, VMMap};
-use crate::util::heap::{HeapMeta, MonotonePageResource, PageResource, VMRequest};
+use crate::util::heap::{MonotonePageResource, PageResource};
 use crate::util::metadata::extract_side_metadata;
-use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSpec};
 use crate::util::{alloc_bit, Address, ObjectReference};
 use crate::{vm::*, ObjectQueue};
 use atomic::Ordering;
@@ -205,9 +203,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        args: crate::policy::space::PlanCreateSpaceArgs<VM>,
-    ) -> Self {
+    pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         let vm_map = args.vm_map;
         let is_discontiguous = args.vmrequest.is_discontiguous();
         let local_specs = extract_side_metadata(&[*VM::VMObjectModel::LOCAL_MARK_BIT_SPEC]);

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -254,14 +254,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        _name: &'static str,
-        _zeroed: bool,
-        _vmrequest: VMRequest,
-        global_side_metadata_specs: Vec<SideMetadataSpec>,
-        _vm_map: &'static VMMap,
-        _mmapper: &'static Mmapper,
-        _heap: &mut HeapMeta,
-        scheduler: Arc<GCWorkScheduler<VM>>,
+        args: crate::policy::space::PlanCreateSpaceArgs<VM>,
     ) -> Self {
         MallocSpace {
             phantom: PhantomData,
@@ -270,14 +263,14 @@ impl<VM: VMBinding> MallocSpace<VM> {
             chunk_addr_min: AtomicUsize::new(usize::max_value()), // XXX: have to use AtomicUsize to represent an Address
             chunk_addr_max: AtomicUsize::new(0),
             metadata: SideMetadataContext {
-                global: global_side_metadata_specs,
+                global: args.global_side_metadata_specs.clone(),
                 local: metadata::extract_side_metadata(&[
                     MetadataSpec::OnSide(ACTIVE_PAGE_METADATA_SPEC),
                     MetadataSpec::OnSide(OFFSET_MALLOC_METADATA_SPEC),
                     *VM::VMObjectModel::LOCAL_MARK_BIT_SPEC,
                 ]),
             },
-            scheduler,
+            scheduler: args.scheduler.clone(),
             #[cfg(debug_assertions)]
             active_mem: Mutex::new(HashMap::new()),
             #[cfg(debug_assertions)]

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -6,12 +6,7 @@ use crate::policy::sft::SFT;
 use crate::policy::space::CommonSpace;
 use crate::scheduler::GCWorkScheduler;
 use crate::util::heap::gc_trigger::GCTrigger;
-use crate::util::heap::gc_trigger::GCTriggerPolicy;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::PageResource;
-use crate::util::heap::VMRequest;
 use crate::util::malloc::library::{BYTES_IN_MALLOC_PAGE, LOG_BYTES_IN_MALLOC_PAGE};
 use crate::util::malloc::malloc_ms_util::*;
 use crate::util::metadata::side_metadata::{
@@ -260,9 +255,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        args: crate::policy::space::PlanCreateSpaceArgs<VM>,
-    ) -> Self {
+    pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         MallocSpace {
             phantom: PhantomData,
             active_bytes: AtomicUsize::new(0),
@@ -278,7 +271,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
                 ]),
             },
             scheduler: args.scheduler.clone(),
-            gc_trigger: args.gc_trigger.clone(),
+            gc_trigger: args.gc_trigger,
             #[cfg(debug_assertions)]
             active_mem: Mutex::new(HashMap::new()),
             #[cfg(debug_assertions)]

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -254,7 +254,6 @@ impl<VM: VMBinding> MallocSpace<VM> {
         specs.push(ACTIVE_CHUNK_METADATA_SPEC);
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         MallocSpace {
             phantom: PhantomData,

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -7,15 +7,8 @@ use crate::{
     scheduler::{GCWorkScheduler, GCWorker},
     util::{
         copy::CopySemantics,
-        heap::{
-            layout::heap_layout::{Mmapper, VMMap},
-            FreeListPageResource, HeapMeta, VMRequest,
-        },
-        metadata::{
-            self,
-            side_metadata::{SideMetadataContext, SideMetadataSpec},
-            MetadataSpec,
-        },
+        heap::FreeListPageResource,
+        metadata::{self, side_metadata::SideMetadataSpec, MetadataSpec},
         ObjectReference,
     },
     vm::VMBinding,
@@ -187,9 +180,7 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        args: crate::policy::space::PlanCreateSpaceArgs<VM>,
-    ) -> MarkSweepSpace<VM> {
+    pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> MarkSweepSpace<VM> {
         let scheduler = args.scheduler.clone();
         let vm_map = args.vm_map;
         let is_discontiguous = args.vmrequest.is_discontiguous();
@@ -219,7 +210,7 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
             },
             common,
             chunk_map: ChunkMap::new(),
-            scheduler: scheduler,
+            scheduler,
             abandoned: Mutex::new(AbandonedBlockLists {
                 available: new_empty_block_lists(),
                 unswept: new_empty_block_lists(),

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -179,7 +179,6 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
         // we need this method for MallocSpace, and we want those two spaces to be used interchangably.
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> MarkSweepSpace<VM> {
         let scheduler = args.scheduler.clone();
         let vm_map = args.vm_map;

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -69,8 +69,8 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         if should_poll && self.get_gc_trigger().poll(false, Some(self.as_space())) {
             debug!("Collection required");
             assert!(allow_gc, "GC is not allowed here: collection is not initialized (did you call initialize_collection()?).");
-            pr.clear_request(pages_reserved);
             VM::VMCollection::block_for_gc(VMMutatorThread(tls)); // We have checked that this is mutator
+            pr.clear_request(pages_reserved); // clear the pages after GC. We need those reserved pages so we can compute new heap size properly.
             unsafe { Address::zero() }
         } else {
             debug!("Collection not required");
@@ -176,8 +176,8 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
 
                     let gc_performed = self.get_gc_trigger().poll(true, Some(self.as_space()));
                     debug_assert!(gc_performed, "GC not performed when forced.");
-                    pr.clear_request(pages_reserved);
                     VM::VMCollection::block_for_gc(VMMutatorThread(tls)); // We asserted that this is mutator.
+                    pr.clear_request(pages_reserved); // clear the pages after GC. We need those reserved pages so we can compute new heap size properly.
                     unsafe { Address::zero() }
                 }
             }

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -101,7 +101,12 @@ impl<VM: VMBinding> GCController<VM> {
     /// Coordinate workers to perform GC in response to a GC request.
     pub fn do_gc_until_completion(&mut self) {
         // Tell GC trigger that GC started
-        self.mmtk.plan.base().gc_trigger.policy.on_gc_start(self.mmtk);
+        self.mmtk
+            .plan
+            .base()
+            .gc_trigger
+            .policy
+            .on_gc_start(self.mmtk);
 
         // Schedule collection.
         ScheduleCollection.do_work_with_stat(&mut self.coordinator_worker, self.mmtk);

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -100,6 +100,9 @@ impl<VM: VMBinding> GCController<VM> {
 
     /// Coordinate workers to perform GC in response to a GC request.
     pub fn do_gc_until_completion(&mut self) {
+        // Tell GC trigger that GC started
+        self.mmtk.plan.base().gc_trigger.policy.on_gc_start(self.mmtk);
+
         // Schedule collection.
         ScheduleCollection.do_work_with_stat(&mut self.coordinator_worker, self.mmtk);
 
@@ -126,6 +129,9 @@ impl<VM: VMBinding> GCController<VM> {
         //       newly generated remembered-sets from those open buckets.
         //       But these remsets should be preserved until next GC.
         EndOfGC.do_work_with_stat(&mut self.coordinator_worker, self.mmtk);
+
+        // Tell GC trigger that GC ended
+        self.mmtk.plan.base().gc_trigger.policy.on_gc_end(self.mmtk);
 
         self.scheduler.debug_assert_all_buckets_deactivated();
     }

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -13,7 +13,7 @@ use std::mem::MaybeUninit;
 
 pub struct GCTrigger<VM: VMBinding> {
     plan: MaybeUninit<&'static dyn Plan<VM = VM>>,
-    policy: Box<dyn GCTriggerPolicy<VM>>,
+    pub policy: Box<dyn GCTriggerPolicy<VM>>,
 }
 
 impl<VM: VMBinding> GCTrigger<VM> {
@@ -45,10 +45,6 @@ impl<VM: VMBinding> GCTrigger<VM> {
             return true;
         }
         false
-    }
-
-    pub fn get_total_pages(&self) -> usize {
-        self.policy.get_heap_size_in_pages()
     }
 
     pub fn is_heap_full(&self) -> bool {

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -2,7 +2,7 @@ use atomic::Ordering;
 
 use crate::plan::gc_requester::GCRequester;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
-use crate::util::options::{Options, GCTriggerPolicySelector};
+use crate::util::options::{Options, GCTriggerSelector};
 use crate::vm::VMBinding;
 use crate::MMTK;
 use crate::policy::space::Space;
@@ -21,15 +21,15 @@ impl<VM: VMBinding> GCTrigger<VM> {
         GCTrigger {
             plan: MaybeUninit::uninit(),
             policy: match *options.gc_trigger {
-                GCTriggerPolicySelector::FixedHeapSize(size) => Box::new(FixedHeapSizeTrigger{
+                GCTriggerSelector::FixedHeapSize(size) => Box::new(FixedHeapSizeTrigger{
                     total_pages: size >> LOG_BYTES_IN_PAGE,
                 }),
-                GCTriggerPolicySelector::DynamicHeapSize(min, max) => Box::new(MemBalancerTrigger {
+                GCTriggerSelector::DynamicHeapSize(min, max) => Box::new(MemBalancerTrigger {
                     min_heap_pages: min >> LOG_BYTES_IN_PAGE,
                     max_heap_pages: max >> LOG_BYTES_IN_PAGE,
                     current_heap_pages: AtomicUsize::new(min >> LOG_BYTES_IN_PAGE)
                 }),
-                GCTriggerPolicySelector::Delegated => unimplemented!()
+                GCTriggerSelector::Delegated => unimplemented!()
             }
         }
     }
@@ -41,6 +41,7 @@ impl<VM: VMBinding> GCTrigger<VM> {
     pub fn poll(&self, space_full: bool, space: Option<&dyn Space<VM>>) -> bool {
         let plan = unsafe { self.plan.assume_init() };
         if self.policy.is_gc_required(space_full, space, plan) {
+            info!("[POLL] {}{}", if let Some(space) = space { format!("{}: ", space.get_name()) } else { "".to_string() }, "Triggering collection");
             plan.base().gc_requester.request();
             return true;
         }
@@ -70,15 +71,15 @@ pub trait GCTriggerPolicy<VM: VMBinding>: Sync + Send {
 
 pub fn create_gc_trigger<VM: VMBinding>(options: &Options) -> Arc<dyn GCTriggerPolicy<VM>> {
     match *options.gc_trigger {
-        GCTriggerPolicySelector::FixedHeapSize(size) => Arc::new(FixedHeapSizeTrigger{
+        GCTriggerSelector::FixedHeapSize(size) => Arc::new(FixedHeapSizeTrigger{
             total_pages: size >> LOG_BYTES_IN_PAGE,
         }),
-        GCTriggerPolicySelector::DynamicHeapSize(min, max) => Arc::new(MemBalancerTrigger {
+        GCTriggerSelector::DynamicHeapSize(min, max) => Arc::new(MemBalancerTrigger {
             min_heap_pages: min >> LOG_BYTES_IN_PAGE,
             max_heap_pages: max >> LOG_BYTES_IN_PAGE,
             current_heap_pages: AtomicUsize::new(min >> LOG_BYTES_IN_PAGE)
         }),
-        GCTriggerPolicySelector::Delegated => unimplemented!()
+        GCTriggerSelector::Delegated => unimplemented!()
     }
 }
 
@@ -119,8 +120,10 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
 
     fn on_gc_end(&self, mmtk: &'static MMTK<VM>) {
         let live = mmtk.plan.get_used_pages() as f64;
-        let new_heap = (live + (live * 4096f64).sqrt()) as usize;
-        self.current_heap_pages.store(new_heap.clamp(self.min_heap_pages, self.max_heap_pages), Ordering::Relaxed);
+        let optimal_heap = (live + (live * 4096f64).sqrt()) as usize;
+        let new_heap = optimal_heap.clamp(self.min_heap_pages, self.max_heap_pages);
+        debug!("MemBalander: new heap limit = {} pages (optimal = {}, clamped to [{}, {}])", new_heap, optimal_heap, self.min_heap_pages, self.max_heap_pages);
+        self.current_heap_pages.store(new_heap, Ordering::Relaxed);
     }
 
     fn is_gc_required(&self, space_full: bool, space: Option<&dyn Space<VM>>, plan: &dyn Plan<VM=VM>) -> bool {

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -1,0 +1,83 @@
+use atomic::Ordering;
+
+use crate::plan::gc_requester::GCRequester;
+use crate::util::options::Options;
+use crate::vm::VMBinding;
+use crate::MMTK;
+use crate::policy::space::Space;
+use crate::plan::Plan;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+
+pub trait GCTrigger<VM: VMBinding>: Sync + Send {
+    fn on_gc_start(&self, mmtk: &'static MMTK<VM>);
+    fn on_gc_end(&self, mmtk: &'static MMTK<VM>);
+    fn is_gc_required(&self, space_full: bool, space: Option<&dyn Space<VM>>, plan: &dyn Plan<VM=VM>) -> bool;
+    fn is_heap_full(&self, plan: &'static dyn Plan<VM=VM>) -> bool;
+    fn get_heap_size_in_pages(&self) -> usize;
+    fn poll(&self, space_full: bool, space: Option<&dyn Space<VM>>, plan: &dyn Plan<VM = VM>) -> bool {
+        if self.is_gc_required(space_full, space, plan) {
+            plan.base().gc_requester.request();
+            return true;
+        }
+        false
+    }
+}
+
+pub fn create_gc_trigger<VM: VMBinding>(options: &Options) -> Arc<dyn GCTrigger<VM>> {
+    todo!()
+}
+
+pub struct FixedHeapSizeTrigger {
+    total_pages: usize,
+}
+impl<VM: VMBinding> GCTrigger<VM> for FixedHeapSizeTrigger {
+    fn on_gc_start(&self, mmtk: &'static MMTK<VM>) {
+
+    }
+
+    fn on_gc_end(&self, mmtk: &'static MMTK<VM>) {
+
+    }
+
+    fn is_gc_required(&self, space_full: bool, space: Option<&dyn Space<VM>>, plan: &dyn Plan<VM=VM>) -> bool {
+        plan.collection_required(space_full, space)
+    }
+
+    fn is_heap_full(&self, plan: &'static dyn Plan<VM=VM>) -> bool {
+        plan.get_reserved_pages() > self.total_pages
+    }
+
+    fn get_heap_size_in_pages(&self) -> usize {
+        self.total_pages
+    }
+}
+
+pub struct MemBalancerTrigger {
+    min_heap_pages: usize,
+    max_heap_pages: usize,
+    current_heap_pages: AtomicUsize,
+}
+impl<VM: VMBinding> GCTrigger<VM> for MemBalancerTrigger {
+    fn on_gc_start(&self, mmtk: &'static MMTK<VM>) {
+
+    }
+
+    fn on_gc_end(&self, mmtk: &'static MMTK<VM>) {
+        let live = mmtk.plan.get_used_pages() as f64;
+        let new_heap = (live + (live * 4096f64).sqrt()) as usize;
+        self.current_heap_pages.store(new_heap.clamp(self.min_heap_pages, self.max_heap_pages), Ordering::Relaxed);
+    }
+
+    fn is_gc_required(&self, space_full: bool, space: Option<&dyn Space<VM>>, plan: &dyn Plan<VM=VM>) -> bool {
+        plan.collection_required(space_full, space)
+    }
+
+    fn is_heap_full(&self, plan: &'static dyn Plan<VM=VM>) -> bool {
+        plan.get_reserved_pages() > self.current_heap_pages.load(Ordering::Relaxed)
+    }
+
+    fn get_heap_size_in_pages(&self) -> usize {
+        self.current_heap_pages.load(Ordering::Relaxed)
+    }
+}

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -94,6 +94,8 @@ pub trait GCTriggerPolicy<VM: VMBinding>: Sync + Send {
     fn is_heap_full(&self, plan: &'static dyn Plan<VM = VM>) -> bool;
     /// Return the current heap size (in pages)
     fn get_heap_size_in_pages(&self) -> usize;
+    /// Can the heap size grow?
+    fn can_heap_size_grow(&self) -> bool;
 }
 
 /// A simple GC trigger that uses a fixed heap size.
@@ -118,6 +120,10 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for FixedHeapSizeTrigger {
 
     fn get_heap_size_in_pages(&self) -> usize {
         self.total_pages
+    }
+
+    fn can_heap_size_grow(&self) -> bool {
+        false
     }
 }
 
@@ -167,6 +173,10 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
 
     fn get_heap_size_in_pages(&self) -> usize {
         self.current_heap_pages.load(Ordering::Relaxed)
+    }
+
+    fn can_heap_size_grow(&self) -> bool {
+        self.current_heap_pages.load(Ordering::Relaxed) < self.max_heap_pages
     }
 }
 impl MemBalancerTrigger {

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -1,15 +1,63 @@
 use atomic::Ordering;
 
 use crate::plan::gc_requester::GCRequester;
-use crate::util::options::Options;
+use crate::util::constants::LOG_BYTES_IN_PAGE;
+use crate::util::options::{Options, GCTriggerPolicySelector};
 use crate::vm::VMBinding;
 use crate::MMTK;
 use crate::policy::space::Space;
 use crate::plan::Plan;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
+use std::mem::MaybeUninit;
 
-pub trait GCTrigger<VM: VMBinding>: Sync + Send {
+pub struct GCTrigger<VM: VMBinding> {
+    plan: MaybeUninit<&'static dyn Plan<VM = VM>>,
+    policy: Box<dyn GCTriggerPolicy<VM>>,
+}
+
+impl<VM: VMBinding> GCTrigger<VM> {
+    pub fn new(options: &Options) -> Self {
+        GCTrigger {
+            plan: MaybeUninit::uninit(),
+            policy: match *options.gc_trigger {
+                GCTriggerPolicySelector::FixedHeapSize(size) => Box::new(FixedHeapSizeTrigger{
+                    total_pages: size >> LOG_BYTES_IN_PAGE,
+                }),
+                GCTriggerPolicySelector::DynamicHeapSize(min, max) => Box::new(MemBalancerTrigger {
+                    min_heap_pages: min >> LOG_BYTES_IN_PAGE,
+                    max_heap_pages: max >> LOG_BYTES_IN_PAGE,
+                    current_heap_pages: AtomicUsize::new(min >> LOG_BYTES_IN_PAGE)
+                }),
+                GCTriggerPolicySelector::Delegated => unimplemented!()
+            }
+        }
+    }
+
+    pub fn set_plan(&mut self, plan: &'static dyn Plan<VM = VM>) {
+        self.plan.write(plan);
+    }
+
+    pub fn poll(&self, space_full: bool, space: Option<&dyn Space<VM>>) -> bool {
+        let plan = unsafe { self.plan.assume_init() };
+        if self.policy.is_gc_required(space_full, space, plan) {
+            plan.base().gc_requester.request();
+            return true;
+        }
+        false
+    }
+
+    pub fn get_total_pages(&self) -> usize {
+        self.policy.get_heap_size_in_pages()
+    }
+
+    pub fn is_heap_full(&self) -> bool {
+        let plan = unsafe { self.plan.assume_init() };
+        self.policy.is_heap_full(plan)
+    }
+}
+
+pub trait GCTriggerPolicy<VM: VMBinding>: Sync + Send {
     fn on_gc_start(&self, mmtk: &'static MMTK<VM>);
     fn on_gc_end(&self, mmtk: &'static MMTK<VM>);
     fn is_gc_required(&self, space_full: bool, space: Option<&dyn Space<VM>>, plan: &dyn Plan<VM=VM>) -> bool;
@@ -24,14 +72,24 @@ pub trait GCTrigger<VM: VMBinding>: Sync + Send {
     }
 }
 
-pub fn create_gc_trigger<VM: VMBinding>(options: &Options) -> Arc<dyn GCTrigger<VM>> {
-    todo!()
+pub fn create_gc_trigger<VM: VMBinding>(options: &Options) -> Arc<dyn GCTriggerPolicy<VM>> {
+    match *options.gc_trigger {
+        GCTriggerPolicySelector::FixedHeapSize(size) => Arc::new(FixedHeapSizeTrigger{
+            total_pages: size >> LOG_BYTES_IN_PAGE,
+        }),
+        GCTriggerPolicySelector::DynamicHeapSize(min, max) => Arc::new(MemBalancerTrigger {
+            min_heap_pages: min >> LOG_BYTES_IN_PAGE,
+            max_heap_pages: max >> LOG_BYTES_IN_PAGE,
+            current_heap_pages: AtomicUsize::new(min >> LOG_BYTES_IN_PAGE)
+        }),
+        GCTriggerPolicySelector::Delegated => unimplemented!()
+    }
 }
 
 pub struct FixedHeapSizeTrigger {
     total_pages: usize,
 }
-impl<VM: VMBinding> GCTrigger<VM> for FixedHeapSizeTrigger {
+impl<VM: VMBinding> GCTriggerPolicy<VM> for FixedHeapSizeTrigger {
     fn on_gc_start(&self, mmtk: &'static MMTK<VM>) {
 
     }
@@ -58,7 +116,7 @@ pub struct MemBalancerTrigger {
     max_heap_pages: usize,
     current_heap_pages: AtomicUsize,
 }
-impl<VM: VMBinding> GCTrigger<VM> for MemBalancerTrigger {
+impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
     fn on_gc_start(&self, mmtk: &'static MMTK<VM>) {
 
     }

--- a/src/util/heap/heap_meta.rs
+++ b/src/util/heap/heap_meta.rs
@@ -6,7 +6,6 @@ use crate::util::Address;
 pub struct HeapMeta {
     pub heap_cursor: Address,
     pub heap_limit: Address,
-    pub total_pages: usize,
 }
 
 impl HeapMeta {
@@ -14,7 +13,6 @@ impl HeapMeta {
         HeapMeta {
             heap_cursor: HEAP_START,
             heap_limit: HEAP_END,
-            total_pages: conversions::bytes_to_pages(*options.heap_size),
         }
     }
 
@@ -45,9 +43,5 @@ impl HeapMeta {
 
     pub fn get_discontig_end(&self) -> Address {
         self.heap_limit - 1
-    }
-
-    pub fn get_total_pages(&self) -> usize {
-        self.total_pages
     }
 }

--- a/src/util/heap/heap_meta.rs
+++ b/src/util/heap/heap_meta.rs
@@ -1,6 +1,4 @@
-use crate::util::conversions;
 use crate::util::heap::layout::vm_layout_constants::{HEAP_END, HEAP_START};
-use crate::util::options::Options;
 use crate::util::Address;
 
 pub struct HeapMeta {
@@ -9,7 +7,7 @@ pub struct HeapMeta {
 }
 
 impl HeapMeta {
-    pub fn new(options: &Options) -> Self {
+    pub fn new() -> Self {
         HeapMeta {
             heap_cursor: HEAP_START,
             heap_limit: HEAP_END,
@@ -43,5 +41,12 @@ impl HeapMeta {
 
     pub fn get_discontig_end(&self) -> Address {
         self.heap_limit - 1
+    }
+}
+
+// make clippy happy
+impl Default for HeapMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/util/heap/mod.rs
+++ b/src/util/heap/mod.rs
@@ -4,12 +4,12 @@ pub mod layout;
 pub mod blockpageresource;
 pub mod chunk_map;
 pub mod freelistpageresource;
+pub mod gc_trigger;
 mod heap_meta;
 pub mod monotonepageresource;
 pub mod pageresource;
 pub mod space_descriptor;
 mod vmrequest;
-pub mod gc_trigger;
 
 pub use self::accounting::PageAccounting;
 pub use self::blockpageresource::BlockPageResource;

--- a/src/util/heap/mod.rs
+++ b/src/util/heap/mod.rs
@@ -9,6 +9,7 @@ pub mod monotonepageresource;
 pub mod pageresource;
 pub mod space_descriptor;
 mod vmrequest;
+pub mod gc_trigger;
 
 pub use self::accounting::PageAccounting;
 pub use self::blockpageresource::BlockPageResource;

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -173,6 +173,17 @@ pub fn get_process_memory_maps() -> String {
     data
 }
 
+/// Returns the total physical memory for the system in bytes.
+pub(crate) fn get_system_total_memory() -> usize {
+    match sys_info::mem_info() {
+        Ok(mem_info) => mem_info.total as usize,
+        Err(e) => {
+            warn!("Failed to get sys_info::mem_info: {:?}. Return 1G in get_system_total_memory()", e);
+            1024 * 1024 * 1024
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,5 +336,11 @@ mod tests {
                 },
             )
         })
+    }
+
+    #[test]
+    fn test_get_system_total_memory() {
+        let total = get_system_total_memory();
+        println!("Total memory: {:?}", total);
     }
 }

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -178,7 +178,10 @@ pub(crate) fn get_system_total_memory() -> usize {
     match sys_info::mem_info() {
         Ok(mem_info) => mem_info.total as usize,
         Err(e) => {
-            warn!("Failed to get sys_info::mem_info: {:?}. Return 1G in get_system_total_memory()", e);
+            warn!(
+                "Failed to get sys_info::mem_info: {:?}. Return 1G in get_system_total_memory()",
+                e
+            );
             1024 * 1024 * 1024
         }
     }

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -626,7 +626,7 @@ options! {
     // there is no core with (perceived) id 12.
     // XXX: This option is currently only supported on Linux.
     thread_affinity:        AffinityKind         [env_var: true, command_line: true] [|v: &AffinityKind| v.validate()] = AffinityKind::OsDefault,
-    // Set the GC trigger. This defines how MMTk triggers a GC.
+    // Set the GC trigger. This defines the heap size and how MMTk triggers a GC.
     // Default to a fixed heap size of 0.3x physical memory.
     gc_trigger     :        GCTriggerSelector    [env_var: true, command_line: true] [always_valid] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.3f64) as usize)
 }

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -625,7 +625,10 @@ options! {
     // `MMTK_THREAD_AFFINITY="12" taskset -c 6-12 <program>` will not work, on the other hand, as
     // there is no core with (perceived) id 12.
     // XXX: This option is currently only supported on Linux.
-    thread_affinity:        AffinityKind         [env_var: true, command_line: true] [|v: &AffinityKind| v.validate()] = AffinityKind::OsDefault
+    thread_affinity:        AffinityKind         [env_var: true, command_line: true] [|v: &AffinityKind| v.validate()] = AffinityKind::OsDefault,
+    // Set the GC trigger. This defines how MMTk triggers a GC.
+    // Default to a fixed heap size of 0.3x physical memory.
+    gc_trigger     :        GCTriggerSelector    [env_var: true, command_line: true] [always_valid] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.3f64) as usize)
 }
 
 #[cfg(test)]

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -427,13 +427,13 @@ impl Options {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum GCTriggerPolicySelector {
+pub enum GCTriggerSelector {
     FixedHeapSize(usize),
     DynamicHeapSize(usize, usize),
     Delegated,
 }
 
-impl GCTriggerPolicySelector {
+impl GCTriggerSelector {
     const K: usize = 1024;
     const M: usize = 1024 * 1024;
     const G: usize = 1024 * 1024 * 1024;
@@ -461,7 +461,7 @@ impl GCTriggerPolicySelector {
     }
 }
 
-impl FromStr for GCTriggerPolicySelector {
+impl FromStr for GCTriggerSelector {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -500,48 +500,48 @@ mod gc_trigger_tests {
     #[test]
     fn test_parse_size() {
         // correct cases
-        assert_eq!(GCTriggerPolicySelector::parse_size("0"), Ok(0));
-        assert_eq!(GCTriggerPolicySelector::parse_size("1K"), Ok(1024));
-        assert_eq!(GCTriggerPolicySelector::parse_size("1k"), Ok(1024));
-        assert_eq!(GCTriggerPolicySelector::parse_size("2M"), Ok(2*1024*1024));
-        assert_eq!(GCTriggerPolicySelector::parse_size("2m"), Ok(2*1024*1024));
-        assert_eq!(GCTriggerPolicySelector::parse_size("4G"), Ok(4*1024*1024*1024));
-        assert_eq!(GCTriggerPolicySelector::parse_size("4g"), Ok(4*1024*1024*1024));
+        assert_eq!(GCTriggerSelector::parse_size("0"), Ok(0));
+        assert_eq!(GCTriggerSelector::parse_size("1K"), Ok(1024));
+        assert_eq!(GCTriggerSelector::parse_size("1k"), Ok(1024));
+        assert_eq!(GCTriggerSelector::parse_size("2M"), Ok(2*1024*1024));
+        assert_eq!(GCTriggerSelector::parse_size("2m"), Ok(2*1024*1024));
+        assert_eq!(GCTriggerSelector::parse_size("4G"), Ok(4*1024*1024*1024));
+        assert_eq!(GCTriggerSelector::parse_size("4g"), Ok(4*1024*1024*1024));
 
         // empty
-        assert_eq!(GCTriggerPolicySelector::parse_size(""), Err("cannot parse integer from empty string".to_string()));
+        assert_eq!(GCTriggerSelector::parse_size(""), Err("cannot parse integer from empty string".to_string()));
 
         // unknown size descriptor
-        assert_eq!(GCTriggerPolicySelector::parse_size("1T"), Err("Unknown size descriptor: \"t\"".to_string()));
+        assert_eq!(GCTriggerSelector::parse_size("1T"), Err("Unknown size descriptor: \"t\"".to_string()));
 
         // negative number - we dont care about actual error message
-        assert!(GCTriggerPolicySelector::parse_size("-1").is_err());
+        assert!(GCTriggerSelector::parse_size("-1").is_err());
 
         // no number
-        assert!(GCTriggerPolicySelector::parse_size("k").is_err());
+        assert!(GCTriggerSelector::parse_size("k").is_err());
     }
 
     #[test]
     fn test_parse_fixed_heap() {
-        assert_eq!(GCTriggerPolicySelector::from_str("FixedHeapSize:1024"), Ok(GCTriggerPolicySelector::FixedHeapSize(1024)));
-        assert_eq!(GCTriggerPolicySelector::from_str("FixedHeapSize:4m"), Ok(GCTriggerPolicySelector::FixedHeapSize(4 * 1024 * 1024)));
+        assert_eq!(GCTriggerSelector::from_str("FixedHeapSize:1024"), Ok(GCTriggerSelector::FixedHeapSize(1024)));
+        assert_eq!(GCTriggerSelector::from_str("FixedHeapSize:4m"), Ok(GCTriggerSelector::FixedHeapSize(4 * 1024 * 1024)));
 
         // incorrect
-        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize").is_err());
-        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize:").is_err());
-        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize:-1").is_err());
-        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize:4t").is_err());
+        assert!(GCTriggerSelector::from_str("FixedHeapSize").is_err());
+        assert!(GCTriggerSelector::from_str("FixedHeapSize:").is_err());
+        assert!(GCTriggerSelector::from_str("FixedHeapSize:-1").is_err());
+        assert!(GCTriggerSelector::from_str("FixedHeapSize:4t").is_err());
     }
 
     #[test]
     fn test_parse_dynamic_heap() {
-        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1024,2048"), Ok(GCTriggerPolicySelector::DynamicHeapSize(1024, 2048)));
-        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1024,1024"), Ok(GCTriggerPolicySelector::DynamicHeapSize(1024, 1024)));
-        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1m,2m"), Ok(GCTriggerPolicySelector::DynamicHeapSize(1 * 1024 * 1024, 2 * 1024 * 1024)));
+        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:1024,2048"), Ok(GCTriggerSelector::DynamicHeapSize(1024, 2048)));
+        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:1024,1024"), Ok(GCTriggerSelector::DynamicHeapSize(1024, 1024)));
+        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:1m,2m"), Ok(GCTriggerSelector::DynamicHeapSize(1 * 1024 * 1024, 2 * 1024 * 1024)));
 
         // incorrect
-        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:2048,1024"), Err("Min heap size 2048 is larger than the given max heap size 1024".to_string()));
-        assert!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1024,1024,").is_err());
+        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:2048,1024"), Err("Min heap size 2048 is larger than the given max heap size 1024".to_string()));
+        assert!(GCTriggerSelector::from_str("DynamicHeapSize:1024,1024,").is_err());
     }
 }
 
@@ -628,7 +628,7 @@ options! {
     thread_affinity:        AffinityKind         [env_var: true, command_line: true] [|v: &AffinityKind| v.validate()] = AffinityKind::OsDefault,
     // Set the GC trigger. This defines the heap size and how MMTk triggers a GC.
     // Default to a fixed heap size of 0.3x physical memory.
-    gc_trigger     :        GCTriggerPolicySelector    [env_var: true, command_line: true] [always_valid] = GCTriggerPolicySelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.3f64) as usize)
+    gc_trigger     :        GCTriggerSelector    [env_var: true, command_line: true] [always_valid] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.3f64) as usize)
 }
 
 #[cfg(test)]

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -449,13 +449,13 @@ impl GCTriggerSelector {
                 .parse::<u64>()
                 .map_err(|e| e.to_string())?;
             let size = if s.ends_with('k') {
-                num * Self::K
+                num.checked_mul(Self::K)
             } else if s.ends_with('m') {
-                num * Self::M
+                num.checked_mul(Self::M)
             } else if s.ends_with('g') {
-                num * Self::G
+                num.checked_mul(Self::G)
             } else if s.ends_with('t') {
-                num * Self::T
+                num.checked_mul(Self::T)
             } else {
                 return Err(format!(
                     "Unknown size descriptor: {:?}",
@@ -463,8 +463,12 @@ impl GCTriggerSelector {
                 ));
             };
 
-            size.try_into()
-                .map_err(|_| format!("size overflow: {}", size))
+            if let Some(size) = size {
+                size.try_into()
+                    .map_err(|_| format!("size overflow: {}", size))
+            } else {
+                Err(format!("size overflow: {}", s))
+            }
         } else {
             s.parse::<usize>().map_err(|e| e.to_string())
         }

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -427,13 +427,13 @@ impl Options {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum GCTriggerSelector {
+pub enum GCTriggerPolicySelector {
     FixedHeapSize(usize),
     DynamicHeapSize(usize, usize),
     Delegated,
 }
 
-impl GCTriggerSelector {
+impl GCTriggerPolicySelector {
     const K: usize = 1024;
     const M: usize = 1024 * 1024;
     const G: usize = 1024 * 1024 * 1024;
@@ -461,7 +461,7 @@ impl GCTriggerSelector {
     }
 }
 
-impl FromStr for GCTriggerSelector {
+impl FromStr for GCTriggerPolicySelector {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -500,48 +500,48 @@ mod gc_trigger_tests {
     #[test]
     fn test_parse_size() {
         // correct cases
-        assert_eq!(GCTriggerSelector::parse_size("0"), Ok(0));
-        assert_eq!(GCTriggerSelector::parse_size("1K"), Ok(1024));
-        assert_eq!(GCTriggerSelector::parse_size("1k"), Ok(1024));
-        assert_eq!(GCTriggerSelector::parse_size("2M"), Ok(2*1024*1024));
-        assert_eq!(GCTriggerSelector::parse_size("2m"), Ok(2*1024*1024));
-        assert_eq!(GCTriggerSelector::parse_size("4G"), Ok(4*1024*1024*1024));
-        assert_eq!(GCTriggerSelector::parse_size("4g"), Ok(4*1024*1024*1024));
+        assert_eq!(GCTriggerPolicySelector::parse_size("0"), Ok(0));
+        assert_eq!(GCTriggerPolicySelector::parse_size("1K"), Ok(1024));
+        assert_eq!(GCTriggerPolicySelector::parse_size("1k"), Ok(1024));
+        assert_eq!(GCTriggerPolicySelector::parse_size("2M"), Ok(2*1024*1024));
+        assert_eq!(GCTriggerPolicySelector::parse_size("2m"), Ok(2*1024*1024));
+        assert_eq!(GCTriggerPolicySelector::parse_size("4G"), Ok(4*1024*1024*1024));
+        assert_eq!(GCTriggerPolicySelector::parse_size("4g"), Ok(4*1024*1024*1024));
 
         // empty
-        assert_eq!(GCTriggerSelector::parse_size(""), Err("cannot parse integer from empty string".to_string()));
+        assert_eq!(GCTriggerPolicySelector::parse_size(""), Err("cannot parse integer from empty string".to_string()));
 
         // unknown size descriptor
-        assert_eq!(GCTriggerSelector::parse_size("1T"), Err("Unknown size descriptor: \"t\"".to_string()));
+        assert_eq!(GCTriggerPolicySelector::parse_size("1T"), Err("Unknown size descriptor: \"t\"".to_string()));
 
         // negative number - we dont care about actual error message
-        assert!(GCTriggerSelector::parse_size("-1").is_err());
+        assert!(GCTriggerPolicySelector::parse_size("-1").is_err());
 
         // no number
-        assert!(GCTriggerSelector::parse_size("k").is_err());
+        assert!(GCTriggerPolicySelector::parse_size("k").is_err());
     }
 
     #[test]
     fn test_parse_fixed_heap() {
-        assert_eq!(GCTriggerSelector::from_str("FixedHeapSize:1024"), Ok(GCTriggerSelector::FixedHeapSize(1024)));
-        assert_eq!(GCTriggerSelector::from_str("FixedHeapSize:4m"), Ok(GCTriggerSelector::FixedHeapSize(4 * 1024 * 1024)));
+        assert_eq!(GCTriggerPolicySelector::from_str("FixedHeapSize:1024"), Ok(GCTriggerPolicySelector::FixedHeapSize(1024)));
+        assert_eq!(GCTriggerPolicySelector::from_str("FixedHeapSize:4m"), Ok(GCTriggerPolicySelector::FixedHeapSize(4 * 1024 * 1024)));
 
         // incorrect
-        assert!(GCTriggerSelector::from_str("FixedHeapSize").is_err());
-        assert!(GCTriggerSelector::from_str("FixedHeapSize:").is_err());
-        assert!(GCTriggerSelector::from_str("FixedHeapSize:-1").is_err());
-        assert!(GCTriggerSelector::from_str("FixedHeapSize:4t").is_err());
+        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize").is_err());
+        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize:").is_err());
+        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize:-1").is_err());
+        assert!(GCTriggerPolicySelector::from_str("FixedHeapSize:4t").is_err());
     }
 
     #[test]
     fn test_parse_dynamic_heap() {
-        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:1024,2048"), Ok(GCTriggerSelector::DynamicHeapSize(1024, 2048)));
-        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:1024,1024"), Ok(GCTriggerSelector::DynamicHeapSize(1024, 1024)));
-        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:1m,2m"), Ok(GCTriggerSelector::DynamicHeapSize(1 * 1024 * 1024, 2 * 1024 * 1024)));
+        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1024,2048"), Ok(GCTriggerPolicySelector::DynamicHeapSize(1024, 2048)));
+        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1024,1024"), Ok(GCTriggerPolicySelector::DynamicHeapSize(1024, 1024)));
+        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1m,2m"), Ok(GCTriggerPolicySelector::DynamicHeapSize(1 * 1024 * 1024, 2 * 1024 * 1024)));
 
         // incorrect
-        assert_eq!(GCTriggerSelector::from_str("DynamicHeapSize:2048,1024"), Err("Min heap size 2048 is larger than the given max heap size 1024".to_string()));
-        assert!(GCTriggerSelector::from_str("DynamicHeapSize:1024,1024,").is_err());
+        assert_eq!(GCTriggerPolicySelector::from_str("DynamicHeapSize:2048,1024"), Err("Min heap size 2048 is larger than the given max heap size 1024".to_string()));
+        assert!(GCTriggerPolicySelector::from_str("DynamicHeapSize:1024,1024,").is_err());
     }
 }
 
@@ -557,7 +557,7 @@ options! {
     threads:               usize                [env_var: true, command_line: true] [|v: &usize| *v > 0]    = num_cpus::get(),
     // Heap size. Default to 512MB.
     // TODO: We should have a default heap size related to the max physical memory.
-    heap_size:             usize                [env_var: true, command_line: true] [|v: &usize| *v > 0]    = 512 << 20,
+    // heap_size:             usize                [env_var: true, command_line: true] [|v: &usize| *v > 0]    = 512 << 20,
     // Enable an optimization that only scans the part of the stack that has changed since the last GC (not supported)
     use_short_stack_scans: bool                 [env_var: true, command_line: true]  [always_valid] = false,
     // Enable a return barrier (not supported)
@@ -628,7 +628,7 @@ options! {
     thread_affinity:        AffinityKind         [env_var: true, command_line: true] [|v: &AffinityKind| v.validate()] = AffinityKind::OsDefault,
     // Set the GC trigger. This defines the heap size and how MMTk triggers a GC.
     // Default to a fixed heap size of 0.3x physical memory.
-    gc_trigger     :        GCTriggerSelector    [env_var: true, command_line: true] [always_valid] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.3f64) as usize)
+    gc_trigger     :        GCTriggerPolicySelector    [env_var: true, command_line: true] [always_valid] = GCTriggerPolicySelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.3f64) as usize)
 }
 
 #[cfg(test)]

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -595,9 +595,6 @@ options! {
     // To allow this as a command-line option, we need to refactor the creation fo the `MMTK` instance.
     // See: https://github.com/mmtk/mmtk-core/issues/532
     threads:               usize                [env_var: true, command_line: true] [|v: &usize| *v > 0]    = num_cpus::get(),
-    // Heap size. Default to 512MB.
-    // TODO: We should have a default heap size related to the max physical memory.
-    // heap_size:             usize                [env_var: true, command_line: true] [|v: &usize| *v > 0]    = 512 << 20,
     // Enable an optimization that only scans the part of the stack that has changed since the last GC (not supported)
     use_short_stack_scans: bool                 [env_var: true, command_line: true]  [always_valid] = false,
     // Enable a return barrier (not supported)
@@ -667,8 +664,8 @@ options! {
     // XXX: This option is currently only supported on Linux.
     thread_affinity:        AffinityKind         [env_var: true, command_line: true] [|v: &AffinityKind| v.validate()] = AffinityKind::OsDefault,
     // Set the GC trigger. This defines the heap size and how MMTk triggers a GC.
-    // Default to a fixed heap size of 0.3x physical memory.
-    gc_trigger     :        GCTriggerSelector    [env_var: true, command_line: true] [always_valid] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.3f64) as usize)
+    // Default to a fixed heap size of 0.5x physical memory.
+    gc_trigger     :        GCTriggerSelector    [env_var: true, command_line: true] [always_valid] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.5f64) as usize)
 }
 
 #[cfg(test)]

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -570,6 +570,7 @@ mod gc_trigger_tests {
             GCTriggerSelector::from_str("FixedHeapSize:4m"),
             Ok(GCTriggerSelector::FixedHeapSize(4 * 1024 * 1024))
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             GCTriggerSelector::from_str("FixedHeapSize:4t"),
             Ok(GCTriggerSelector::FixedHeapSize(

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -513,12 +513,12 @@ mod gc_trigger_tests {
         assert_eq!(GCTriggerSelector::parse_size("2M"), Ok(2 * 1024 * 1024));
         assert_eq!(GCTriggerSelector::parse_size("2m"), Ok(2 * 1024 * 1024));
         assert_eq!(
-            GCTriggerSelector::parse_size("4G"),
-            Ok(4 * 1024 * 1024 * 1024)
+            GCTriggerSelector::parse_size("2G"),
+            Ok(2 * 1024 * 1024 * 1024)
         );
         assert_eq!(
-            GCTriggerSelector::parse_size("4g"),
-            Ok(4 * 1024 * 1024 * 1024)
+            GCTriggerSelector::parse_size("2g"),
+            Ok(2 * 1024 * 1024 * 1024)
         );
 
         // empty

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -19,7 +19,7 @@ pub extern "C" fn mmtk_init(heap_size: usize) {
     // set heap size first
     {
         let mut builder = BUILDER.lock().unwrap();
-        let success = builder.options.heap_size.set(heap_size);
+        let success = builder.options.gc_trigger.set(mmtk::util::options::GCTriggerSelector::FixedHeapSize(heap_size));
         assert!(success, "Failed to set heap size to {}", heap_size);
     }
 


### PR DESCRIPTION
This PR adds `GCTrigger` and forwards calls related with GC triggering to `GCTrigger`. `GCTrigger` would allow different implementations, such as fixed heap size, dynamic resizing, and runtime delegation. This PR only implements `FixedHeapSizeTrigger` and a simplified version of `MemBalancerTrigger`. This PR closes https://github.com/mmtk/mmtk-core/issues/561, and makes it easier to implement https://github.com/mmtk/mmtk-core/issues/641.

Changes:
* Adds `util::heap::gc_trigger::GCTrigger`. `Plan::poll()` is moved to `GCTrigger`. Any call to `Plan::poll()` is replaced with `GCTrigger::poll()`.
* Adds `util::options::GCTriggerSelector` and `gc_trigger` in `Options`. `gc_trigger` defaults to a fixed heap size of half of the physical memory.
* Refactoring on arguments for creating plans and spaces.
  * I needed to pass `GCTrigger` to plans and spaces so I think it would be better that I just take this chance to do the refactoring. 
  * We now have structs to organize the arguments and any plan and space will receive the same set of the arguments for their constructors. This greatly simplifies our code.

Performance:
There is very little difference for the refactoring in this PR. The following compares this PR with master, both using the same fixed heap size. It shows the refactoring and the changes have no measurable overhead.

![gc_trigger](https://user-images.githubusercontent.com/1664709/207722172-4b506c0e-5949-4252-b525-a671fbbef500.png)
<details>
  <summary>Plotty link (not public visible)</summary>
https://squirrel.anu.edu.au/plotty/yilin/mmtk/#0|skunk-2022-12-14-Wed-054336&benchmark^build^invocation^iteration&bmtime^time^time.other^time.stw&|10&iteration^1^2|20&1^invocation|30&1&benchmark&build;jdk-mmtk-master|41&Histogram%20(with%20CI)^build^benchmark&
</details>