### PR TITLE
Run CI build/unit test with latest stable Rust toolchain

### DIFF
--- a/.github/workflows/pre-review-ci.yml
+++ b/.github/workflows/pre-review-ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           export MSRV=`cargo read-manifest | python -c 'import json,sys; print(json.load(sys.stdin)["rust_version"])'`
           export TEST=`cat rust-toolchain`
-          echo "::set-output name=array::[\"$MSRV\", \"$TEST\"]"
+          echo "::set-output name=array::[\"$MSRV\", \"$TEST\", \"stable\"]"
 
   pre-code-review-checks:
     needs: setup-test-matrix


### PR DESCRIPTION
This PR adds checks to build and unit test MMTk core with the latest Rust stable version. We do not require the tests with latest stable Rust to pass in order to merge a PR. See discussion in https://github.com/mmtk/mmtk-core/pull/881#issuecomment-1664925112.