### PR TITLE
Fix unaligned access

### DIFF
--- a/src/util/malloc/malloc_ms_util.rs
+++ b/src/util/malloc/malloc_ms_util.rs
@@ -33,20 +33,20 @@ pub fn align_offset_alloc<VM: VMBinding>(size: usize, align: usize, offset: usiz
         result += align;
     }
     let malloc_res_ptr: *mut usize = (result - BYTES_IN_ADDRESS).to_mut_ptr();
-    unsafe { *malloc_res_ptr = address.as_usize() };
+    unsafe { malloc_res_ptr.write_unaligned(address.as_usize()) };
     result
 }
 
 pub fn offset_malloc_usable_size(address: Address) -> usize {
     let malloc_res_ptr: *mut usize = (address - BYTES_IN_ADDRESS).to_mut_ptr();
-    let malloc_res = unsafe { *malloc_res_ptr } as *mut libc::c_void;
+    let malloc_res = unsafe { malloc_res_ptr.read_unaligned() } as *mut libc::c_void;
     unsafe { malloc_usable_size(malloc_res) }
 }
 
 /// free an address that is allocated with some offset
 pub fn offset_free(address: Address) {
     let malloc_res_ptr: *mut usize = (address - BYTES_IN_ADDRESS).to_mut_ptr();
-    let malloc_res = unsafe { *malloc_res_ptr } as *mut libc::c_void;
+    let malloc_res = unsafe { malloc_res_ptr.read_unaligned() } as *mut libc::c_void;
     unsafe { free(malloc_res) };
 }
 

--- a/vmbindings/dummyvm/src/edges.rs
+++ b/vmbindings/dummyvm/src/edges.rs
@@ -64,7 +64,7 @@ impl MemorySlice for DummyVMMemorySlice {
     }
 
     fn bytes(&self) -> usize {
-        unsafe { (*self.0).len() * std::mem::size_of::<ObjectReference>() }
+        unsafe { std::mem::size_of_val(&*self.0) }
     }
 
     fn copy(src: &Self, tgt: &Self) {


### PR DESCRIPTION
`align_offset_alloc` and related functions now use `ptr::{read,write}_unaligned` to access the prepended address.

When calculating the address or offset of metadata, we ensure its address or offset is at least word-aligned.

Fixes: https://github.com/mmtk/mmtk-core/issues/886
Fixes: https://github.com/mmtk/mmtk-core/issues/888