### PR TITLE
Add feature to stress copying for Immix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ is_mmtk_object = ["global_alloc_bit"]
 # Enable object pinning, in particular, enable pinning/unpinning, and its metadata
 object_pinning = []
 
-# The following two features are useful for using Immix for VMs that do not support moving GC.
+# The following features are useful for using Immix for VMs that do not support moving GC.
 
 # Disable defragmentation for ImmixSpace.  This makes Immix a non-moving plan.
 immix_no_defrag = []
@@ -98,8 +98,22 @@ immix_no_defrag = []
 immix_no_nursery_copy = []
 # Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.
 immix_smaller_block = []
+
+# The following features are useful for debugging moving GC when using Immix.
+# If the VM cannot use Semispace for this purpose (for example, if the VM needs object pinning),
+# these features will make Immix copy as many objects as possible.
+
+# Make every GC a defragment GC.
+immix_stress_defrag = []
+# Make Immix copy as many objects as possible.
+# It makes every GC a defragment GC and marks every allocated block as defragmentation source.
+immix_stress_copy = ["immix_stress_defrag"]
+
+# General Immix features
+
 # Zero the unmarked lines after a GC cycle in immix. This helps debug untraced objects.
 immix_zero_on_release = []
+
 
 # Run sanity GC
 sanity = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ is_mmtk_object = ["global_alloc_bit"]
 # Enable object pinning, in particular, enable pinning/unpinning, and its metadata
 object_pinning = []
 
-# The following features are useful for using Immix for VMs that do not support moving GC.
+# The following two features are useful for using Immix for VMs that do not support moving GC.
 
 # Disable defragmentation for ImmixSpace.  This makes Immix a non-moving plan.
 immix_no_defrag = []
@@ -98,22 +98,8 @@ immix_no_defrag = []
 immix_no_nursery_copy = []
 # Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.
 immix_smaller_block = []
-
-# The following features are useful for debugging moving GC when using Immix.
-# If the VM cannot use Semispace for this purpose (for example, if the VM needs object pinning),
-# these features will make Immix copy as many objects as possible.
-
-# Make every GC a defragment GC.
-immix_stress_defrag = []
-# Make Immix copy as many objects as possible.
-# It makes every GC a defragment GC and marks every allocated block as defragmentation source.
-immix_stress_copy = ["immix_stress_defrag"]
-
-# General Immix features
-
 # Zero the unmarked lines after a GC cycle in immix. This helps debug untraced objects.
 immix_zero_on_release = []
-
 
 # Run sanity GC
 sanity = []

--- a/src/policy/immix/defrag.rs
+++ b/src/policy/immix/defrag.rs
@@ -29,7 +29,6 @@ impl Defrag {
     const NUM_BINS: usize = (Block::LINES >> 1) + 1;
     const DEFRAG_LINE_REUSE_RATIO: f32 = 0.99;
     const MIN_SPILL_THRESHOLD: usize = 2;
-    const DEFRAG_STRESS: bool = false;
     const DEFRAG_HEADROOM_PERCENT: usize = 2;
 
     /// Allocate a new local histogram.
@@ -61,7 +60,7 @@ impl Defrag {
             && (emergency_collection
                 || (collection_attempts > 1)
                 || !exhausted_reusable_space
-                || Self::DEFRAG_STRESS
+                || super::STRESS_DEFRAG
                 || (collect_whole_heap && user_triggered && full_heap_system_gc));
         // println!("Defrag: {}", in_defrag);
         self.in_defrag_collection

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -791,11 +791,10 @@ impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
                 continue;
             }
             // Check if this block needs to be defragmented.
-            if super::DEFRAG && defrag_threshold != 0 && block.get_holes() > defrag_threshold {
-                block.set_as_defrag_source(true);
-            } else {
-                block.set_as_defrag_source(false);
-            }
+            block.set_as_defrag_source(
+                super::DEFRAG_EVERY_BLOCK ||
+                super::DEFRAG && defrag_threshold != 0 && block.get_holes() > defrag_threshold,
+            );
             // Clear block mark data.
             block.set_state(BlockState::Unmarked);
             debug_assert!(!block.get_state().is_reusable());

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -792,8 +792,10 @@ impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
             }
             // Check if this block needs to be defragmented.
             block.set_as_defrag_source(
-                super::DEFRAG_EVERY_BLOCK ||
-                super::DEFRAG && defrag_threshold != 0 && block.get_holes() > defrag_threshold,
+                super::DEFRAG_EVERY_BLOCK
+                    || super::DEFRAG
+                        && defrag_threshold != 0
+                        && block.get_holes() > defrag_threshold,
             );
             // Clear block mark data.
             block.set_state(BlockState::Unmarked);

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -780,7 +780,6 @@ impl<VM: VMBinding> PrepareBlockState<VM> {
 
 impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        let defrag_threshold = self.defrag_threshold.unwrap_or(0);
         // Clear object mark table for this chunk
         self.reset_object_mark();
         // Iterate over all blocks in this chunk
@@ -791,12 +790,20 @@ impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
                 continue;
             }
             // Check if this block needs to be defragmented.
