### PR TITLE
Notify GC trigger about pending allocation

### DIFF
--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -68,8 +68,14 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         if should_poll && self.get_gc_trigger().poll(false, Some(self.as_space())) {
             debug!("Collection required");
             assert!(allow_gc, "GC is not allowed here: collection is not initialized (did you call initialize_collection()?).");
+
+            // Clear the request, and inform GC trigger about the pending allocation.
+            pr.clear_request(pages_reserved);
+            self.get_gc_trigger()
+                .policy
+                .on_pending_allocation(pages_reserved);
+
             VM::VMCollection::block_for_gc(VMMutatorThread(tls)); // We have checked that this is mutator
-            pr.clear_request(pages_reserved); // clear the pages after GC. We need those reserved pages so we can compute new heap size properly.
             unsafe { Address::zero() }
         } else {
             debug!("Collection not required");
@@ -175,8 +181,14 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
 
                     let gc_performed = self.get_gc_trigger().poll(true, Some(self.as_space()));
                     debug_assert!(gc_performed, "GC not performed when forced.");
+
+                    // Clear the request, and inform GC trigger about the pending allocation.
+                    pr.clear_request(pages_reserved);
+                    self.get_gc_trigger()
+                        .policy
+                        .on_pending_allocation(pages_reserved);
+
                     VM::VMCollection::block_for_gc(VMMutatorThread(tls)); // We asserted that this is mutator.
-                    pr.clear_request(pages_reserved); // clear the pages after GC. We need those reserved pages so we can compute new heap size properly.
                     unsafe { Address::zero() }
                 }
             }

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -364,6 +364,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
                 );
             }
         });
+        // Clear pending allocation pages at the end of GC, no matter we used it or not.
+        self.pending_pages.store(0, Ordering::SeqCst);
     }
 
     fn is_gc_required(
@@ -480,9 +482,8 @@ impl MemBalancerTrigger {
             (live as f64 * 4096f64).sqrt()
         };
 
-        // Get pending allocations and clear it
+        // Get pending allocations
         let pending_pages = self.pending_pages.load(Ordering::SeqCst);
-        self.pending_pages.store(0, Ordering::SeqCst);
 
         // This is the optimal heap limit due to mem balancer. We will need to clamp the value to the defined min/max range.
         let optimal_heap = live + e as usize + extra_reserve + pending_pages;


### PR DESCRIPTION
This PR reverts a change about where to call `pr.clear_request()` in `Space.acquire()` in https://github.com/mmtk/mmtk-core/pull/712. The change caused issues like https://github.com/mmtk/mmtk-core/issues/734. This PR reverts the change. We now clear the reserved pages before GC (the same as before, and the same as Java MMTk), and additionally we inform the GC trigger about pending allocation pages. This closes https://github.com/mmtk/mmtk-core/issues/734.