### PR TITLE
Allow plan-specific bucket config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
 sysinfo = "0.29"
+variant_count = "1.1.0"
 
 [dev-dependencies]
 paste = "1.0.8"

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -885,7 +885,7 @@ pub fn add_work_packet<VM: VMBinding, W: GCWork<VM>>(
     bucket: WorkBucketStage,
     packet: W,
 ) {
-    mmtk.scheduler.work_buckets[bucket].add(packet)
+    mmtk.scheduler.work_buckets[&bucket].add(packet)
 }
 
 /// Bulk add a number of work packets to the given work bucket. Note that this simply adds the work packets
@@ -900,5 +900,5 @@ pub fn add_work_packets<VM: VMBinding>(
     bucket: WorkBucketStage,
     packets: Vec<Box<dyn GCWork<VM>>>,
 ) {
-    mmtk.scheduler.work_buckets[bucket].bulk_add(packets)
+    mmtk.scheduler.work_buckets[&bucket].bulk_add(packets)
 }

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -105,7 +105,11 @@ impl<VM: VMBinding> MMTK<VM> {
             *options.threads
         };
 
-        let scheduler = GCWorkScheduler::new(num_workers, (*options.thread_affinity).clone());
+        let scheduler = GCWorkScheduler::new(
+            num_workers,
+            (*options.thread_affinity).clone(),
+            crate::plan::create_work_bucket_stage_config::<VM>(*options.plan),
+        );
 
         let plan = crate::plan::create_plan(
             *options.plan,

--- a/src/plan/generational/barrier.rs
+++ b/src/plan/generational/barrier.rs
@@ -44,7 +44,7 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>>
     fn flush_modbuf(&mut self) {
         let buf = self.modbuf.take();
         if !buf.is_empty() {
-            self.mmtk.scheduler.work_buckets[WorkBucketStage::Closure]
+            self.mmtk.scheduler.work_buckets[&WorkBucketStage::Closure]
                 .add(ProcessModBuf::<GenNurseryProcessEdges<VM, P>>::new(buf));
         }
     }
@@ -53,7 +53,7 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>>
         let buf = self.region_modbuf.take();
         if !buf.is_empty() {
             debug_assert!(!buf.is_empty());
-            self.mmtk.scheduler.work_buckets[WorkBucketStage::Closure].add(ProcessRegionModBuf::<
+            self.mmtk.scheduler.work_buckets[&WorkBucketStage::Closure].add(ProcessRegionModBuf::<
                 GenNurseryProcessEdges<VM, P>,
             >::new(buf));
         }

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -132,6 +132,18 @@ pub fn create_plan<VM: VMBinding>(
     plan
 }
 
+pub fn create_work_bucket_stage_config<VM: VMBinding>(
+    plan_selector: PlanSelector,
+) -> WorkBucketStageConfig {
+    // For any plan that needs extra work buckets, they should create their own stage config.
+    match plan_selector {
+        PlanSelector::MarkCompact => {
+            crate::plan::markcompact::MarkCompact::<VM>::work_bucket_stage_config()
+        }
+        _ => WorkBucketStageConfig::default(),
+    }
+}
+
 /// Create thread local GC worker.
 pub fn create_gc_worker_context<VM: VMBinding>(
     tls: VMWorkerThread,

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -1,11 +1,10 @@
-use super::global::MarkCompact;
+use super::global::*;
 use crate::policy::markcompactspace::MarkCompactSpace;
 use crate::policy::markcompactspace::{TRACE_KIND_FORWARD, TRACE_KIND_MARK};
 use crate::scheduler::gc_work::PlanProcessEdges;
 use crate::scheduler::gc_work::*;
 use crate::scheduler::GCWork;
 use crate::scheduler::GCWorker;
-use crate::scheduler::WorkBucketStage;
 use crate::vm::ActivePlan;
 use crate::vm::Scanning;
 use crate::vm::VMBinding;
@@ -47,11 +46,11 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         // scheduler.work_buckets[WorkBucketStage::RefForwarding]
         //     .add(ScanStackRoots::<ForwardingProcessEdges<VM>>::new());
         for mutator in VM::VMActivePlan::mutators() {
-            mmtk.scheduler.work_buckets[&WorkBucketStage::SecondRoots]
+            mmtk.scheduler.work_buckets[&SECOND_ROOTS_STAGE]
                 .add(ScanStackRoot::<ForwardingProcessEdges<VM>>(mutator));
         }
 
-        mmtk.scheduler.work_buckets[&WorkBucketStage::SecondRoots]
+        mmtk.scheduler.work_buckets[&SECOND_ROOTS_STAGE]
             .add(ScanVMSpecificRoots::<ForwardingProcessEdges<VM>>::new());
     }
 }

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -47,11 +47,11 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         // scheduler.work_buckets[WorkBucketStage::RefForwarding]
         //     .add(ScanStackRoots::<ForwardingProcessEdges<VM>>::new());
         for mutator in VM::VMActivePlan::mutators() {
-            mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
+            mmtk.scheduler.work_buckets[&WorkBucketStage::SecondRoots]
                 .add(ScanStackRoot::<ForwardingProcessEdges<VM>>(mutator));
         }
 
-        mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
+        mmtk.scheduler.work_buckets[&WorkBucketStage::SecondRoots]
             .add(ScanVMSpecificRoots::<ForwardingProcessEdges<VM>>::new());
     }
 }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -22,6 +22,7 @@ mod global;
 pub(crate) use global::create_gc_worker_context;
 pub(crate) use global::create_mutator;
 pub(crate) use global::create_plan;
