### PR TITLE
Fix stale forwarding bits bug

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -769,12 +769,6 @@ impl<VM: VMBinding> PrepareBlockState<VM> {
                 unimplemented!("We cannot bulk zero unlogged bit.")
             }
         }
-        if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC {
-            side.bzero_metadata(self.chunk.start(), Chunk::BYTES);
-        }
-        // NOTE: We don't need to reset the forwarding pointer metadata because it is meaningless
-        // until the forwarding bits are also set, at which time we also write the forwarding
-        // pointer.
     }
 }
 
@@ -808,6 +802,18 @@ impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
             block.set_state(BlockState::Unmarked);
             debug_assert!(!block.get_state().is_reusable());
             debug_assert_ne!(block.get_state(), BlockState::Marked);
+            // Clear forwarding bits if necessary.
+            if is_defrag_source {
+                if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC {
+                    // Clear on-the-side forwarding bits.
+                    // NOTE: In theory, we only need to clear the forwarding bits of occupied lines of
+                    // blocks that are defrag sources.
+                    side.bzero_metadata(block.start(), Block::BYTES);
+                }
+            }
+            // NOTE: We don't need to reset the forwarding pointer metadata because it is meaningless
+            // until the forwarding bits are also set, at which time we also write the forwarding
+            // pointer.
         }
     }
 }

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -107,18 +107,8 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
     /// * `bytes`: The size of the object in bytes.
     /// * `semantics`: The copy semantic used for the copying.
     pub fn post_copy(&mut self, object: ObjectReference, bytes: usize, semantics: CopySemantics) {
-        // Clear forwarding bits if the forwarding bits are in the header.
-        if !VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC.is_on_side() {
-            object_forwarding::clear_forwarding_bits::<VM>(object);
-        } else {
-            // NOTE: If the forwarding bits were on the side, they would have been cleared when
-            // preparing the space.  See:
-            // - `CopySpace::prepare` and
-            // - `PrepareBlockState::reset_object_mark`.
-            debug_assert!(!object_forwarding::is_forwarded_or_being_forwarded::<VM>(
-                object
-            ));
-        }
+        // Clear forwarding bits.
+        object_forwarding::clear_forwarding_bits::<VM>(object);
         // If we are copying objects in mature space, we would need to mark the object as mature.
         if semantics.is_mature() && self.config.constraints.needs_log_bit {
             // If the plan uses unlogged bit, we set the unlogged bit (the object is unlogged/mature)


### PR DESCRIPTION
When copying, we erroneously assumed that the forwarding bits of the new copy must not have been set if the forwarding bits metadata is on the side.  If the new copy is allocated in a previously free chunk, it may contain stale forwarding bits from the previous GC.

Now we clear forwarding bits in post_copy regardless whether the forwarding bits metadata is in the header or on the side.

Given that post_copy always clears forwarding bits, PrepareBlockState now only clears forwarding bits for defrag source blocks of ImmixSpace.

Closes: https://github.com/mmtk/mmtk-core/issues/776