### PR TITLE
Replace alloc-related `offset` type to `usize` instead `isize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ mimalloc-sys = { version = "0.1.6", optional = true }
 mmtk-macros = { version = "0.18.0", path = "macros/" }
 num_cpus = "1.8"
 num-traits = "0.2"
-pfm = { version = "0.1.0-beta.1", optional = true }
+pfm = { version = "0.1.0-beta.3", optional = true }
 regex = "1.7.0"
 spin = "0.9.5"
 static_assertions = "1.1.0"

--- a/docs/header/mmtk.h
+++ b/docs/header/mmtk.h
@@ -44,14 +44,14 @@ extern void mmtk_disable_collection();
 extern void* mmtk_alloc(MMTk_Mutator mutator,
                         size_t size,
                         size_t align,
-                        ssize_t offset,
+                        size_t offset,
                         int allocator);
 
 // Slowpath allocation for an object
 extern void* mmtk_alloc_slow(MMTk_Mutator mutator,
                              size_t size,
                              size_t align,
-                             ssize_t offset,
+                             size_t offset,
                              int allocator);
 
 // Perform post-allocation hooks or actions such as initializing object metadata

--- a/examples/reference_bump_allocator.c
+++ b/examples/reference_bump_allocator.c
@@ -31,7 +31,7 @@ extern MMTk_Mutator bind_mutator(void *tls) {
     return NULL;
 }
 
-extern void* align_allocation(void* region, size_t align, ssize_t offset) {
+extern void* align_allocation(void* region, size_t align, size_t offset) {
     ssize_t region_signed = (ssize_t) region;
 
     ssize_t mask = (ssize_t) (align - 1);
@@ -42,7 +42,7 @@ extern void* align_allocation(void* region, size_t align, ssize_t offset) {
 }
 
 extern void* alloc(MMTk_Mutator mutator, size_t size,
-                   size_t align, ssize_t offset, int allocator) {
+                   size_t align, size_t offset, int allocator) {
 
     void* result = align_allocation(IMMORTAL_SPACE.heap_cursor, align, offset);
     void* new_cursor = (void*)((size_t) result + size);
@@ -54,7 +54,7 @@ extern void* alloc(MMTk_Mutator mutator, size_t size,
 }
 
 extern void* alloc_slow(MMTk_Mutator mutator, size_t size,
-                        size_t align, ssize_t offset, int allocator) {
+                        size_t align, size_t offset, int allocator) {
 
     perror("Not implemented\n");
     exit(1);

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -146,7 +146,7 @@ pub fn alloc<VM: VMBinding>(
     mutator: &mut Mutator<VM>,
     size: usize,
     align: usize,
-    offset: isize,
+    offset: usize,
     semantics: AllocationSemantics,
 ) -> Address {
     // MMTk has assumptions about minimal object size.

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -86,7 +86,7 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
         &mut self,
         size: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         allocator: AllocationSemantics,
     ) -> Address {
         unsafe {
@@ -161,7 +161,7 @@ pub trait MutatorContext<VM: VMBinding>: Send + 'static {
         &mut self,
         size: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         allocator: AllocationSemantics,
     ) -> Address;
     fn post_alloc(&mut self, refer: ObjectReference, bytes: usize, allocator: AllocationSemantics);

--- a/src/policy/copy_context.rs
+++ b/src/policy/copy_context.rs
@@ -20,7 +20,7 @@ pub trait PolicyCopyContext: 'static + Send {
         original: ObjectReference,
         bytes: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
     ) -> Address;
     fn post_copy(&mut self, _obj: ObjectReference, _bytes: usize) {}
 }

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -306,7 +306,7 @@ impl<VM: VMBinding> PolicyCopyContext for CopySpaceCopyContext<VM> {
         _original: ObjectReference,
         bytes: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
     ) -> Address {
         self.copy_allocator.alloc(bytes, align, offset)
     }

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -900,7 +900,7 @@ impl<VM: VMBinding> PolicyCopyContext for ImmixCopyContext<VM> {
         _original: ObjectReference,
         bytes: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
     ) -> Address {
         self.allocator.alloc(bytes, align, offset)
     }
@@ -949,7 +949,7 @@ impl<VM: VMBinding> PolicyCopyContext for ImmixHybridCopyContext<VM> {
         _original: ObjectReference,
         bytes: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
     ) -> Address {
         if self.get_space().in_defrag() {
             self.defrag_allocator.alloc(bytes, align, offset)

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -325,7 +325,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
         }
     }
 
-    pub fn alloc(&self, tls: VMThread, size: usize, align: usize, offset: isize) -> Address {
+    pub fn alloc(&self, tls: VMThread, size: usize, align: usize, offset: usize) -> Address {
         // TODO: Should refactor this and Space.acquire()
         if self.get_gc_trigger().poll(false, Some(self)) {
             assert!(VM::VMActivePlan::is_mutator(tls), "Polling in GC worker");

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -23,7 +23,7 @@ pub enum AllocationError {
 pub fn align_allocation_no_fill<VM: VMBinding>(
     region: Address,
     alignment: usize,
-    offset: isize,
+    offset: usize,
 ) -> Address {
     align_allocation_inner::<VM>(region, alignment, offset, VM::MIN_ALIGNMENT, false)
 }
@@ -31,7 +31,7 @@ pub fn align_allocation_no_fill<VM: VMBinding>(
 pub fn align_allocation<VM: VMBinding>(
     region: Address,
     alignment: usize,
-    offset: isize,
+    offset: usize,
 ) -> Address {
     align_allocation_inner::<VM>(region, alignment, offset, VM::MIN_ALIGNMENT, true)
 }
@@ -39,7 +39,7 @@ pub fn align_allocation<VM: VMBinding>(
 pub fn align_allocation_inner<VM: VMBinding>(
     region: Address,
     alignment: usize,
-    offset: isize,
+    offset: usize,
     known_alignment: usize,
     fillalignmentgap: bool,
 ) -> Address {
@@ -51,10 +51,9 @@ pub fn align_allocation_inner<VM: VMBinding>(
     }
     debug_assert!(!(fillalignmentgap && region.is_zero()));
     debug_assert!(alignment <= VM::MAX_ALIGNMENT);
-    debug_assert!(offset >= 0);
     debug_assert!(region.is_aligned_to(VM::ALLOC_END_ALIGNMENT));
     debug_assert!((alignment & (VM::MIN_ALIGNMENT - 1)) == 0);
-    debug_assert!((offset & (VM::MIN_ALIGNMENT - 1) as isize) == 0);
+    debug_assert!((offset & (VM::MIN_ALIGNMENT - 1) as usize) == 0);
 
     // No alignment ever required.
     if alignment <= known_alignment || VM::MAX_ALIGNMENT <= VM::MIN_ALIGNMENT {
@@ -64,7 +63,7 @@ pub fn align_allocation_inner<VM: VMBinding>(
     // May require an alignment
     let region_isize = region.as_usize() as isize;
     let mask = (alignment - 1) as isize; // fromIntSignExtend
-    let neg_off = -offset; // fromIntSignExtend
+    let neg_off: isize = -(offset as isize); // fromIntSignExtend
 
     // TODO: Consider using neg_off.wrapping_sub_unsigned(region.as_usize()), and we can remove region_isize.
     // This requires Rust 1.66.0+.
@@ -164,7 +163,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     /// * `size`: the allocation size in bytes.
     /// * `align`: the required alignment in bytes.
     /// * `offset` the required offset in bytes.
-    fn alloc(&mut self, size: usize, align: usize, offset: isize) -> Address;
+    fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address;
 
     /// Slowpath allocation attempt. This function is explicitly not inlined for performance
     /// considerations.
@@ -174,7 +173,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     /// * `align`: the required alignment in bytes.
     /// * `offset` the required offset in bytes.
     #[inline(never)]
-    fn alloc_slow(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc_slow(&mut self, size: usize, align: usize, offset: usize) -> Address {
         self.alloc_slow_inline(size, align, offset)
     }
 
@@ -194,7 +193,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     /// * `size`: the allocation size in bytes.
     /// * `align`: the required alignment in bytes.
     /// * `offset` the required offset in bytes.
-    fn alloc_slow_inline(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc_slow_inline(&mut self, size: usize, align: usize, offset: usize) -> Address {
         let tls = self.get_tls();
         let plan = self.get_plan().base();
         let is_mutator = VM::VMActivePlan::is_mutator(tls);
@@ -317,7 +316,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     /// * `size`: the allocation size in bytes.
     /// * `align`: the required alignment in bytes.
     /// * `offset` the required offset in bytes.
-    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: isize) -> Address;
+    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: usize) -> Address;
 
     /// Single slowpath allocation attempt for stress test. When the stress factor is set (e.g. to
     /// N), we would expect for every N bytes allocated, we will trigger a stress GC.  However, for
@@ -351,7 +350,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
         &mut self,
         size: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         need_poll: bool,
     ) -> Address {
         // If an allocator does thread local allocation but does not override this method to

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -53,7 +53,7 @@ pub fn align_allocation_inner<VM: VMBinding>(
     debug_assert!(alignment <= VM::MAX_ALIGNMENT);
     debug_assert!(region.is_aligned_to(VM::ALLOC_END_ALIGNMENT));
     debug_assert!((alignment & (VM::MIN_ALIGNMENT - 1)) == 0);
-    debug_assert!((offset & (VM::MIN_ALIGNMENT - 1) as usize) == 0);
+    debug_assert!((offset & (VM::MIN_ALIGNMENT - 1)) == 0);
 
     // No alignment ever required.
     if alignment <= known_alignment || VM::MAX_ALIGNMENT <= VM::MIN_ALIGNMENT {

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -61,7 +61,7 @@ impl<VM: VMBinding> Allocator<VM> for BumpAllocator<VM> {
         BLOCK_SIZE
     }
 
-    fn alloc(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address {
         trace!("alloc");
         let result = align_allocation_no_fill::<VM>(self.cursor, align, offset);
         let new_cursor = result + size;
@@ -83,7 +83,7 @@ impl<VM: VMBinding> Allocator<VM> for BumpAllocator<VM> {
         }
     }
 
-    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: usize) -> Address {
         trace!("alloc_slow");
         self.acquire_block(size, align, offset, false)
     }
@@ -100,7 +100,7 @@ impl<VM: VMBinding> Allocator<VM> for BumpAllocator<VM> {
         &mut self,
         size: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         need_poll: bool,
     ) -> Address {
         if need_poll {
@@ -155,7 +155,7 @@ impl<VM: VMBinding> BumpAllocator<VM> {
         &mut self,
         size: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         stress_test: bool,
     ) -> Address {
         let block_size = (size + BLOCK_MASK) & (!BLOCK_MASK);

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -43,7 +43,7 @@ impl<VM: VMBinding> Allocator<VM> for FreeListAllocator<VM> {
     }
 
     // Find a block with free space and allocate to it
-    fn alloc(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address {
         debug_assert!(
             size <= MAX_BIN_SIZE,
             "Alloc request for {} bytes is too big.",
@@ -79,7 +79,7 @@ impl<VM: VMBinding> Allocator<VM> for FreeListAllocator<VM> {
         self.alloc_slow(size, align, offset)
     }
 
-    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: usize) -> Address {
         // Try get a block from the space
         if let Some(block) = self.acquire_global_block(size, align, false) {
             let addr = self.block_alloc(block);
@@ -101,7 +101,7 @@ impl<VM: VMBinding> Allocator<VM> for FreeListAllocator<VM> {
         &mut self,
         size: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         need_poll: bool,
     ) -> Address {
         trace!("allow slow precise stress s={}", size);

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -34,7 +34,7 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
         false
     }
 
-    fn alloc(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address {
         let cell: Address = self.alloc_slow(size, align, offset);
         // We may get a null ptr from alloc due to the VM being OOM
         if !cell.is_zero() {
@@ -44,7 +44,7 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
         }
     }
 
-    fn alloc_slow_once(&mut self, size: usize, align: usize, _offset: isize) -> Address {
+    fn alloc_slow_once(&mut self, size: usize, align: usize, _offset: usize) -> Address {
         let header = 0; // HashSet is used instead of DoublyLinkedList
         let maxbytes = allocator::get_maximum_aligned_size::<VM>(size + header, align);
         let pages = crate::util::conversions::bytes_to_pages_up(maxbytes);

--- a/src/util/alloc/malloc_allocator.rs
+++ b/src/util/alloc/malloc_allocator.rs
@@ -25,7 +25,7 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
         self.plan
     }
 
-    fn alloc(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address {
         self.alloc_slow(size, align, offset)
     }
 
@@ -37,9 +37,7 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
         false
     }
 
-    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: isize) -> Address {
-        assert!(offset >= 0);
-
+    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: usize) -> Address {
         self.space.alloc(self.tls, size, align, offset)
     }
 }

--- a/src/util/alloc/markcompact_allocator.rs
+++ b/src/util/alloc/markcompact_allocator.rs
@@ -48,7 +48,7 @@ impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
         self.bump_allocator.get_thread_local_buffer_granularity()
     }
 
-    fn alloc(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address {
         let rtn = self
             .bump_allocator
             .alloc(size + Self::HEADER_RESERVED_IN_BYTES, align, offset);
@@ -61,7 +61,7 @@ impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
         }
     }
 
-    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: isize) -> Address {
+    fn alloc_slow_once(&mut self, size: usize, align: usize, offset: usize) -> Address {
         trace!("alloc_slow");
         self.bump_allocator.alloc_slow_once(size, align, offset)
     }
@@ -78,7 +78,7 @@ impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
         &mut self,
         size: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         need_poll: bool,
     ) -> Address {
         self.bump_allocator

--- a/src/util/analysis/mod.rs
+++ b/src/util/analysis/mod.rs
@@ -23,7 +23,7 @@ use self::obj_size::PerSizeClassObjectCounter;
 /// invoke it in its respective place.
 ///
 pub trait RtAnalysis<VM: VMBinding> {
-    fn alloc_hook(&mut self, _size: usize, _align: usize, _offset: isize) {}
+    fn alloc_hook(&mut self, _size: usize, _align: usize, _offset: usize) {}
     fn gc_hook(&mut self, _mmtk: &'static MMTK<VM>) {}
     fn set_running(&mut self, running: bool);
 }
@@ -72,7 +72,7 @@ impl<VM: VMBinding> AnalysisManager<VM> {
         routines.push(routine.clone());
     }
 
-    pub fn alloc_hook(&self, size: usize, align: usize, offset: isize) {
+    pub fn alloc_hook(&self, size: usize, align: usize, offset: usize) {
         let routines = self.routines.lock().unwrap();
         for r in &*routines {
             r.lock().unwrap().alloc_hook(size, align, offset);

--- a/src/util/analysis/obj_num.rs
+++ b/src/util/analysis/obj_num.rs
@@ -18,7 +18,7 @@ impl ObjectCounter {
 }
 
 impl<VM: VMBinding> RtAnalysis<VM> for ObjectCounter {
-    fn alloc_hook(&mut self, _size: usize, _align: usize, _offset: isize) {
+    fn alloc_hook(&mut self, _size: usize, _align: usize, _offset: usize) {
         if self.running {
             // The analysis routine simply updates the counter when the allocation hook is called
             self.counter.lock().unwrap().inc();

--- a/src/util/analysis/obj_size.rs
+++ b/src/util/analysis/obj_size.rs
@@ -46,7 +46,7 @@ impl PerSizeClassObjectCounter {
 }
 
 impl<VM: VMBinding> RtAnalysis<VM> for PerSizeClassObjectCounter {
-    fn alloc_hook(&mut self, size: usize, _align: usize, _offset: isize) {
+    fn alloc_hook(&mut self, size: usize, _align: usize, _offset: usize) {
         if !self.running {
             return;
         }

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -75,7 +75,7 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
         original: ObjectReference,
         bytes: usize,
         align: usize,
-        offset: isize,
+        offset: usize,
         semantics: CopySemantics,
     ) -> Address {
         #[cfg(debug_assertions)]

--- a/src/util/malloc/malloc_ms_util.rs
+++ b/src/util/malloc/malloc_ms_util.rs
@@ -26,7 +26,7 @@ pub fn align_offset_alloc<VM: VMBinding>(size: usize, align: usize, offset: usiz
     if address.is_zero() {
         return address;
     }
-    let mod_offset = offset % (align as usize);
+    let mod_offset = offset % align;
     let mut result =
         crate::util::alloc::allocator::align_allocation_no_fill::<VM>(address, align, mod_offset);
     if result - BYTES_IN_ADDRESS < address {

--- a/src/util/malloc/malloc_ms_util.rs
+++ b/src/util/malloc/malloc_ms_util.rs
@@ -18,7 +18,7 @@ pub fn align_alloc<VM: VMBinding>(size: usize, align: usize) -> Address {
 
 // Beside returning the allocation result,
 // this will store the malloc result at (result - BYTES_IN_ADDRESS)
-pub fn align_offset_alloc<VM: VMBinding>(size: usize, align: usize, offset: isize) -> Address {
+pub fn align_offset_alloc<VM: VMBinding>(size: usize, align: usize, offset: usize) -> Address {
     // we allocate extra `align` bytes here, so we are able to handle offset
     let actual_size = size + align + BYTES_IN_ADDRESS;
     let raw = unsafe { calloc(1, actual_size) };
@@ -26,7 +26,7 @@ pub fn align_offset_alloc<VM: VMBinding>(size: usize, align: usize, offset: isiz
     if address.is_zero() {
         return address;
     }
-    let mod_offset = offset % (align as isize);
+    let mod_offset = offset % (align as usize);
     let mut result =
         crate::util::alloc::allocator::align_allocation_no_fill::<VM>(address, align, mod_offset);
     if result - BYTES_IN_ADDRESS < address {
@@ -64,7 +64,7 @@ pub fn get_malloc_usable_size(address: Address, is_offset_malloc: bool) -> usize
 
 /// allocate `size` bytes, which is aligned to `align` at `offset`
 /// return the address, and whether it is an offset allocation
-pub fn alloc<VM: VMBinding>(size: usize, align: usize, offset: isize) -> (Address, bool) {
+pub fn alloc<VM: VMBinding>(size: usize, align: usize, offset: usize) -> (Address, bool) {
     let address: Address;
     let mut is_offset_malloc = false;
     // malloc returns 16 bytes aligned address.

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -351,7 +351,7 @@ pub trait ObjectModel<VM: VMBinding> {
     ///
     /// Arguments:
     /// * `object`: The object to be queried.
-    fn get_align_offset_when_copied(object: ObjectReference) -> isize;
+    fn get_align_offset_when_copied(object: ObjectReference) -> usize;
 
     /// Get the type descriptor for an object.
     ///

--- a/vmbindings/dummyvm/api/mmtk.h
+++ b/vmbindings/dummyvm/api/mmtk.h
@@ -42,14 +42,14 @@ extern void mmtk_disable_collection();
 extern void* mmtk_alloc(MMTk_Mutator mutator,
                         size_t size,
                         size_t align,
-                        ssize_t offset,
+                        size_t offset,
                         int allocator);
 
 // Slowpath allocation for an object
 extern void* mmtk_alloc_slow(MMTk_Mutator mutator,
                              size_t size,
                              size_t align,
-                             ssize_t offset,
+                             size_t offset,
                              int allocator);
 
 // Perform post-allocation hooks or actions such as initializing object metadata

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -44,7 +44,7 @@ pub extern "C" fn mmtk_destroy_mutator(mutator: *mut Mutator<DummyVM>) {
 
 #[no_mangle]
 pub extern "C" fn mmtk_alloc(mutator: *mut Mutator<DummyVM>, size: usize,
-                    align: usize, offset: isize, mut semantics: AllocationSemantics) -> Address {
+                    align: usize, offset: usize, mut semantics: AllocationSemantics) -> Address {
     if size >= SINGLETON.get_plan().constraints().max_non_los_default_alloc_bytes {
         semantics = AllocationSemantics::Los;
     }

--- a/vmbindings/dummyvm/src/object_model.rs
+++ b/vmbindings/dummyvm/src/object_model.rs
@@ -42,7 +42,7 @@ impl ObjectModel<DummyVM> for VMObjectModel {
         ::std::mem::size_of::<usize>()
     }
 
-    fn get_align_offset_when_copied(_object: ObjectReference) -> isize {
+    fn get_align_offset_when_copied(_object: ObjectReference) -> usize {
         0
     }
 

--- a/vmbindings/dummyvm/src/tests/allocate_align_offset.rs
+++ b/vmbindings/dummyvm/src/tests/allocate_align_offset.rs
@@ -30,7 +30,7 @@ pub fn allocate_alignment() {
 #[test]
 pub fn allocate_offset() {
     MUTATOR.with_fixture(|fixture| {
-        const OFFSET: isize = 4;
+        const OFFSET: usize = 4;
         let min = DummyVM::MIN_ALIGNMENT;
         let max = DummyVM::MAX_ALIGNMENT;
         info!("Allowed alignment between {} and {}", min, max);


### PR DESCRIPTION
EDIT1: fix #674 
this pr only replaces the `isize` to `usize` for `offset` in allocation, which makes the code more robust.
there is no further test since a negative will be a failure at compile time.