+pub(crate) use global::create_work_bucket_stage_config;
 pub use global::AllocationSemantics;
 pub(crate) use global::GcStatus;
 pub use global::Plan;

--- a/src/plan/plan_constraints.rs
+++ b/src/plan/plan_constraints.rs
@@ -32,6 +32,7 @@ pub struct PlanConstraints {
     pub generate_gc_trace: bool,
     /// Some policies do object forwarding after the first liveness transitive closure, such as mark compact.
     /// For plans that use those policies, they should set this as true.
+    /// TODO: This is unused now. Mark compact will schedule their own work packet.
     pub needs_forward_after_liveness: bool,
 }
 

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -384,7 +384,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                     },
                 })
             });
-            self.scheduler().work_buckets[WorkBucketStage::Prepare].bulk_add(work_packets);
+            self.scheduler().work_buckets[&WorkBucketStage::Prepare].bulk_add(work_packets);
 
             if !super::BLOCK_ONLY {
                 self.line_mark_state.fetch_add(1, Ordering::AcqRel);
@@ -415,7 +415,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         }
         // Sweep chunks and blocks
         let work_packets = self.generate_sweep_tasks();
-        self.scheduler().work_buckets[WorkBucketStage::Release].bulk_add(work_packets);
+        self.scheduler().work_buckets[&WorkBucketStage::Release].bulk_add(work_packets);
         if super::DEFRAG {
             self.defrag.release(self);
         }

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -491,7 +491,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
             self.work_live_bytes.store(0, Ordering::SeqCst);
         }
 
