### PR TITLE
Remove unused get_type_descriptor

### DIFF
--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -353,14 +353,6 @@ pub trait ObjectModel<VM: VMBinding> {
     /// * `object`: The object to be queried.
     fn get_align_offset_when_copied(object: ObjectReference) -> isize;
 
-    /// Get the type descriptor for an object.
-    ///
-    /// FIXME: Do we need this? If so, determine lifetime, return byte[]
-    ///
-    /// Arguments:
-    /// * `reference`: The object to be queried.
-    fn get_type_descriptor(reference: ObjectReference) -> &'static [i8];
-
     /// This is the worst case expansion that can occur due to object size increasing while
     /// copying. This constant is used to calculate whether a nursery has grown larger than the
     /// mature space for generational plans.

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -50,10 +50,6 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         unimplemented!()
     }
 
-    fn get_type_descriptor(_reference: ObjectReference) -> &'static [i8] {
-        unimplemented!()
-    }
-
     fn ref_to_object_start(object: ObjectReference) -> Address {
         object.to_raw_address().sub(OBJECT_REF_OFFSET)
     }


### PR DESCRIPTION
`get_type_descriptor` is unused, and it is legacy code from Java MMTk. We can remove it from mmtk-core, and also remove it from all the bindings.