### PR TITLE
Immix: Clear alloc bits during sweeping

### DIFF
--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -241,6 +241,9 @@ impl Block {
                         holes += 1;
                     }
 
+                    #[cfg(feature = "global_alloc_bit")]
+                    crate::util::alloc_bit::bzero_alloc_bit(line.start(), Line::BYTES);
+
                     #[cfg(feature = "immix_zero_on_release")]
                     crate::util::memory::zero(line.start(), Line::BYTES);
 

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -510,8 +510,6 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 Block::containing::<VM>(object).set_state(BlockState::Marked);
                 object
             } else {
-                #[cfg(feature = "global_alloc_bit")]
-                crate::util::alloc_bit::unset_alloc_bit::<VM>(object);
                 ForwardingWord::forward_object::<VM>(object, semantics, copy_context)
             };
             debug_assert_eq!(

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -257,8 +257,6 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     end_line,
                     self.tls
                 );
-                #[cfg(feature = "global_alloc_bit")]
-                crate::util::alloc_bit::bzero_alloc_bit(self.cursor, self.limit - self.cursor);
                 crate::util::memory::zero(self.cursor, self.limit - self.cursor);
                 debug_assert!(
                     align_allocation_no_fill::<VM>(self.cursor, align, offset) + size <= self.limit


### PR DESCRIPTION
No longer clear alloc bit when an object is being moved.  This fixes an assertion error when trace_object is called on the same object twice during defrag GC.

Clear alloc bits eagerly during sweeping instead of during allocation. This ensures an address has the alloc bit (i.e. valid-object bit) if and only if that address corresponds to a valid object reference during mutator execution.