-            block.set_as_defrag_source(
-                super::DEFRAG_EVERY_BLOCK
-                    || super::DEFRAG
-                        && defrag_threshold != 0
-                        && block.get_holes() > defrag_threshold,
-            );
+            let is_defrag_source = if !super::DEFRAG {
+                // Do not set any block as defrag source if defrag is disabled.
+                false
+            } else if super::DEFRAG_EVERY_BLOCK {
+                // Set every block as defrag source if so desired.
+                true
+            } else if let Some(defrag_threshold) = self.defrag_threshold {
+                // This GC is a defrag GC.
+                block.get_holes() > defrag_threshold
+            } else {
+                // Not a defrag GC.
+                false
+            };
+            block.set_as_defrag_source(is_defrag_source);
             // Clear block mark data.
             block.set_state(BlockState::Unmarked);
             debug_assert!(!block.get_state().is_reusable());

--- a/src/policy/immix/mod.rs
+++ b/src/policy/immix/mod.rs
@@ -14,17 +14,15 @@ pub const MAX_IMMIX_OBJECT_SIZE: usize = Block::BYTES >> 1;
 /// Mark/sweep memory for block-level only
 pub const BLOCK_ONLY: bool = false;
 
-#[cfg(all(feature = "immix_no_defrag", feature = "immix_stress_defrag"))]
-compile_error!("feature \"immix_no_defrag\" and feature \"immix_stress_defrag\" cannot be enabled at the same time");
-
 /// Opportunistic copying
 pub const DEFRAG: bool = !cfg!(feature = "immix_no_defrag");
 
 /// Make every GC a defragment GC. (for debugging)
-pub const STRESS_DEFRAG: bool = cfg!(feature = "immix_stress_defrag");
+pub const STRESS_DEFRAG: bool = false;
 
 /// Mark every allocated block as defragmentation source before GC. (for debugging)
-pub const DEFRAG_EVERY_BLOCK: bool = cfg!(feature = "immix_stress_copy");
+/// Set both this and `STRESS_DEFRAG` to true to make Immix move as many objects as possible.
+pub const DEFRAG_EVERY_BLOCK: bool = false;
 
 /// If Immix is used as a nursery space, do we prefer copy?
 /// If this is true, we copy nursery objects if possible.

--- a/src/policy/immix/mod.rs
+++ b/src/policy/immix/mod.rs
@@ -14,8 +14,17 @@ pub const MAX_IMMIX_OBJECT_SIZE: usize = Block::BYTES >> 1;
 /// Mark/sweep memory for block-level only
 pub const BLOCK_ONLY: bool = false;
 
+#[cfg(all(feature = "immix_no_defrag", feature = "immix_stress_defrag"))]
+compile_error!("feature \"immix_no_defrag\" and feature \"immix_stress_defrag\" cannot be enabled at the same time");
+
 /// Opportunistic copying
 pub const DEFRAG: bool = !cfg!(feature = "immix_no_defrag");
+
+/// Make every GC a defragment GC. (for debugging)
+pub const STRESS_DEFRAG: bool = cfg!(feature = "immix_stress_defrag");
+
+/// Mark every allocated block as defragmentation source before GC. (for debugging)
+pub const DEFRAG_EVERY_BLOCK: bool = cfg!(feature = "immix_stress_copy");
 
 /// If Immix is used as a nursery space, do we prefer copy?
 /// If this is true, we copy nursery objects if possible.


### PR DESCRIPTION
Added two features:

-   immix_stress_defrag: make every GC a defrag GC
-   immix_stress_copy: additionally make every block a defrag source

These features will make Immix copy as many objects as possible.  They are useful for debugging object copying for VMs that cannot use Semispace for this purpose.