-        self.scheduler.work_buckets[WorkBucketStage::Release].bulk_add(work_packets);
+        self.scheduler.work_buckets[&WorkBucketStage::Release].bulk_add(work_packets);
     }
 
     pub fn sweep_chunk(&self, chunk_start: Address) {

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -265,7 +265,7 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
         // do that when we release mutators (eager sweeping), or do that at allocation time (lazy sweeping).
         use crate::scheduler::WorkBucketStage;
         let work_packets = self.generate_sweep_tasks();
-        self.scheduler.work_buckets[WorkBucketStage::Release].bulk_add(work_packets);
+        self.scheduler.work_buckets[&WorkBucketStage::Release].bulk_add(work_packets);
 
         let mut abandoned = self.abandoned.lock().unwrap();
         abandoned.move_consumed_to_unswept();

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -86,7 +86,7 @@ impl<VM: VMBinding> GCController<VM> {
         );
 
         // Add a ScheduleCollection work packet.  It is the seed of other work packets.
-        self.scheduler.work_buckets[WorkBucketStage::Unconstrained].add(ScheduleCollection);
+        self.scheduler.work_buckets[&WorkBucketStage::Unconstrained].add(ScheduleCollection);
 
         // Notify only one worker at this time because there is only one work packet,
         // namely `ScheduleCollection`.

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -387,12 +387,14 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for VMProcessWeakRefs<E> {
 ///
 /// NOTE: This will replace `RefForwarding` and `ForwardFinalization` in the future.
 pub struct VMForwardWeakRefs<E: ProcessEdgesWork> {
+    stage: WorkBucketStage,
     phantom_data: PhantomData<E>,
 }
 
 impl<E: ProcessEdgesWork> VMForwardWeakRefs<E> {
-    pub fn new() -> Self {
+    pub fn new(stage: WorkBucketStage) -> Self {
         Self {
+            stage,
             phantom_data: PhantomData,
         }
     }
@@ -402,10 +404,8 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for VMForwardWeakRefs<E> {
     fn do_work(&mut self, worker: &mut GCWorker<E::VM>, _mmtk: &'static MMTK<E::VM>) {
         trace!("VMForwardWeakRefs");
 
-        let stage = WorkBucketStage::VMRefForwarding;
-
         let tracer_factory = ProcessEdgesWorkTracerContext::<E> {
-            stage,
+            stage: self.stage,
             phantom_data: PhantomData,
         };
         <E::VM as VMBinding>::VMScanning::forward_weak_refs(worker, tracer_factory)

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use work::GCWorkContext;
 
 mod work_bucket;
 pub use work_bucket::WorkBucketStage;
+pub use work_bucket::WorkBucketStageConfig;
 
 mod worker;
 pub(crate) use worker::current_worker_ordinal;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use work::GCWorkContext;
 
 mod work_bucket;
 pub use work_bucket::WorkBucketStage;
-pub use work_bucket::WorkBucketStageConfig;
+pub(crate) use work_bucket::WorkBucketStageConfig;
 
 mod worker;
 pub(crate) use worker::current_worker_ordinal;

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -286,10 +286,10 @@ impl<VM: VMBinding> GCWorker<VM> {
     /// If the bucket is activated, the packet will be pushed to the local queue, otherwise it will be
     /// pushed to the global bucket with a higher priority.
     pub fn add_work_prioritized(&mut self, bucket: WorkBucketStage, work: impl GCWork<VM>) {
-        if !self.scheduler().work_buckets[bucket].is_activated()
+        if !self.scheduler().work_buckets[&bucket].is_activated()
             || self.local_work_buffer.len() >= Self::LOCALLY_CACHED_WORK_PACKETS
         {
-            self.scheduler.work_buckets[bucket].add_prioritized(Box::new(work));
+            self.scheduler.work_buckets[&bucket].add_prioritized(Box::new(work));
             return;
         }
         self.local_work_buffer.push(Box::new(work));
@@ -299,10 +299,10 @@ impl<VM: VMBinding> GCWorker<VM> {
     /// If the bucket is activated, the packet will be pushed to the local queue, otherwise it will be
     /// pushed to the global bucket.
     pub fn add_work(&mut self, bucket: WorkBucketStage, work: impl GCWork<VM>) {
-        if !self.scheduler().work_buckets[bucket].is_activated()
+        if !self.scheduler().work_buckets[&bucket].is_activated()
             || self.local_work_buffer.len() >= Self::LOCALLY_CACHED_WORK_PACKETS
         {
-            self.scheduler.work_buckets[bucket].add(work);
+            self.scheduler.work_buckets[&bucket].add(work);
             return;
         }
         self.local_work_buffer.push(Box::new(work));

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -125,3 +125,13 @@ mod initialize_once_tests {
         assert_eq!(INITIALIZE_COUNT.load(Ordering::SeqCst), 1);
     }
 }
+
+/// Insert a value before the given value. Returns true if we find the given value in the vector, and perform the insertion.
+pub fn vec_insert_before<T: PartialEq>(vec: &mut Vec<T>, insert: T, before: &T) -> bool {
+    if let Some(pos) = vec.iter().position(|x| x == before) {
+        vec.insert(pos, insert);
+        true
+    } else {
+        false
+    }
+}

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -125,13 +125,3 @@ mod initialize_once_tests {
         assert_eq!(INITIALIZE_COUNT.load(Ordering::SeqCst), 1);
     }
 }
-
-/// Insert a value before the given value. Returns true if we find the given value in the vector, and perform the insertion.
-pub fn vec_insert_before<T: PartialEq>(vec: &mut Vec<T>, insert: T, before: &T) -> bool {
-    if let Some(pos) = vec.iter().position(|x| x == before) {
-        vec.insert(pos, insert);
-        true
-    } else {
-        false
-    }
-}


### PR DESCRIPTION
This PR adds `WorkBucketStageConfig` which can be defined by each plan. Thus each plan can create their own custom buckets. Currently only mark compact needs a custom bucket for compaction.
* Add `WorkBucketStageConfig` which defines all the bucket stages, and the first STW stage. Each plan may provide its own config.
* Add `WorkBucketStage::Custom(usize)`, and remove `WorkBucketStage::Compact`. The mark compact plan create their own custom bucket stage.
* Use `HashMap`, instead of `EnumMap` for buckets. All `buckets[stage]` uses need to be replaced with `buckets[&stage]` due to the difference in indexing the map.