### PR TITLE
Allow forwarding bits to be on the side for Immix

### DIFF
--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -100,8 +100,18 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
     /// * `bytes`: The size of the object in bytes.
     /// * `semantics`: The copy semantic used for the copying.
     pub fn post_copy(&mut self, object: ObjectReference, bytes: usize, semantics: CopySemantics) {
-        // Clear forwarding bits.
-        object_forwarding::clear_forwarding_bits::<VM>(object);
+        // Clear forwarding bits if the forwarding bits are in the header.
+        if !VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC.is_on_side() {
+            object_forwarding::clear_forwarding_bits::<VM>(object);
+        } else {
+            // NOTE: If the forwarding bits were on the side, they would have been cleared when
+            // preparing the space.  See:
+            // - `CopySpace::prepare` and
+            // - `PrepareBlockState::reset_object_mark`.
+            debug_assert!(!object_forwarding::is_forwarded_or_being_forwarded::<VM>(
+                object
+            ));
+        }
         // If we are copying objects in mature space, we would need to mark the object as mature.
         if semantics.is_mature() && self.config.constraints.needs_log_bit {
             // If the plan uses unlogged bit, we set the unlogged bit (the object is unlogged/mature)


### PR DESCRIPTION
Now ImmixSpace can use on-the-side forwarding bits metadata.  When on the side, the forwarding bits are eagerly cleared when sweeping lines.

It is useful for adding Immix support to an existing VM where we can't squeeze any bits out of the existing object header for GC.

How to test: We can use mmtk-openjdk, and change `FORWARDING_BITS_METADATA_SPEC` to a side metadata.

```diff
 pub(crate) const FORWARDING_BITS_METADATA_SPEC: VMLocalForwardingBitsSpec =
-    VMLocalForwardingBitsSpec::in_header(FORWARDING_BITS_OFFSET);
+    VMLocalForwardingBitsSpec::side_after(MARKING_METADATA_SPEC.as_spec());
```