### PR TITLE
Set entire byte for side log bit when we copy objects to mature space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ cfg-if = "1.0"
 itertools = "0.10.5"
 sys-info = "0.9"
 regex = "1.7.0"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ extern crate crossbeam;
 extern crate num_cpus;
 #[macro_use]
 extern crate downcast_rs;
+#[macro_use]
+extern crate static_assertions;
 
 mod mmtk;
 pub use mmtk::MMTKBuilder;

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -591,7 +591,11 @@ impl<VM: VMBinding> ImmixSpace<VM> {
 
     fn unlog_object_if_needed(&self, object: ObjectReference) {
         if self.space_args.unlog_object_when_traced {
-            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
+            // Every immix line is 256 bytes, which is mapped to 4 bytes in the side metadata.
+            // If we have one object in the line that is mature, we can assume all the objects in the line are mature objects.
+            // So we can just mark the byte.
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
+                .mark_byte_as_unlogged::<VM>(object, Ordering::Relaxed);
         }
     }
 

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -123,7 +123,7 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
         if semantics.is_mature() && self.config.constraints.needs_log_bit {
             // If the plan uses unlogged bit, we set the unlogged bit (the object is unlogged/mature)
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
-                .mark_as_unlogged_in_mature_space::<VM>(object, Ordering::SeqCst);
+                .mark_byte_as_unlogged::<VM>(object, Ordering::Relaxed);
         }
         // Policy specific post copy.
         match self.config.copy_mapping[semantics] {

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -115,7 +115,8 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
         // If we are copying objects in mature space, we would need to mark the object as mature.
         if semantics.is_mature() && self.config.constraints.needs_log_bit {
             // If the plan uses unlogged bit, we set the unlogged bit (the object is unlogged/mature)
-            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
+                .mark_as_unlogged_in_mature_space::<VM>(object, Ordering::SeqCst);
         }
         // Policy specific post copy.
         match self.config.copy_mapping[semantics] {

--- a/src/util/metadata/log_bit.rs
+++ b/src/util/metadata/log_bit.rs
@@ -3,9 +3,31 @@ use crate::vm::VMBinding;
 use crate::vm::VMGlobalLogBitSpec;
 use std::sync::atomic::Ordering;
 
+use super::MetadataSpec;
+
 impl VMGlobalLogBitSpec {
     /// Mark the log bit as unlogged (1 means unlogged)
     pub fn mark_as_unlogged<VM: VMBinding>(&self, object: ObjectReference, order: Ordering) {
         self.store_atomic::<VM, u8>(object, 1, None, order)
+    }
+
+    /// Mark the log bit as unlogged for an object in the mature space. This method should only be used
+    /// if the object is in the mature space (i.e. every object in the same space is mature object).
+    /// This method is meant to be an optimization, and can always be replaced with `mark_as_unlogged`.
+    pub fn mark_as_unlogged_in_mature_space<VM: VMBinding>(
+        &self,
+        object: ObjectReference,
+        order: Ordering,
+    ) {
+        match self.as_spec() {
+            // If the log bit is in the header, there is nothing we can do. We just call `mark_as_unlogged`.
+            MetadataSpec::InHeader(_) => self.mark_as_unlogged::<VM>(object, order),
+            // If the log bit is in the side metadata, we can simply set the entire byte to 0xff. Because we
+            // know we are setting log bit for mature space, and every object in the space should have log
+            // bit as 1.
+            MetadataSpec::OnSide(spec) => unsafe {
+                spec.set_raw_byte_atomic(object.to_address::<VM>(), order)
+            },
+        }
     }
 }

--- a/src/util/metadata/log_bit.rs
+++ b/src/util/metadata/log_bit.rs
@@ -15,11 +15,7 @@ impl VMGlobalLogBitSpec {
     /// it may unlog adjacent objects. This method should only be used
     /// when adjacent objects are also in the mature space, and there is no harm if we also unlog them.
     /// This method is meant to be an optimization, and can always be replaced with `mark_as_unlogged`.
-    pub fn mark_byte_as_unlogged<VM: VMBinding>(
-        &self,
-        object: ObjectReference,
-        order: Ordering,
-    ) {
+    pub fn mark_byte_as_unlogged<VM: VMBinding>(&self, object: ObjectReference, order: Ordering) {
         match self.as_spec() {
             // If the log bit is in the header, there is nothing we can do. We just call `mark_as_unlogged`.
             MetadataSpec::InHeader(_) => self.mark_as_unlogged::<VM>(object, order),

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -20,7 +20,7 @@ use crate::util::constants::*;
 mod active_plan;
 mod collection;
 pub mod edge_shape;
-mod object_model;
+pub(crate) mod object_model;
 mod reference_glue;
 mod scanning;
 pub use self::active_plan::ActivePlan;


### PR DESCRIPTION
This PR adds `SideMetadataSpec:: set_raw_byte_atomic` and use it to implement `VMGlobalLogBitSpec ::mark_byte_as_unlogged`. We use the new method to unlog objects for two scenarios: 1. copy objects to a mature space, and 2. unlog immix objects during tracing in sticky immix.