### PR TITLE
Expose Immix, MarkCompact and BumpAllocator fields to public API

### DIFF
--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -18,9 +18,9 @@ pub struct BumpAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
     /// Current cursor for bump pointer
-    cursor: Address,
+    pub cursor: Address,
     /// Limit for bump pointer
-    limit: Address,
+    pub limit: Address,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
     space: &'static dyn Space<VM>,
     /// [`Plan`] instance that this allocator instance is associated with.

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -16,9 +16,9 @@ use crate::vm::*;
 pub struct ImmixAllocator<VM: VMBinding> {
     pub tls: VMThread,
     /// Bump pointer
-    cursor: Address,
+    pub cursor: Address,
     /// Limit for bump pointer
-    limit: Address,
+    pub limit: Address,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
     space: &'static ImmixSpace<VM>,
     /// [`Plan`] instance that this allocator instance is associated with.

--- a/src/util/alloc/markcompact_allocator.rs
+++ b/src/util/alloc/markcompact_allocator.rs
@@ -10,7 +10,7 @@ use crate::vm::VMBinding;
 /// reserve extra bytes when allocating
 #[repr(C)]
 pub struct MarkCompactAllocator<VM: VMBinding> {
-    bump_allocator: BumpAllocator<VM>,
+    pub bump_allocator: BumpAllocator<VM>,
 }
 
 impl<VM: VMBinding> MarkCompactAllocator<VM> {


### PR DESCRIPTION
`cursor`  and `limit` fields of Immix and BumpAllocator are now public, access to BumpAllocator through MarkCompact allocator is also public