### PR TITLE
Use extreme assertion for metadata mapped assert

### DIFF
--- a/src/policy/marksweepspace/malloc_ms/metadata.rs
+++ b/src/policy/marksweepspace/malloc_ms/metadata.rs
@@ -280,7 +280,7 @@ pub(super) unsafe fn unset_chunk_mark_unsafe(chunk_start: Address) {
 pub(super) unsafe fn load128(metadata_spec: &SideMetadataSpec, data_addr: Address) -> u128 {
     let meta_addr = side_metadata::address_to_meta_address(metadata_spec, data_addr);
 
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, feature = "extreme_assertions"))]
     metadata_spec.assert_metadata_mapped(data_addr);
 
     meta_addr.load::<u128>()

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -406,6 +406,7 @@ impl SideMetadataSpec {
         #[cfg(debug_assertions)]
         {
             self.assert_value_type::<T>(input);
+            #[cfg(feature = "extreme_assertions")]
             self.assert_metadata_mapped(data_addr);
         }
 


### PR DESCRIPTION
The `assert_metadata_mapped` method uses the `mmap` system call and expects a failure.  This is too costly even for debug builds.  We disable it unless the "extreme_assertions" feature is enabled.

This issue has a greater impact on VMs that use the valid-object bit (VO bit) metadata because the metadata is accessed on every object allocation, and there is such an assertion in metadata access.

The `rr` debugging tool seems to record every system call.  This PR also makes `rr` *much* faster (e.g. 14.20s vs 0.202s when running hello world in Ruby).

# How to test

Compile mmtk-core with debug build, and use `strace` to run the VM.  Before this PR, a hello world program in Ruby (using mmtk-ruby) shall have 400000+ `mmap` invocations returning -1 with `errno = EEXIST`; with this PR, they will all disappear.
