### PR TITLE
Rename ambiguous `scan_thread_root{,s}` functions

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -444,7 +444,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanStackRoots<E> {
     fn do_work(&mut self, worker: &mut GCWorker<E::VM>, mmtk: &'static MMTK<E::VM>) {
         trace!("ScanStackRoots");
         let factory = ProcessEdgesWorkRootsWorkFactory::<E>::new(mmtk);
-        <E::VM as VMBinding>::VMScanning::scan_thread_roots(worker.tls, factory);
+        <E::VM as VMBinding>::VMScanning::scan_roots_in_all_mutator_threads(worker.tls, factory);
         <E::VM as VMBinding>::VMScanning::notify_initial_thread_scan_complete(false, worker.tls);
         for mutator in <E::VM as VMBinding>::VMActivePlan::mutators() {
             mutator.flush();
@@ -461,7 +461,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanStackRoot<E> {
         let base = &mmtk.plan.base();
         let mutators = <E::VM as VMBinding>::VMActivePlan::number_of_mutators();
         let factory = ProcessEdgesWorkRootsWorkFactory::<E>::new(mmtk);
-        <E::VM as VMBinding>::VMScanning::scan_thread_root(
+        <E::VM as VMBinding>::VMScanning::scan_roots_in_mutator_thread(
             worker.tls,
             unsafe { &mut *(self.0 as *mut _) },
             factory,

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -200,7 +200,10 @@ pub trait Scanning<VM: VMBinding> {
     /// Arguments:
     /// * `tls`: The GC thread that is performing this scanning.
     /// * `factory`: The VM uses it to create work packets for scanning roots.
-    fn scan_roots_in_all_mutator_threads(tls: VMWorkerThread, factory: impl RootsWorkFactory<VM::VMEdge>);
+    fn scan_roots_in_all_mutator_threads(
+        tls: VMWorkerThread,
+        factory: impl RootsWorkFactory<VM::VMEdge>,
+    );
 
     /// Scan one mutator for roots.
     ///

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -200,7 +200,7 @@ pub trait Scanning<VM: VMBinding> {
     /// Arguments:
     /// * `tls`: The GC thread that is performing this scanning.
     /// * `factory`: The VM uses it to create work packets for scanning roots.
-    fn scan_thread_roots(tls: VMWorkerThread, factory: impl RootsWorkFactory<VM::VMEdge>);
+    fn scan_roots_in_all_mutator_threads(tls: VMWorkerThread, factory: impl RootsWorkFactory<VM::VMEdge>);
 
     /// Scan one mutator for roots.
     ///
@@ -208,7 +208,7 @@ pub trait Scanning<VM: VMBinding> {
     /// * `tls`: The GC thread that is performing this scanning.
     /// * `mutator`: The reference to the mutator whose roots will be scanned.
     /// * `factory`: The VM uses it to create work packets for scanning roots.
-    fn scan_thread_root(
+    fn scan_roots_in_mutator_thread(
         tls: VMWorkerThread,
         mutator: &'static mut Mutator<VM>,
         factory: impl RootsWorkFactory<VM::VMEdge>,

--- a/vmbindings/dummyvm/src/scanning.rs
+++ b/vmbindings/dummyvm/src/scanning.rs
@@ -10,10 +10,10 @@ use mmtk::Mutator;
 pub struct VMScanning {}
 
 impl Scanning<DummyVM> for VMScanning {
-    fn scan_thread_roots(_tls: VMWorkerThread, _factory: impl RootsWorkFactory<DummyVMEdge>) {
+    fn scan_roots_in_all_mutator_threads(_tls: VMWorkerThread, _factory: impl RootsWorkFactory<DummyVMEdge>) {
         unimplemented!()
     }
-    fn scan_thread_root(
+    fn scan_roots_in_mutator_thread(
         _tls: VMWorkerThread,
         _mutator: &'static mut Mutator<DummyVM>,
         _factory: impl RootsWorkFactory<DummyVMEdge>,


### PR DESCRIPTION
Closes #601.