### PR TITLE
Use min nursery as mem balancer's extra memory

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -79,7 +79,10 @@ pub fn mmtk_init<VM: VMBinding>(builder: &MMTKBuilder) -> Box<MMTK<VM>> {
     }
     let mmtk = builder.build();
 
-    info!("Initialized MMTk with {:?}", *mmtk.options.plan);
+    info!(
+        "Initialized MMTk with {:?} ({:?})",
+        *mmtk.options.plan, *mmtk.options.gc_trigger
+    );
     #[cfg(feature = "extreme_assertions")]
     warn!("The feature 'extreme_assertions' is enabled. MMTk will run expensive run-time checks. Slow performance should be expected.");
     Box::new(mmtk)

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -359,10 +359,10 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
                 if stats.generational_mem_stats_on_gc_end(plan) {
                     self.compute_new_heap_limit(
                         mmtk.plan.get_reserved_pages(),
-                        // We reserve an extra of 2x max nursery: when MMTk triggers a GC, it needs to ensure there is enough room in the mature space
-                        // to accomodate the copiyng from nursery, thus it counts the nursery size twice to make sure that objects can all be copied.
+                        // We reserve an extra of min nursery. This ensures that we will not trigger
+                        // a full heap GC in the next GC (if available pages is smaller than min nursery, we will force a full heap GC)
                         mmtk.plan.get_collection_reserved_pages()
-                            + mmtk.options.get_max_nursery_pages() * 2,
+                            + mmtk.options.get_min_nursery_pages(),
                         stats,
                     );
                 }


### PR DESCRIPTION
This PR changes the calculation of extra memory in mem balancer from max nursery to min nursery. This closes https://github.com/mmtk/mmtk-core/issues/790.