### PR TITLE
Add trace_object_immediately to EdgeVisitor

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -249,7 +249,7 @@ impl<VM: VMBinding> GCWork<VM> for EndOfGC {
 
 /// This implements `ObjectTracer` by forwarding the `trace_object` calls to the wrapped
 /// `ProcessEdgesWork` instance.
-struct ProcessEdgesWorkTracer<E: ProcessEdgesWork> {
+pub struct ProcessEdgesWorkTracer<E: ProcessEdgesWork> {
     process_edges_work: E,
     stage: WorkBucketStage,
 }
@@ -269,6 +269,10 @@ impl<E: ProcessEdgesWork> ObjectTracer for ProcessEdgesWorkTracer<E> {
 }
 
 impl<E: ProcessEdgesWork> ProcessEdgesWorkTracer<E> {
+    pub fn new(process_edges_work: E, stage: WorkBucketStage) -> Self {
+        Self { process_edges_work, stage }
+    }
+
     fn flush_if_full(&mut self) {
         if self.process_edges_work.nodes.is_full() {
             self.flush();

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -9,20 +9,21 @@ use crate::vm::VMBinding;
 pub trait EdgeVisitor<ES: Edge> {
     /// Call this function for each edge.
     fn visit_edge(&mut self, edge: ES);
+    fn visit_object_immediately(&mut self, object: ObjectReference) -> ObjectReference;
 }
 
 /// This lets us use closures as EdgeVisitor.
-impl<ES: Edge, F: FnMut(ES)> EdgeVisitor<ES> for F {
-    fn visit_edge(&mut self, edge: ES) {
-        #[cfg(debug_assertions)]
-        trace!(
-            "(FunctionClosure) Visit edge {:?} (pointing to {})",
-            edge,
-            edge.load()
-        );
-        self(edge)
-    }
-}
+// impl<ES: Edge, F: FnMut(ES)> EdgeVisitor<ES> for F {
+//     fn visit_edge(&mut self, edge: ES) {
+//         #[cfg(debug_assertions)]
+//         trace!(
+//             "(FunctionClosure) Visit edge {:?} (pointing to {})",
+//             edge,
+//             edge.load()
+//         );
+//         self(edge)
+//     }
+// }
 
 /// Callback trait of scanning functions that directly trace through edges.
 pub trait ObjectTracer {


### PR DESCRIPTION
This PR adds `trace_object_immediately` to `EdgeVisitor`. This allows the binding to deal with some fields specially during object scanning. This allows flexibility during object scanning for the bindings, and they can choose how to deal with each edge.

The motivation is that Julia objects may have some fields that are internal references. When scanning the object, we can compute the offset from the internal reference to the actual object reference. Currently we are using `enum JuliaEdge { Simple(SimpleEdge), Offset(OffsetEdge) }` and `struct OffsetEdge { slot, offset }` to deal with this: the `OffsetEdge` knows the slot to load from and store to, and knows how to compute the actual object reference from the internal reference in the slot and the offset. However, this approach has drawbacks: 1. makes `enum JuliaEdge` large (2 words + enum tag). As we store a lot of edges, and we pass edges around in MMTk core. Using a large struct for edges has overhead. Considering `OffsetEdge` is just an infrequent case (maybe 10% in the workload I am looking at), paying cost penalty for it seems unnecessary. 2. we need to check which edge type it is all the time. This also imposes overhead. So I am trying to just use `SimpleEdge(Address)` for Julia. To achieve this, I need a different method from `EdgeVisitor` that I can use to deal with internal references. `trace_object_immediately` works for this case.