### PR TITLE
Remove a warning in sticky immix trace_object_nursery

### DIFF
--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -287,10 +287,6 @@ impl<VM: VMBinding> crate::plan::generational::global::GenerationalPlanExt<VM> f
                 .trace_object::<Q>(queue, object);
         }
 
-        warn!(
-            "Object {} is not in nursery or in LOS, it is not traced!",
-            object
-        );
         object
     }
 }


### PR DESCRIPTION
This PR removes an unnecessary `warn` in `trace_object_nursery` in sticky immix. The `warn` logging was used for debugging in OpenJDK where we only allocate objects in the default space and LOS. The logging actually logs every encountered object that is not in the immix space and LOS, which is unnecessary. 