### PR TITLE
Work around stack overflow in array_from_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ spin = "0.9.5"
 static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
-sysinfo = "0.29"
+# Fix to 0.29.5.  Updating to 0.29.6 requires MSRV 1.63.
+sysinfo = "=0.29.5"
 
 [dev-dependencies]
 paste = "1.0.8"

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -127,14 +127,24 @@ mod initialize_once_tests {
 }
 
 /// This implements `std::array::from_fn` introduced in Rust 1.63.
-/// We should replace this with the standard counterpart after bumping MSRV.
-pub(crate) fn array_from_fn<T, const N: usize, F>(cb: F) -> [T; N]
+/// We should replace this with the standard counterpart after bumping MSRV,
+/// but we also need to evaluate whether it would use too much stack space (see code comments).
+pub(crate) fn array_from_fn<T, const N: usize, F>(mut cb: F) -> [T; N]
 where
     F: FnMut(usize) -> T,
 {
-    let mut index_array = [0; N];
-    for (index, item) in index_array.iter_mut().enumerate() {
-        *item = index;
+    // Note on unsafety: An alternative to the unsafe implementation below is creating a fixed
+    // array of `[0, 1, 2, ..., N-1]` and using the `.map(cb)` method to create the result.
+    // However, the `array::map` method implemented in the standard library consumes a surprisingly
+    // large amount of stack space.  For VMs that run on confined stacks, such as JikesRVM, that
+    // would cause stack overflow.  Therefore we implement it manually using unsafe primitives.
+    let mut result_array: MaybeUninit<[T; N]> = MaybeUninit::zeroed();
+    let array_ptr = result_array.as_mut_ptr();
+    for index in 0..N {
+        let item = cb(index);
+        unsafe {
+            std::ptr::addr_of_mut!((*array_ptr)[index]).write(item);
+        }
     }
-    index_array.map(cb)
+    unsafe { result_array.assume_init() }
 }


### PR DESCRIPTION
It should fix a crash in JikesRVM caused by overflown stack overwriting objects in the VM space.

Fixes: https://github.com/mmtk/mmtk-core/issues/874