### PR TITLE
Counting VM-allocated pages into heap size.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ delegate = "0.9.0"
 downcast-rs = "1.1.1"
 enum-map = "2.4.2"
 env_logger = "0.10.0"
+# We do not use this crate, but env_logger uses it. env_logger uses is_terminal 0.4.0. However, since 0.4.8, is_terminal requires Rust 1.63.
+# So we fix on 0.4.7 here. Once we bump our MSRV, we can remove this.
+is-terminal = "=0.4.7"
 itertools = "0.10.5"
 jemalloc-sys = { version = "0.5.3", features = ["disable_initial_exec_tls"], optional = true }
 lazy_static = "1.1"

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -259,6 +259,9 @@ pub trait Plan: 'static + Sync + Downcast {
         let used_pages = self.get_used_pages();
         let collection_reserve = self.get_collection_reserved_pages();
         let vm_live_bytes = <Self::VM as VMBinding>::VMCollection::vm_live_bytes();
+        // Note that `vm_live_bytes` may not be the exact number of bytes in whole pages.  The VM
+        // binding is allowed to return an approximate value if it is expensive or impossible to
+        // compute the exact number of pages occupied.
         let vm_live_pages = conversions::bytes_to_pages_up(vm_live_bytes);
         let total = used_pages + collection_reserve + vm_live_pages;
 

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -253,8 +253,8 @@ pub trait Plan: 'static + Sync + Downcast {
     // if necessary.
 
     /// Get the number of pages that are reserved, including pages used by MMTk spaces, pages that
