### PR TITLE
Let ObjectReference implement Ord

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -461,7 +461,7 @@ use crate::vm::VMBinding;
 /// methods in [`crate::vm::ObjectModel`]. Major refactoring is needed in MMTk to allow
 /// the opaque `ObjectReference` type, and we haven't seen a use case for now.
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, Hash, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Eq, Hash, PartialOrd, Ord, PartialEq)]
 pub struct ObjectReference(usize);
 
 impl ObjectReference {


### PR DESCRIPTION
This will enable `Vec<ObjectReference>` to be sorted, and enable `ObjectReference` to be used as the keys of ordered collections such as `BTreeMap`.  Although mmtk-core currently never sorts `Vec<ObjectReference>`, developers of mmtk-core as well as bindings may experiment with accessing `ObjectReference` instances from low addresses to high addresses.  It complicates things if `ObjectReference` does not implement `Ord`.