### PR TITLE
Remove some uses of mem::transmute in marksweep block

### DIFF
--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -165,8 +165,7 @@ impl Block {
     }
 
     pub fn store_block_list(&self, block_list: &BlockList) {
-        let block_list_usize: usize =
-            unsafe { std::mem::transmute::<&BlockList, usize>(block_list) };
+        let block_list_usize: usize = block_list as *const BlockList as usize;
         unsafe {
             Block::BLOCK_LIST_TABLE.store::<usize>(self.start(), block_list_usize);
         }
@@ -187,8 +186,8 @@ impl Block {
     }
 
     pub fn store_tls(&self, tls: VMThread) {
-        let tls = unsafe { std::mem::transmute::<OpaquePointer, usize>(tls.0) };
-        unsafe { Block::TLS_TABLE.store(self.start(), tls) }
+        let tls_usize: usize = tls.0.to_address().as_usize();
+        unsafe { Block::TLS_TABLE.store(self.start(), tls_usize) }
     }
 
     pub fn load_tls(&self) -> VMThread {

--- a/src/util/opaque_pointer.rs
+++ b/src/util/opaque_pointer.rs
@@ -26,6 +26,10 @@ impl OpaquePointer {
         OpaquePointer(addr.to_mut_ptr::<c_void>())
     }
 
+    pub fn to_address(self) -> Address {
+        Address::from_mut_ptr(self.0)
+    }
+
     pub fn is_null(self) -> bool {
         self.0.is_null()
     }


### PR DESCRIPTION
This PR removes a few unnecessary uses of `mem::transmute` in mark sweep `Block`. This closes https://github.com/mmtk/mmtk-core/issues/825.