### PR TITLE
Fix bugs in StickyImmix

### DIFF
--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -273,7 +273,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
         let min_nursery = plan.base().options.get_min_nursery_pages();
         let next_gc_full_heap = available < min_nursery;
         trace!(
-            "next gc will be full heap? {}, availabe pages = {}, min nursery = {}",
+            "next gc will be full heap? {}, available pages = {}, min nursery = {}",
             next_gc_full_heap,
             available,
             min_nursery
@@ -288,7 +288,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
     }
 
     /// Get pages reserved for the collection by a generational plan. A generational plan should
-    /// add their own reservatioin with the value returned by this method.
+    /// add their own reservation with the value returned by this method.
     pub fn get_collection_reserved_pages(&self) -> usize {
         self.nursery.reserved_pages()
     }

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -43,7 +43,7 @@ pub struct GenImmix<VM: VMBinding> {
     /// An immix space as the mature space.
     #[post_scan]
     #[trace(CopySemantics::Mature)]
-    pub immix: ImmixSpace<VM>,
+    pub immix_space: ImmixSpace<VM>,
     /// Whether the last GC was a defrag GC for the immix space.
     pub last_gc_was_defrag: AtomicBool,
     /// Whether the last GC was a full heap GC
@@ -79,7 +79,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
                 CopySemantics::Mature => CopySelector::ImmixHybrid(0),
                 _ => CopySelector::Unused,
             },
-            space_mapping: vec![(CopySelector::ImmixHybrid(0), &self.immix)],
+            space_mapping: vec![(CopySelector::ImmixHybrid(0), &self.immix_space)],
             constraints: &GENIMMIX_CONSTRAINTS,
         }
     }
@@ -100,7 +100,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
 
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.gen.get_spaces();
-        ret.push(&self.immix);
+        ret.push(&self.immix_space);
         ret
     }
 
@@ -123,7 +123,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
                 GenImmix<VM>,
                 GenImmixMatureGCWorkContext<VM, TRACE_KIND_FAST>,
                 GenImmixMatureGCWorkContext<VM, TRACE_KIND_DEFRAG>,
-            >(self, &self.immix, scheduler);
+            >(self, &self.immix_space, scheduler);
         }
     }
 
@@ -135,7 +135,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.prepare(tls);
         if full_heap {
-            self.immix.prepare(full_heap);
+            self.immix_space.prepare(full_heap);
         }
     }
 
@@ -143,7 +143,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.release(tls);
         if full_heap {
-            let did_defrag = self.immix.release(full_heap);
+            let did_defrag = self.immix_space.release(full_heap);
             self.last_gc_was_defrag.store(did_defrag, Ordering::Relaxed);
         } else {
             self.last_gc_was_defrag.store(false, Ordering::Relaxed);
@@ -158,11 +158,11 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
     }
 
     fn get_collection_reserved_pages(&self) -> usize {
-        self.gen.get_collection_reserved_pages() + self.immix.defrag_headroom_pages()
+        self.gen.get_collection_reserved_pages() + self.immix_space.defrag_headroom_pages()
     }
 
     fn get_used_pages(&self) -> usize {
-        self.gen.get_used_pages() + self.immix.reserved_pages()
+        self.gen.get_used_pages() + self.immix_space.reserved_pages()
     }
 
     /// Return the number of pages available for allocation. Assuming all future allocations goes to nursery.
@@ -201,11 +201,11 @@ impl<VM: VMBinding> GenerationalPlan for GenImmix<VM> {
     }
 
     fn get_mature_physical_pages_available(&self) -> usize {
-        self.immix.available_physical_pages()
+        self.immix_space.available_physical_pages()
     }
 
     fn get_mature_reserved_pages(&self) -> usize {
-        self.immix.reserved_pages()
+        self.immix_space.reserved_pages()
     }
 
     fn force_full_heap_collection(&self) {
@@ -248,7 +248,7 @@ impl<VM: VMBinding> GenImmix<VM> {
 
         let genimmix = GenImmix {
             gen: CommonGenPlan::new(plan_args),
-            immix: immix_space,
+            immix_space,
             last_gc_was_defrag: AtomicBool::new(false),
             last_gc_was_full_heap: AtomicBool::new(false),
         };
@@ -262,7 +262,7 @@ impl<VM: VMBinding> GenImmix<VM> {
                 .gen
                 .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
             genimmix
-                .immix
+                .immix_space
                 .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
         }
 

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -147,7 +147,7 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
     ) -> bool {
         let nursery_full =
             self.immix.immix_space.get_pages_allocated() > self.options().get_max_nursery_pages();
-        if space_full && space.is_some() && space.unwrap().name() == self.immix.immix_space.name() {
+        if space_full && space.is_some() && space.unwrap().name() != self.immix.immix_space.name() {
             self.next_gc_full_heap.store(true, Ordering::SeqCst);
         }
         self.immix.collection_required(space_full, space) || nursery_full
@@ -158,7 +158,7 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
     }
 
     fn get_collection_reserved_pages(&self) -> usize {
-        self.immix.get_collection_reserved_pages() + self.immix.immix_space.defrag_headroom_pages()
+        self.immix.get_collection_reserved_pages()
     }
 
     fn get_used_pages(&self) -> usize {


### PR DESCRIPTION
This commit fixes two bugs in StickyImmix:

  1. The first bug is that StickyImmix double counts the Immix defragmentation headroom in the collection reserve.
  2. The second bug is that StickyImmix had inverted the condition for when a full heap GC is to be performed.

This commit also renames the ImmixSpace in GenImmix to `immix_space` to be more descriptive.