### PR TITLE
Other changes related Immix for Ruby

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -52,7 +52,6 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
         self.get_name()
     }
 
-    #[inline(always)]
     fn get_forwarded_object(&self, object: ObjectReference) -> Option<ObjectReference> {
         if !Block::containing::<VM>(object).is_defrag_source() {
             return None;

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -51,6 +51,20 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
     fn name(&self) -> &str {
         self.get_name()
     }
+
+    #[inline(always)]
+    fn get_forwarded_object(&self, object: ObjectReference) -> Option<ObjectReference> {
+        if !Block::containing::<VM>(object).is_defrag_source() {
+            return None;
+        }
+
+        if ForwardingWord::is_forwarded::<VM>(object) {
+            Some(ForwardingWord::read_forwarding_pointer::<VM>(object))
+        } else {
+            None
+        }
+    }
+
     fn is_live(&self, object: ObjectReference) -> bool {
         if !super::DEFRAG {
             // If defrag is disabled, we won't forward objects.

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -728,15 +728,6 @@ impl<E: ProcessEdgesWork> RootsWorkFactory<EdgeOf<E>> for ProcessEdgesWorkRootsW
     }
 
     fn create_process_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
-        // Note: Node roots cannot be moved.  Currently, this implies that the plan must never
-        // move objects.  However, in the future, if we start to support object pinning, then
-        // moving plans that support object pinning (such as Immix) can still use node roots.
-        assert!(
-            !self.mmtk.plan.constraints().moves_objects,
-            "Attempted to add node roots when using a plan that moves objects.  Plan: {:?}",
-            *self.mmtk.options.plan
-        );
-
         // We want to use E::create_scan_work.
         let process_edges_work = E::new(vec![], true, self.mmtk);
         let work = process_edges_work.create_scan_work(nodes, true);


### PR DESCRIPTION
These are small changes related to getting Ruby working with Immix.

**Implemented `get_forwarded_object` for ImmixSpace.**  `mmtk-core` didn't use the `get_forwarded_object` method.  In theory, we can let Ruby support copying GC without that method.  The `trace_object` method is sufficient to forward all fields.  However, it feels odd to have that method exposed as a method of `ObjectReference` but not implemented for Immix.  It is a nice debugging tool.  It is also useful during weak reference processing where the VM wants to forward weak fields, but not expand the transitive closure.

**Removed an assertion that the plan must be non-moving when scanning non-moving roots.**  Now that we already have object pinning for Immix, it is no longer relevant.