### PR TITLE
Fix some documentation issues

### DIFF
--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -3,6 +3,9 @@
 # rustdoc.yml will copy the docs from respective directories to a directory for publishing.
 # If the output path is changed in this script, we need to update rustdoc.yml as well.
 
+# deny warnings for rustdoc
+export RUSTFLAGS="-D warnings"
+
 # Check cargo doc
 # We generate two versions of docs: one with only public items for binding developers for our API, and
 # the other with both public and private items for MMTk developers (GC implementers).

--- a/docs/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/tutorial/code/mygc_semispace/gc_work.rs
@@ -25,7 +25,7 @@ impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext2<VM> {
 }
 // ANCHOR: workcontext_plan
 
-use crate::util::{Address, ObjectReference};
+use crate::util::ObjectReference;
 use crate::util::copy::CopySemantics;
 use crate::MMTK;
 use crate::policy::space::Space;

--- a/docs/tutorial/code/mygc_semispace/global.rs
+++ b/docs/tutorial/code/mygc_semispace/global.rs
@@ -13,17 +13,12 @@ use crate::policy::space::Space;
 use crate::scheduler::*; // Modify
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
-use crate::util::heap::layout::heap_layout::Mmapper;
-use crate::util::heap::layout::heap_layout::VMMap;
-use crate::util::heap::HeapMeta;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::{SideMetadataSanity, SideMetadataContext};
-use crate::util::options::Options;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
 use std::sync::atomic::{AtomicBool, Ordering}; // Add
-use std::sync::Arc;
 // ANCHOR_END: imports_no_gc_work
 
 // Remove #[allow(unused_imports)].

--- a/docs/tutorial/code/mygc_semispace/mod.rs
+++ b/docs/tutorial/code/mygc_semispace/mod.rs
@@ -1,3 +1,6 @@
+// This module's code is unused When we compile this module with MMTk core. Allow it.
+#![allow(dead_code)]
+
 mod gc_work; // Add
 mod global;
 mod mutator;

