### PR TITLE
Change info logging to debug in ImmortalSpace

### DIFF
--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -157,7 +157,7 @@ impl<VM: VMBinding> ImmortalSpace<VM> {
         } else {
             // Otherwise, we reset the mark bit for the allocated regions.
             self.pr.for_allocated_regions(|addr, size| {
-                info!(
+                debug!(
                     "{:?}: reset mark bit from {} to {}",
                     self.name(),
                     addr,


### PR DESCRIPTION
This was a mistake. I was using it for debugging, and accidentally committed the change.