### PR TITLE
Fix UB in SFTMap implementations

### DIFF
--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -136,7 +136,7 @@ mod space_map {
             }
 
             //*mut_self.sft.get_unchecked_mut(index) = space;
-            *(*self.sft.get()).get_unchecked_mut(index) = unsafe { std::mem::transmute(space) };
+            *(*self.sft.get()).get_unchecked_mut(index) = std::mem::transmute(space);
         }
 
         unsafe fn clear(&self, addr: Address) {

--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -64,11 +64,11 @@ pub(crate) fn create_sft_map() -> Box<dyn SFTMap> {
     cfg_if::cfg_if! {
         if #[cfg(all(feature = "malloc_mark_sweep", target_pointer_width = "64"))] {
             // 64-bit malloc mark sweep needs a chunk-based SFT map, but the sparse map is not suitable for 64bits.
-            Box::new(dense_chunk_map::SFTDenseChunkMap::<'static>::new())
+            Box::new(dense_chunk_map::SFTDenseChunkMap::new())
         } else if #[cfg(target_pointer_width = "64")] {
             Box::new(space_map::SFTSpaceMap::new())
         } else if #[cfg(target_pointer_width = "32")] {
-            Box::new(sparse_chunk_map::SFTSparseChunkMap::<'static>::new())
+            Box::new(sparse_chunk_map::SFTSparseChunkMap::new())
         } else {
             compile_err!("Cannot figure out which SFT map to use.");
         }

--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -135,7 +135,6 @@ mod space_map {
                 }
             }
 
-            //*mut_self.sft.get_unchecked_mut(index) = space;
             *(*self.sft.get()).get_unchecked_mut(index) = std::mem::transmute(space);
         }
 

--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -363,12 +363,11 @@ mod dense_chunk_map {
         pub fn addr_to_index(addr: Address) -> u8 {
             SFT_DENSE_CHUNK_MAP_INDEX.load_atomic::<u8>(addr, Ordering::Relaxed)
         }
-        #[inline(always)]
+       
         fn sft(&self) -> &Vec<*const (dyn SFT + Sync + 'static)> {
             unsafe { &*self.sft.get() }
         }
 
-        #[inline(always)]
         fn index_map(&self) -> &HashMap<String, usize> {
             unsafe { &*self.index_map.get() }
         }

--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -363,7 +363,7 @@ mod dense_chunk_map {
         pub fn addr_to_index(addr: Address) -> u8 {
             SFT_DENSE_CHUNK_MAP_INDEX.load_atomic::<u8>(addr, Ordering::Relaxed)
         }
-       
+
         fn sft(&self) -> &Vec<*const (dyn SFT + Sync + 'static)> {
             unsafe { &*self.sft.get() }
         }

--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -118,7 +118,6 @@ mod space_map {
             start: Address,
             bytes: usize,
         ) {
-            //let mut_self = self.mut_self();
             let index = Self::addr_to_index(start);
             if cfg!(debug_assertions) {
                 // Make sure we only update from empty to a valid space, or overwrite the space
@@ -141,7 +140,6 @@ mod space_map {
         unsafe fn clear(&self, addr: Address) {
             let index = Self::addr_to_index(addr);
             *(*self.sft.get()).get_unchecked_mut(index) = &EMPTY_SPACE_SFT;
-            //*mut_self.sft.get_unchecked_mut(index) = &EMPTY_SPACE_SFT;
         }
     }
 


### PR DESCRIPTION
1) Replaces casts of references to mutable references with `UnsafeCell<T>`. 
2) Spaces are stored inside each of implementation as pointers in order to make Rust compiler happy because of lifetimes. 