--- a/docs/tutorial/src/mygc/ss/alloc.md
+++ b/docs/tutorial/src/mygc/ss/alloc.md
@@ -66,6 +66,15 @@ Finished code (step 2):
 {{#include ../../../code/mygc_semispace/global.rs:plan_def}}
 ```
 
+Note that we have attributes on some fields. These attributes tell MMTk's macros on
+how to generate code to trace objects in this plan. Although there are other approaches that
+you can implement object tracing, in this tutorial we use the macros, as it is the simplest.
+Make sure you import the macros. We will discuss on what those attributes mean in later sections.
+
+```rust
+use mmtk_macros::PlanTraceObject;
+```
+
 ### Implement the Plan trait for MyGC
 
 #### Constructor
@@ -86,16 +95,6 @@ that you just defined.
    4. Finally, replace the old MyGC initializer.
 ```rust
 {{#include ../../../code/mygc_semispace/global.rs:plan_new}}
-```
-
-#### Initializer
-
-Find `gc_init()`. Change it to initialise the common plan and the two 
-copyspaces, rather than the base plan and mygc_space. The contents of the 
-initializer calls are identical.
-
-```rust
-{{#include ../../../code/mygc_semispace/global.rs:gc_init}}
 ```
 
 ### Access MyGC spaces

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -28,17 +28,17 @@ use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 use std::sync::atomic::Ordering;
 
-/// Initialize an MMTk instance. A VM should call this method after creating an [MMTK](../mmtk/struct.MMTK.html)
+/// Initialize an MMTk instance. A VM should call this method after creating an [`crate::MMTK`]
 /// instance but before using any of the methods provided in MMTk (except `process()` and `process_bulk()`).
 ///
 /// We expect a binding to ininitialize MMTk in the following steps:
 ///
-/// 1. Create an [MMTKBuilder](../mmtk/struct.MMTKBuilder.html) instance.
-/// 2. Set command line options for MMTKBuilder by [process()](./fn.process.html) or [process_bulk()](./fn.process_bulk.html).
+/// 1. Create an [`crate::MMTKBuilder`] instance.
+/// 2. Set command line options for MMTKBuilder by [`crate::memory_manager::process`] or [`crate::memory_manager::process_bulk`].
 /// 3. Initialize MMTk by calling this function, `mmtk_init()`, and pass the builder earlier. This call will return an MMTK instance.
 ///    Usually a binding store the MMTK instance statically as a singleton. We plan to allow multiple instances, but this is not yet fully
 ///    supported. Currently we assume a binding will only need one MMTk instance.
-/// 4. Enable garbage collection in MMTk by [enable_collection()](./fn.enable_collection.html). A binding should only call this once its
+/// 4. Enable garbage collection in MMTk by [`crate::memory_manager::enable_collection`]. A binding should only call this once its
 ///    thread system is ready. MMTk will not trigger garbage collection before this call.
 ///
 /// Note that this method will attempt to initialize a logger. If the VM would like to use its own logger, it should initialize the logger before calling this method.

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -1027,7 +1027,7 @@ pub enum AllocationSemantics {
     Immortal = 1,
     /// Large objects. It is usually desirable to allocate large objects specially. Large objects
     /// are allocated with page granularity and will not be moved.
-    /// Each plan provides `max_non_los_default_alloc_bytes` (see [`crate::plan::plan_constraints::PlanConstraints`]),
+    /// Each plan provides `max_non_los_default_alloc_bytes` (see [`crate::plan::PlanConstraints`]),
     /// which defines a threshold for objects that can be allocated with the default semantic. Any object that is larger than the
     /// threshold must be allocated with the `Los` semantic.
     /// This semantic may get removed and MMTk will transparently allocate into large object space for large objects.

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -56,4 +56,3 @@ pub use marksweep::MS_CONSTRAINTS;
 pub use nogc::NOGC_CONSTRAINTS;
 pub use pageprotect::PP_CONSTRAINTS;
 pub use semispace::SS_CONSTRAINTS;
-pub mod mygc;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -56,3 +56,4 @@ pub use marksweep::MS_CONSTRAINTS;
 pub use nogc::NOGC_CONSTRAINTS;
 pub use pageprotect::PP_CONSTRAINTS;
 pub use semispace::SS_CONSTRAINTS;
+pub mod mygc;

--- a/src/policy/copy_context.rs
+++ b/src/policy/copy_context.rs
@@ -9,7 +9,7 @@ use crate::vm::VMBinding;
 /// mature space is ImmixSpace. When we copy from nursery to mature, ImmixCopyContext should be
 /// used.
 /// Note that this trait should only be implemented with policy specific behaviors. Please
-/// refer to [GCWorkerCopyContext](util/copy/struct.GCWorkerCopyContext.html) which implements common
+/// refer to [`crate::util::copy::GCWorkerCopyContext`] which implements common
 /// behaviors for copying.
 pub trait PolicyCopyContext: 'static + Send {
     type VM: VMBinding;

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -763,7 +763,7 @@ use crate::plan::Plan;
 use crate::plan::PlanTraceObject;
 use crate::policy::gc_work::TraceKind;
 
-/// This provides an implementation of [`ProcessEdgesWork`](scheduler/gc_work/ProcessEdgesWork). A plan that implements
+/// This provides an implementation of [`crate::scheduler::gc_work::ProcessEdgesWork`]. A plan that implements
 /// `PlanTraceObject` can use this work packet for tracing objects.
 pub struct PlanProcessEdges<
     VM: VMBinding,

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -24,7 +24,7 @@ const MAX_IMMIX_COPY_ALLOCATORS: usize = 2;
 type CopySpaceMapping<VM> = Vec<(CopySelector, &'static dyn Space<VM>)>;
 
 /// A configuration for GCWorkerCopyContext.
-/// Similar to [MutatorConfig](plan/mutator_context/struct.MutatorConfig.html),
+/// Similar to a `MutatorConfig`,
 /// We expect each copying plan to provide a CopyConfig.
 pub struct CopyConfig<VM: VMBinding> {
     /// Mapping CopySemantics to the actual copying allocators (CopySelector)

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -127,7 +127,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for FixedHeapSizeTrigger {
     }
 }
 
-/// An implementation of MemBalancer (Optimal heap limits for reducing browser memory use, https://dl.acm.org/doi/10.1145/3563323)
+/// An implementation of MemBalancer (Optimal heap limits for reducing browser memory use, <https://dl.acm.org/doi/10.1145/3563323>)
 /// We use MemBalancer to decide a heap limit between the min heap and the max heap.
 /// The current implementation is a simplified version of mem balancer and it does not take collection/allocation speed into account,
 /// and uses a fixed constant instead.

--- a/src/util/metadata/metadata_val_traits.rs
+++ b/src/util/metadata/metadata_val_traits.rs
@@ -4,7 +4,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use num_traits::{Unsigned, WrappingAdd, WrappingSub, Zero};
 
 /// Describes bits and log2 bits for the numbers.
-/// If num_traits has this, we do not need our own implementation: https://github.com/rust-num/num-traits/issues/247
+/// If num_traits has this, we do not need our own implementation: <https://github.com/rust-num/num-traits/issues/247>
 pub trait Bits {
     const BITS: u32;
     const LOG2: u32;
@@ -24,7 +24,7 @@ impl_bits_trait!(u64);
 impl_bits_trait!(usize);
 
 /// Describes bitwise operations.
-/// If num_traits has this, we do not need our own implementation: https://github.com/rust-num/num-traits/issues/232
+/// If num_traits has this, we do not need our own implementation: <https://github.com/rust-num/num-traits/issues/232>
 pub trait BitwiseOps {
     fn bitand(self, other: Self) -> Self;
     fn bitor(self, other: Self) -> Self;

--- a/src/util/opaque_pointer.rs
+++ b/src/util/opaque_pointer.rs
@@ -44,14 +44,14 @@ impl VMThread {
     pub const UNINITIALIZED: Self = Self(OpaquePointer::UNINITIALIZED);
 }
 
-/// A VMMutatorThread is a VMThread that associates with a [Mutator](plan/mutator_context/Mutator).
+/// A VMMutatorThread is a VMThread that associates with a [`crate::plan::Mutator`].
 /// When a VMMutatorThread is used as an argument or a field of a type, it generally means
 /// the function or the functions for the type is executed in the context of the mutator thread.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct VMMutatorThread(pub VMThread);
 
-/// A VMWorkerThread is a VMThread that is associates with a [GCWorker](scheduler/GCWorker).
+/// A VMWorkerThread is a VMThread that is associates with a [`crate::scheduler::GCWorker`].
 /// When a VMWorkerThread is used as an argument or a field of a type, it generally means
 /// the function or the functions for the type is executed in the context of the mutator thread.
 #[repr(transparent)]

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -57,12 +57,6 @@ use crate::vm::VMBinding;
 /// and for a third SideMetadataSpec (`LS3`), the `offset` will be `BASE(LS2) + required_metadata_space_per_chunk(LS2)`.
 ///
 /// For all other policies, the `offset` starts from zero. This is safe because no two policies ever manage one chunk, so there will be no overlap.
-///
-/// [`HeaderMetadataSpec`]: ../util/metadata/header_metadata/struct.HeaderMetadataSpec.html
-/// [`SideMetadataSpec`]:   ../util/metadata/side_metadata/strutc.SideMetadataSpec.html
-/// [`header_metadata`]:    ../util/metadata/header_metadata/index.html
-/// [`GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS`]: ../util/metadata/side_metadata/constant.GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS.html
-/// [`LOCAL_SIDE_METADATA_VM_BASE_ADDRESS`]:  ../util/metadata/side_metadata/constant.LOCAL_SIDE_METADATA_VM_BASE_ADDRESS.html
 pub trait ObjectModel<VM: VMBinding> {
     // Per-object Metadata Spec definitions go here
     //


### PR DESCRIPTION
This PR fixes some outdated text in the tutorial (https://mmtk.zulipchat.com/#narrow/stream/262679-General/topic/Tutorial.20Feedback/near/316653711), and fixes some hard-coded rustdoc link with paths (https://github.com/mmtk/mmtk-core/issues/713). This closes https://github.com/mmtk/mmtk-core/issues/713.

It also adds a check in our rustdoc generation to deny warnings.