### PR TITLE
Add missing set_worker

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -797,6 +797,7 @@ pub trait ScanObjectsWork<VM: VMBinding>: GCWork<VM> + Sized {
         let scanned_root_objects = self.roots().then(|| {
             // We create an instance of E to use its `trace_object` method and its object queue.
             let mut process_edges_work = Self::E::new(vec![], false, mmtk);
+            process_edges_work.set_worker(worker);
 
             for object in buffer.iter().copied() {
                 let new_object = process_edges_work.trace_object(object);


### PR DESCRIPTION
The worker was not set after creating the `ProcessEdgesWork`.  It didn't crash because that `ProcessEdgesWork` was used to trace node roots.  Node roots are pinned, so it never used the copy context in the worker.  But the newly added `debug_assert!` in `ImmixSpace::trace_object` accesses the `worker`, and it will crash fail if `worker` is null.