### PR TITLE
Add object() in MemorySlice

### DIFF
--- a/src/plan/generational/barrier.rs
+++ b/src/plan/generational/barrier.rs
@@ -82,11 +82,12 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>> BarrierSem
     }
 
     fn memory_region_copy_slow(&mut self, _src: VM::VMMemorySlice, dst: VM::VMMemorySlice) {
-        // Only enqueue array slices in mature spaces
+        // Check if the destination object/slice is in nursery space.
         let dst_in_nursery = match dst.object() {
             Some(obj) => self.plan.is_object_in_nursery(obj),
             None => self.plan.is_address_in_nursery(dst.start()),
         };
+        // Only enqueue array slices in mature spaces
         if !dst_in_nursery {
             // enqueue
             debug_assert_eq!(

--- a/src/plan/generational/barrier.rs
+++ b/src/plan/generational/barrier.rs
@@ -83,7 +83,11 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>> BarrierSem
 
     fn memory_region_copy_slow(&mut self, _src: VM::VMMemorySlice, dst: VM::VMMemorySlice) {
         // Only enqueue array slices in mature spaces
-        if !self.plan.is_address_in_nursery(dst.start()) {
+        let dst_in_nursery = match dst.object() {
+            Some(obj) => self.plan.is_object_in_nursery(obj),
+            None => self.plan.is_address_in_nursery(dst.start()),
+        };
+        if !dst_in_nursery {
             // enqueue
             debug_assert_eq!(
                 dst.bytes() & (BYTES_IN_ADDRESS - 1),

--- a/src/vm/edge_shape.rs
+++ b/src/vm/edge_shape.rs
@@ -130,7 +130,10 @@ pub trait MemorySlice: Send + Debug + PartialEq + Eq + Clone + Hash {
     type EdgeIterator: Iterator<Item = Self::Edge>;
     /// Iterate object edges within the slice. If there are non-reference values in the slice, the iterator should skip them.
     fn iter_edges(&self) -> Self::EdgeIterator;
-    /// The object which this slice belongs to. If we know the object for the slice, we will check the object state (mature or not), rather than the slice address.
+    /// The object which this slice belongs to. If we know the object for the slice, we will check the object state (e.g. mature or not), rather than the slice address.
+    /// Normally checking the object and checking the slice does not make a difference, as the slice is part of the object (in terms of memory range). However,
+    /// if a slice is in a different location from the object, the object state and the slice can be hugely different, and providing a proper implementation
+    /// of this method for the owner object is important.
     fn object(&self) -> Option<ObjectReference>;
     /// Start address of the memory slice
     fn start(&self) -> Address;

--- a/src/vm/edge_shape.rs
+++ b/src/vm/edge_shape.rs
@@ -130,6 +130,8 @@ pub trait MemorySlice: Send + Debug + PartialEq + Eq + Clone + Hash {
     type EdgeIterator: Iterator<Item = Self::Edge>;
     /// Iterate object edges within the slice. If there are non-reference values in the slice, the iterator should skip them.
     fn iter_edges(&self) -> Self::EdgeIterator;
+    /// The object which this slice belongs to. If we know the object for the slice, we will check the object state (mature or not), rather than the slice address.
+    fn object(&self) -> Option<ObjectReference>;
     /// Start address of the memory slice
     fn start(&self) -> Address;
     /// Size of the memory slice
@@ -167,6 +169,10 @@ impl MemorySlice for Range<Address> {
             cursor: self.start,
             limit: self.end,
         }
+    }
+
+    fn object(&self) -> Option<ObjectReference> {
+        None
     }
 
     fn start(&self) -> Address {
@@ -215,6 +221,10 @@ impl<E: Edge> MemorySlice for UnimplementedMemorySlice<E> {
     type EdgeIterator = UnimplementedMemorySliceEdgeIterator<E>;
 
     fn iter_edges(&self) -> Self::EdgeIterator {
+        unimplemented!()
+    }
+
+    fn object(&self) -> Option<ObjectReference> {
         unimplemented!()
     }
 

--- a/vmbindings/dummyvm/src/edges.rs
+++ b/vmbindings/dummyvm/src/edges.rs
@@ -55,6 +55,10 @@ impl MemorySlice for DummyVMMemorySlice {
         }
     }
 
+    fn object(&self) -> Option<ObjectReference> {
+        None
+    }
+
     fn start(&self) -> Address {
         Address::from_ptr(unsafe { (*self.0).as_ptr_range().start })
     }


### PR DESCRIPTION
This PR adds a method `object()` to `trait MemorySlice` to allow defining an owner object for a memory slice. When we check if a slice is in mature space, we will check its owner object rather than the slice address.