### PR TITLE
Use atomic and/or for marking and forwarding

### DIFF
--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -251,37 +251,19 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
     /// succeeds, the method will return true, meaning the object is marked by this invocation.
     /// Otherwise, it returns false.
     fn test_and_mark(&self, object: ObjectReference, value: u8) -> bool {
-        loop {
-            let mask = if self.in_nursery_gc {
-                LOS_BIT_MASK
-            } else {
-                MARK_BIT
-            };
-            let old_value = VM::VMObjectModel::LOCAL_LOS_MARK_NURSERY_SPEC.load_atomic::<VM, u8>(
+        let mask = if self.in_nursery_gc {
+            LOS_BIT_MASK
+        } else {
+            MARK_BIT
+        };
+        let result = VM::VMObjectModel::LOCAL_LOS_MARK_NURSERY_SPEC
+            .fetch_update_metadata::<VM, u8, _>(
                 object,
-                None,
                 Ordering::SeqCst,
+                Ordering::SeqCst,
+                |old_value| (old_value & mask != value).then(|| old_value & !LOS_BIT_MASK | value),
             );
-            let mark_bit = old_value & mask;
-            if mark_bit == value {
-                return false;
-            }
-            // using LOS_BIT_MASK have side effects of clearing nursery bit
-            if VM::VMObjectModel::LOCAL_LOS_MARK_NURSERY_SPEC
-                .compare_exchange_metadata::<VM, u8>(
-                    object,
-                    old_value,
-                    old_value & !LOS_BIT_MASK | value,
-                    None,
-                    Ordering::SeqCst,
-                    Ordering::SeqCst,
-                )
-                .is_ok()
-            {
-                break;
-            }
-        }
-        true
+        result.is_ok()
     }
 
     fn test_mark_bit(&self, object: ObjectReference, value: u8) -> bool {

--- a/src/util/object_forwarding.rs
+++ b/src/util/object_forwarding.rs
@@ -22,23 +22,15 @@ const FORWARDING_POINTER_MASK: usize = 0xffff_fffc;
 /// Attempt to become the worker thread who will forward the object.
 /// The successful worker will set the object forwarding bits to BEING_FORWARDED, preventing other workers from forwarding the same object.
 pub fn attempt_to_forward<VM: VMBinding>(object: ObjectReference) -> u8 {
-    loop {
-        let old_value = get_forwarding_status::<VM>(object);
-        if old_value != FORWARDING_NOT_TRIGGERED_YET
-            || VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC
-                .compare_exchange_metadata::<VM, u8>(
-                    object,
-                    old_value,
-                    BEING_FORWARDED,
-                    None,
-                    Ordering::SeqCst,
-                    Ordering::Relaxed,
-                )
-                .is_ok()
-        {
-            return old_value;
-        }
-    }
+    // We simply "or" the current value with `BEING_FORWARDED` and return the old value.
+    // If the old value was 00 (`FORWARDING_NOT_TRIGGERED_YET`),
+    // it will be changed to 10 (`BEING_FORWARDED`);
+    // otherwise (the old value would be 10 or 11) it will be a no-op.
+    VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC.fetch_or_metadata::<VM, u8>(
+        object,
+        BEING_FORWARDED,
+        Ordering::SeqCst,
+    )
 }
 
 /// Spin-wait for the object's forwarding to become complete and then read the forwarding pointer to the new object.
@@ -132,12 +124,11 @@ pub fn state_is_being_forwarded(forwarding_bits: u8) -> bool {
 /// Zero the forwarding bits of an object.
 /// This function is used on new objects.
 pub fn clear_forwarding_bits<VM: VMBinding>(object: ObjectReference) {
-    VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC.store_atomic::<VM, u8>(
+    VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC.fetch_and_metadata::<VM, u8>(
         object,
         0,
-        None,
         Ordering::SeqCst,
-    )
+    );
 }
 
 /// Read the forwarding pointer of an object.


### PR DESCRIPTION
Use atomic and/or operation instead of atomic store for marking and forwarding.

Atomic store is currently implemented with compare-exchange or fetch_update.  Atomic and/or operations may be much faster because they are unconditional and do not need a loop.