### PR TITLE
Expose Allocators type to public API

### DIFF
--- a/src/util/alloc/mod.rs
+++ b/src/util/alloc/mod.rs
@@ -9,6 +9,7 @@ pub use allocator::Allocator;
 /// A list of all the allocators, embedded in Mutator
 pub(crate) mod allocators;
 pub use allocators::AllocatorSelector;
+pub use allocators::Allocators;
 
 /// Bump pointer allocator
 mod bumpallocator;


### PR DESCRIPTION
Without it getting offsets of `Allocators` fields is impossible in Rust, other bindings just declare that type in header file but in Rust it should be as simple as using memoffset crate + Allocators type from mmtk-core itself.