### PR TITLE
Introduce immix_non_moving to replace the current immix_no_defrag and immix_no_nursery_copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,10 +92,9 @@ object_pinning = []
 
 # The following two features are useful for using Immix for VMs that do not support moving GC.
 
-# Disable defragmentation for ImmixSpace.  This makes Immix a non-moving plan.
-immix_no_defrag = []
-# Disable nursery copy for ImmixSpace. This along with immix_no_defrag makes StickyImmix a non-moving plan.
-immix_no_nursery_copy = []
+# Disable any object copying in Immix. This makes Immix a non-moving policy.
+immix_non_moving = []
+
 # Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.
 immix_smaller_block = []
 # Zero the unmarked lines after a GC cycle in immix. This helps debug untraced objects.

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -246,7 +246,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         args: crate::policy::space::PlanCreateSpaceArgs<VM>,
         space_args: ImmixSpaceArgs,
     ) -> Self {
-        #[cfg(feature = "immix_no_defrag")]
+        #[cfg(feature = "immix_non_moving")]
         info!(
             "Creating non-moving ImmixSpace: {}. Block size: 2^{}",
             args.name,

--- a/src/policy/immix/mod.rs
+++ b/src/policy/immix/mod.rs
@@ -14,8 +14,8 @@ pub const MAX_IMMIX_OBJECT_SIZE: usize = Block::BYTES >> 1;
 /// Mark/sweep memory for block-level only
 pub const BLOCK_ONLY: bool = false;
 
-/// Opportunistic copying
-pub const DEFRAG: bool = !cfg!(feature = "immix_no_defrag");
+/// Do we allow Immix to do defragmentation?
+pub const DEFRAG: bool = !cfg!(feature = "immix_non_moving"); // defrag if we are allowed to move.
 
 /// Make every GC a defragment GC. (for debugging)
 pub const STRESS_DEFRAG: bool = false;
@@ -25,8 +25,7 @@ pub const STRESS_DEFRAG: bool = false;
 pub const DEFRAG_EVERY_BLOCK: bool = false;
 
 /// If Immix is used as a nursery space, do we prefer copy?
-/// If this is true, we copy nursery objects if possible.
-pub const PREFER_COPY_ON_NURSERY_GC: bool = !cfg!(feature = "immix_no_nursery_copy");
+pub const PREFER_COPY_ON_NURSERY_GC: bool = !cfg!(feature = "immix_non_moving"); // copy nursery objects if we are allowed to move.
 
 /// In some cases/settings, Immix may never move objects.
 /// Currently we only have two cases where we move objects: 1. defrag, 2. nursery copy.


### PR DESCRIPTION
This PR introduces a feature `immix_non_moving`. Based on the proposal https://github.com/mmtk/mmtk-core/issues/775, defrag or nursery copy could simply be a constant controlled by the feature `immix_non_moving`. This also solves the confusion that a binding needs to enable `immix_no_nursery_copy` to make the Immix policy non-moving even if they use Immix which does not do nursery copy.