-    /// will be used (e.g. for copying), and live pages allocated by the VM as reported by the VM
-    /// binding.
+    /// will be used (e.g. for copying), and live pages allocated outside MMTk spaces as reported
+    /// by the VM binding.
     fn get_reserved_pages(&self) -> usize {
         let used_pages = self.get_used_pages();
         let collection_reserve = self.get_collection_reserved_pages();

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -4,7 +4,6 @@ use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::util::conversions;
 use crate::util::options::{GCTriggerSelector, Options};
-use crate::vm::Collection;
 use crate::vm::VMBinding;
 use crate::MMTK;
 use std::mem::MaybeUninit;
@@ -128,7 +127,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for FixedHeapSizeTrigger {
 
     fn is_heap_full(&self, plan: &'static dyn Plan<VM = VM>) -> bool {
         // If reserved pages is larger than the total pages, the heap is full.
-        plan.get_reserved_pages() + VM::VMCollection::vm_allocated_pages() > self.total_pages
+        plan.get_reserved_pages() > self.total_pages
     }
 
     fn get_heap_size_in_pages(&self) -> usize {
@@ -392,8 +391,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
 
     fn is_heap_full(&self, plan: &'static dyn Plan<VM = VM>) -> bool {
         // If reserved pages is larger than the current heap size, the heap is full.
-        plan.get_reserved_pages() + VM::VMCollection::vm_allocated_pages()
-            > self.current_heap_pages.load(Ordering::Relaxed)
+        plan.get_reserved_pages() > self.current_heap_pages.load(Ordering::Relaxed)
     }
 
     fn get_heap_size_in_pages(&self) -> usize {

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -4,6 +4,7 @@ use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::util::conversions;
 use crate::util::options::{GCTriggerSelector, Options};
+use crate::vm::Collection;
 use crate::vm::VMBinding;
 use crate::MMTK;
 use std::mem::MaybeUninit;
@@ -127,7 +128,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for FixedHeapSizeTrigger {
 
     fn is_heap_full(&self, plan: &'static dyn Plan<VM = VM>) -> bool {
         // If reserved pages is larger than the total pages, the heap is full.
-        plan.get_reserved_pages() > self.total_pages
+        plan.get_reserved_pages() + VM::VMCollection::vm_allocated_pages() > self.total_pages
     }
 
     fn get_heap_size_in_pages(&self) -> usize {
@@ -391,7 +392,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
 
     fn is_heap_full(&self, plan: &'static dyn Plan<VM = VM>) -> bool {
         // If reserved pages is larger than the current heap size, the heap is full.
-        plan.get_reserved_pages() > self.current_heap_pages.load(Ordering::Relaxed)
+        plan.get_reserved_pages() + VM::VMCollection::vm_allocated_pages()
+            > self.current_heap_pages.load(Ordering::Relaxed)
     }
 
     fn get_heap_size_in_pages(&self) -> usize {

--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -113,21 +113,15 @@ pub trait Collection<VM: VMBinding> {
     fn post_forwarding(_tls: VMWorkerThread) {}
 
     /// Return the amount of memory (in bytes) which the VM allocated outside the MMTk heap but
-    /// wants to include into the current MMTk heap size.
+    /// wants to include into the current MMTk heap size.  MMTk core will consider the reported
+    /// memory as part of MMTk heap for the purpose of heap size accounting.
     ///
-    /// MMTk core will consider this amount for triggering GC.  In the current implementation, MMTk
-    /// will add this amount to the amount of memory allocated or reserved in MMTk spaces, and will
-    /// trigger a GC if the sum exceeds the maximum heap size or a limit dynamically determined by
-    /// the MemBalancer.
-    ///
-    /// MMTk does not specify what memory this amount should include.  However, because this amount
-    /// is used to trigger GC, it is advisable to include memory that is kept alive by heap objects
-    /// and can be released by executing finalizers (or other language-specific cleaning-up
-    /// routines) that are executed when the heap objects are dead.  For example, if a language
-    /// implementation allocates array headers in the MMTk heap, but allocates their underlying
-    /// buffers that hold the actual elements using `malloc`, then those buffers should be included
-    /// in this amount.  When the GC finds such an array dead, its finalizer shall `free` the
-    /// buffer and reduce this amount.
+    /// This amount should include memory that is kept alive by heap objects and can be released by
+    /// executing finalizers (or other language-specific cleaning-up routines) that are executed
+    /// when the heap objects are dead.  For example, if a language implementation allocates array
+    /// headers in the MMTk heap, but allocates their underlying buffers that hold the actual
+    /// elements using `malloc`, then those buffers should be included in this amount.  When the GC
+    /// finds such an array dead, its finalizer shall `free` the buffer and reduce this amount.
     ///
     /// If possible, the VM should account off-heap memory by pages.  That is, count the number of
     /// pages occupied by off-heap objects, and report the number of bytes of those whole pages

--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -123,24 +123,24 @@ pub trait Collection<VM: VMBinding> {
     /// elements using `malloc`, then those buffers should be included in this amount.  When the GC
     /// finds such an array dead, its finalizer shall `free` the buffer and reduce this amount.
     ///
-    /// If possible, the VM should account off-heap memory by pages.  That is, count the number of
+    /// If possible, the VM should account off-heap memory in pages.  That is, count the number of
     /// pages occupied by off-heap objects, and report the number of bytes of those whole pages
     /// instead of individual objects.  Because the underlying operating system manages memory at
     /// page granularity, the occupied pages (instead of individual objects) determine the memory
     /// footprint of a process, and how much memory MMTk spaces can obtain from the OS.
     ///
-    /// However, if the VM is incapable of accouting off-heap memory by pages (for example, if the
+    /// However, if the VM is incapable of accounting off-heap memory in pages (for example, if the
     /// VM uses `malloc` and the implementation of `malloc` is opaque to the VM), the VM binding
     /// can simply return the total number of bytes of those off-heap objects as an approximation.
     ///
     /// # Performance note
     ///
     /// This function will be called when MMTk polls for GC.  It happens every time the MMTk
-    /// allocators allocated a certain amount of memory, usually one or a few blocks.  Because this
-    /// function is called very frequently, its implementation must be efficient.  If it is too
-    /// expensive to compute the exact amount, an approximate value should be sufficient for MMTk
-    /// to trigger GC promptly in order to release off-heap memory, and keep the memory footprint
-    /// under control.
+    /// allocators have allocated a certain amount of memory, usually one or a few blocks.  Because
+    /// this function is called very frequently, its implementation must be efficient.  If it is
+    /// too expensive to compute the exact amount, an approximate value should be sufficient for
+    /// MMTk to trigger GC promptly in order to release off-heap memory, and keep the memory
+    /// footprint under control.
     fn vm_live_bytes() -> usize {
         // By default, MMTk assumes the amount of memory the VM allocates off-heap is negligible.
         0


### PR DESCRIPTION
Some VMs allocate memory outside the MMTk heap, using `malloc` or other allocation methods.  Those memory can usually be reclaiming by the finalizers of dead object in the MMTk heap.  This commit allows the VM to report the amount of such off-heap memory so that MMTk can trigger GC more promptly to reclaim such memory.

to-do list:
-   [x] Ensure it works with dynamic heap size.

# Related work

The "**malloc_counted_size**" feature: Introduced in https://github.com/mmtk/mmtk-core/pull/608, that feature was intended for implementing malloc/free in MMTk's spaces, although the current implementation simply wraps the `malloc` function from libc.  This PR, on the other hand, is agnostic of how the VM allocates memory outside the MMTk heap.  This PR is useful if the VM already does similar accounting.  For example, Ruby accounts for memory allocated by `xmalloc`, a wrapper of `malloc`.
