### PR TITLE
Some fixes for sanity GC

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -645,7 +645,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for E {
             self.flush();
         }
         #[cfg(feature = "sanity")]
-        if self.roots {
+        if self.roots && !_mmtk.plan.is_in_sanity() {
             self.cache_roots_for_sanity_gc();
         }
         trace!("ProcessEdgesWork End");
@@ -765,7 +765,7 @@ pub trait ScanObjectsWork<VM: VMBinding>: GCWork<VM> + Sized {
 
         #[cfg(feature = "sanity")]
         {
-            if self.roots() {
+            if self.roots() && !mmtk.plan.is_in_sanity() {
                 mmtk.sanity_checker
                     .lock()
                     .unwrap()

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -67,6 +67,10 @@ impl<P: Plan> GCWork<P::VM> for ScheduleSanityGC<P> {
 
         scheduler.reset_state();
 
+        // We are going to do sanity GC which will traverse the object graph again. Reset edge logger to clear recorded edges.
+        #[cfg(feature = "extreme_assertions")]
+        mmtk.edge_logger.reset();
+
         plan.base().inside_sanity.store(true, Ordering::SeqCst);
         // Stop & scan mutators (mutator scanning can happen before STW)
 
@@ -96,8 +100,6 @@ impl<P: Plan> GCWork<P::VM> for ScheduleSanityGC<P> {
                 ));
             }
         }
-        scheduler.work_buckets[WorkBucketStage::Prepare]
-            .add(ScanVMSpecificRoots::<SanityGCProcessEdges<P::VM>>::new());
         // Prepare global/collectors/mutators
         worker.scheduler().work_buckets[WorkBucketStage::Prepare]
             .add(SanityPrepare::<P>::new(plan.downcast_ref::<P>().unwrap()));


### PR DESCRIPTION
This PR fixes a few issues for sanity GC.

1. We should not cache roots (for sanity GC) if we are doing sanity GC.
2. We do not need to schedule the work `VMSpecificRoots` in sanity GC. The roots are cached.
3. Reset edge logger before sanity GC. In sanity GC, we will visit the object and edges again. We have to clear what we have logged before.