### PR TITLE
Fix performance regression test scripts

### DIFF
--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -69,6 +69,8 @@ jobs:
           export FROM_DATE=2020-07-10
           export PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH
           export JAVA_HOME=/opt/jdk1.6.0_45/
+          # To workaround "javax.net.ssl.SSLException: Received fatal alert: protocol_version"
+          export JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
           ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -2,19 +2,19 @@ name: Performance Regression CI
 
 # Triggerred when a new commit is pushed to master
 on:
-  # push:
-  #   branches:
-  #     - master
+  push:
+    branches:
+      - master
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'test'
+  RESULT_REPO_BRANCH: 'self-hosted'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
 
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.6.9"
+          ref: "0.6.9"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.6.9"
+          ref: "0.6.9"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.6.9"
+          ref: "0.6.9"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -60,6 +60,11 @@ jobs:
       - id: branch
         # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
         run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+      # Just test if we can build JikesRVM
+      - name: Test Build
+        run: |
+          cd mmtk-jikesrvm/repos/jikesrvm
+          JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./bin/buildit localhost BaseBaseNoGC
       # run
       - name: Performance Run
         run: |
@@ -79,132 +84,132 @@ jobs:
           publish_branch: gh-pages
           keep_files: true
 
-  # OpenJDK
-  openjdk-perf-regression:
-    runs-on: [self-hosted, Linux, freq-scaling-off]
-    steps:
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v2
-        with:
-          path: mmtk-core
-      - name: Checkout OpenJDK Binding
-        uses: actions/checkout@v2
-        with:
-          repository: mmtk/mmtk-openjdk
-          path: mmtk-openjdk
-      - name: Checkout OpenJDK
-        working-directory: mmtk-openjdk
-        run: |
-          ./.github/scripts/ci-checkout.sh
-      # checkout perf-kit
-      - name: Checkout Perf Kit
-        uses: actions/checkout@v2
-        with:
-          repository: mmtk/ci-perf-kit
-          ref: "branch-0.6.9"
-          path: ci-perf-kit
-          token: ${{ secrets.CI_ACCESS_TOKEN }}
-          submodules: true
-      # setup
-      - name: Overwrite MMTk core in openjdk binding
-        run: cp -r mmtk-core mmtk-openjdk/repos/
-      - name: Setup Rust Toolchain
-        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-      # cleanup previosu build
-      - name: Cleanup previous build
-        run: |
-          rm -rf mmtk-openjdk/repos/openjdk/scratch
-          rm -rf mmtk-openjdk/repos/openjdk/build
-      - name: Setup
-        run: |
-          ./ci-perf-kit/scripts/history-run-setup.sh
-          mkdir -p ci-perf-kit/running/benchmarks/dacapo
-          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
-          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
-          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
-      - id: branch
-        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
-      # run
-      - name: Performance Run
-        run: |
-          export RESULT_REPO=mmtk/ci-perf-result
-          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-          export FROM_DATE=2020-07-10
-          ./ci-perf-kit/scripts/openjdk-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
-      # deploy
-      - name: Deploy to Github Page
-        if: ${{ env.DEPLOY == 'true' }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-          external_repository: mmtk/ci-perf-result
-          publish_dir: ./reports
-          publish_branch: gh-pages
-          keep_files: true
+  # # OpenJDK
+  # openjdk-perf-regression:
+  #   runs-on: [self-hosted, Linux, freq-scaling-off]
+  #   steps:
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v2
+  #       with:
+  #         path: mmtk-core
+  #     - name: Checkout OpenJDK Binding
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: mmtk/mmtk-openjdk
+  #         path: mmtk-openjdk
+  #     - name: Checkout OpenJDK
+  #       working-directory: mmtk-openjdk
+  #       run: |
+  #         ./.github/scripts/ci-checkout.sh
+  #     # checkout perf-kit
+  #     - name: Checkout Perf Kit
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: mmtk/ci-perf-kit
+  #         ref: "branch-0.6.9"
+  #         path: ci-perf-kit
+  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         submodules: true
+  #     # setup
+  #     - name: Overwrite MMTk core in openjdk binding
+  #       run: cp -r mmtk-core mmtk-openjdk/repos/
+  #     - name: Setup Rust Toolchain
+  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+  #     # cleanup previosu build
+  #     - name: Cleanup previous build
+  #       run: |
+  #         rm -rf mmtk-openjdk/repos/openjdk/scratch
+  #         rm -rf mmtk-openjdk/repos/openjdk/build
+  #     - name: Setup
+  #       run: |
+  #         ./ci-perf-kit/scripts/history-run-setup.sh
+  #         mkdir -p ci-perf-kit/running/benchmarks/dacapo
+  #         cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
+  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
+  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
+  #     - id: branch
+  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+  #       run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+  #     # run
+  #     - name: Performance Run
+  #       run: |
+  #         export RESULT_REPO=mmtk/ci-perf-result
+  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+  #         export FROM_DATE=2020-07-10
+  #         ./ci-perf-kit/scripts/openjdk-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
+  #     # deploy
+  #     - name: Deploy to Github Page
+  #       if: ${{ env.DEPLOY == 'true' }}
+  #       uses: peaceiris/actions-gh-pages@v3
+  #       with:
+  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         external_repository: mmtk/ci-perf-result
+  #         publish_dir: ./reports
+  #         publish_branch: gh-pages
+  #         keep_files: true
 
-  openjdk-mutator-perf:
-    runs-on: [self-hosted, Linux, freq-scaling-off]
-    steps:
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v2
-        with:
-          path: mmtk-core
-      - name: Checkout OpenJDK Binding
-        uses: actions/checkout@v2
-        with:
-          repository: mmtk/mmtk-openjdk
-          path: mmtk-openjdk
-      - name: Checkout OpenJDK
-        working-directory: mmtk-openjdk
-        run: |
-          ./.github/scripts/ci-checkout.sh
-      # checkout perf-kit
-      - name: Checkout Perf Kit
-        uses: actions/checkout@v2
-        with:
-          repository: mmtk/ci-perf-kit
-          ref: "branch-0.6.9"
-          path: ci-perf-kit
-          token: ${{ secrets.CI_ACCESS_TOKEN }}
-          submodules: true
-      # setup
-      - name: Overwrite MMTk core in openjdk binding
-        run: cp -r mmtk-core mmtk-openjdk/repos/
-      - name: Setup Rust Toolchain
-        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-      # cleanup previosu build
-      - name: Cleanup previous build
-        run: |
-          rm -rf mmtk-openjdk/repos/openjdk/scratch
-          rm -rf mmtk-openjdk/repos/openjdk/build
-      - id: branch
-        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
-      - name: Setup
-        run: |
-          ./ci-perf-kit/scripts/history-run-setup.sh
-          mkdir -p ci-perf-kit/running/benchmarks/dacapo
-          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
-          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
-          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
-      # run
-      - name: Performance Run
-        run: |
-          export RESULT_REPO=mmtk/ci-perf-result
-          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-          export FROM_DATE=2020-08-03
-          export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
-          ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
-      # deploy
-      - name: Deploy to Github Page
-        if: ${{ env.DEPLOY == 'true' }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-          external_repository: mmtk/ci-perf-result
-          publish_dir: ./reports
-          publish_branch: gh-pages
-          keep_files: true
+  # openjdk-mutator-perf:
+  #   runs-on: [self-hosted, Linux, freq-scaling-off]
+  #   steps:
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v2
+  #       with:
+  #         path: mmtk-core
+  #     - name: Checkout OpenJDK Binding
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: mmtk/mmtk-openjdk
+  #         path: mmtk-openjdk
+  #     - name: Checkout OpenJDK
+  #       working-directory: mmtk-openjdk
+  #       run: |
+  #         ./.github/scripts/ci-checkout.sh
+  #     # checkout perf-kit
+  #     - name: Checkout Perf Kit
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: mmtk/ci-perf-kit
+  #         ref: "branch-0.6.9"
+  #         path: ci-perf-kit
+  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         submodules: true
+  #     # setup
+  #     - name: Overwrite MMTk core in openjdk binding
+  #       run: cp -r mmtk-core mmtk-openjdk/repos/
+  #     - name: Setup Rust Toolchain
+  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+  #     # cleanup previosu build
+  #     - name: Cleanup previous build
+  #       run: |
+  #         rm -rf mmtk-openjdk/repos/openjdk/scratch
+  #         rm -rf mmtk-openjdk/repos/openjdk/build
+  #     - id: branch
+  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+  #       run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+  #     - name: Setup
+  #       run: |
+  #         ./ci-perf-kit/scripts/history-run-setup.sh
+  #         mkdir -p ci-perf-kit/running/benchmarks/dacapo
+  #         cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
+  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
+  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
+  #     # run
+  #     - name: Performance Run
+  #       run: |
+  #         export RESULT_REPO=mmtk/ci-perf-result
+  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+  #         export FROM_DATE=2020-08-03
+  #         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+  #         ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
+  #     # deploy
+  #     - name: Deploy to Github Page
+  #       if: ${{ env.DEPLOY == 'true' }}
+  #       uses: peaceiris/actions-gh-pages@v3
+  #       with:
+  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         external_repository: mmtk/ci-perf-result
+  #         publish_dir: ./reports
+  #         publish_branch: gh-pages
+  #         keep_files: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -2,19 +2,19 @@ name: Performance Regression CI
 
 # Triggerred when a new commit is pushed to master
 on:
-  push:
-    branches:
-      - master
+  # push:
+  #   branches:
+  #     - master
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'self-hosted'
+  RESULT_REPO_BRANCH: 'test'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
 
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.8"
+          ref: "branch-0.6.9"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -67,7 +67,9 @@ jobs:
           export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
           export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
           export FROM_DATE=2020-07-10
-          JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
+          export PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH
+          export JAVA_HOME=/opt/jdk1.6.0_45/
+          ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page
         if: ${{ env.DEPLOY == 'true' }}
@@ -101,7 +103,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.8"
+          ref: "branch-0.6.9"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -165,7 +167,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.8"
+          ref: "branch-0.6.9"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -196,7 +198,6 @@ jobs:
           export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
           export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
           export FROM_DATE=2020-08-03
-          export JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-amd64
           ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -60,6 +60,11 @@ jobs:
       - id: branch
         # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
         run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+      # JDK1.6 does not support TLS1.2, and repo.maven.org does not support TLS1.0
+      - name: Workaround dependency SSL issue
+        run: |
+          mkdir -p mmtk-jikesrvm/repos/jikesrvm/components/asm/3.0/asm-3.0/
+          wget https://repo1.maven.org/maven2/asm/asm/3.0/asm-3.0.jar -o mmtk-jikesrvm/repos/jikesrvm/components/asm/3.0/asm-3.0/asm.jar
       # run
       - name: Performance Run
         run: |
@@ -69,8 +74,6 @@ jobs:
           export FROM_DATE=2020-07-10
           export PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH
           export JAVA_HOME=/opt/jdk1.6.0_45/
-          # To workaround "javax.net.ssl.SSLException: Received fatal alert: protocol_version"
-          export JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
           ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -60,11 +60,6 @@ jobs:
       - id: branch
         # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
         run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
-      # JDK1.6 does not support TLS1.2, and repo.maven.org does not support TLS1.0
-      - name: Workaround dependency SSL issue
-        run: |
-          mkdir -p mmtk-jikesrvm/repos/jikesrvm/components/asm/3.0/asm-3.0/
-          wget https://repo1.maven.org/maven2/asm/asm/3.0/asm-3.0.jar -o mmtk-jikesrvm/repos/jikesrvm/components/asm/3.0/asm-3.0/asm.jar
       # run
       - name: Performance Run
         run: |
@@ -72,9 +67,7 @@ jobs:
           export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
           export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
           export FROM_DATE=2020-07-10
-          export PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH
-          export JAVA_HOME=/opt/jdk1.6.0_45/
-          ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
+          JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page
         if: ${{ env.DEPLOY == 'true' }}

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -60,11 +60,6 @@ jobs:
       - id: branch
         # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
         run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
-      # Just test if we can build JikesRVM
-      - name: Test Build
-        run: |
-          cd mmtk-jikesrvm/repos/jikesrvm
-          JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./bin/buildit localhost BaseBaseNoGC
       # run
       - name: Performance Run
         run: |
@@ -84,132 +79,132 @@ jobs:
           publish_branch: gh-pages
           keep_files: true
 
-  # # OpenJDK
-  # openjdk-perf-regression:
-  #   runs-on: [self-hosted, Linux, freq-scaling-off]
-  #   steps:
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: mmtk-core
-  #     - name: Checkout OpenJDK Binding
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: mmtk/mmtk-openjdk
-  #         path: mmtk-openjdk
-  #     - name: Checkout OpenJDK
-  #       working-directory: mmtk-openjdk
-  #       run: |
-  #         ./.github/scripts/ci-checkout.sh
-  #     # checkout perf-kit
-  #     - name: Checkout Perf Kit
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: mmtk/ci-perf-kit
-  #         ref: "branch-0.6.9"
-  #         path: ci-perf-kit
-  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         submodules: true
-  #     # setup
-  #     - name: Overwrite MMTk core in openjdk binding
-  #       run: cp -r mmtk-core mmtk-openjdk/repos/
-  #     - name: Setup Rust Toolchain
-  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-  #     # cleanup previosu build
-  #     - name: Cleanup previous build
-  #       run: |
-  #         rm -rf mmtk-openjdk/repos/openjdk/scratch
-  #         rm -rf mmtk-openjdk/repos/openjdk/build
-  #     - name: Setup
-  #       run: |
-  #         ./ci-perf-kit/scripts/history-run-setup.sh
-  #         mkdir -p ci-perf-kit/running/benchmarks/dacapo
-  #         cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
-  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
-  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
-  #     - id: branch
-  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-  #       run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
-  #     # run
-  #     - name: Performance Run
-  #       run: |
-  #         export RESULT_REPO=mmtk/ci-perf-result
-  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-  #         export FROM_DATE=2020-07-10
-  #         ./ci-perf-kit/scripts/openjdk-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
-  #     # deploy
-  #     - name: Deploy to Github Page
-  #       if: ${{ env.DEPLOY == 'true' }}
-  #       uses: peaceiris/actions-gh-pages@v3
-  #       with:
-  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         external_repository: mmtk/ci-perf-result
-  #         publish_dir: ./reports
-  #         publish_branch: gh-pages
-  #         keep_files: true
+  # OpenJDK
+  openjdk-perf-regression:
+    runs-on: [self-hosted, Linux, freq-scaling-off]
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v2
+        with:
+          path: mmtk-core
+      - name: Checkout OpenJDK Binding
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/mmtk-openjdk
+          path: mmtk-openjdk
+      - name: Checkout OpenJDK
+        working-directory: mmtk-openjdk
+        run: |
+          ./.github/scripts/ci-checkout.sh
+      # checkout perf-kit
+      - name: Checkout Perf Kit
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/ci-perf-kit
+          ref: "branch-0.6.9"
+          path: ci-perf-kit
+          token: ${{ secrets.CI_ACCESS_TOKEN }}
+          submodules: true
+      # setup
+      - name: Overwrite MMTk core in openjdk binding
+        run: cp -r mmtk-core mmtk-openjdk/repos/
+      - name: Setup Rust Toolchain
+        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+      # cleanup previosu build
+      - name: Cleanup previous build
+        run: |
+          rm -rf mmtk-openjdk/repos/openjdk/scratch
+          rm -rf mmtk-openjdk/repos/openjdk/build
+      - name: Setup
+        run: |
+          ./ci-perf-kit/scripts/history-run-setup.sh
+          mkdir -p ci-perf-kit/running/benchmarks/dacapo
+          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
+          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
+          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
+      - id: branch
+        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+      # run
+      - name: Performance Run
+        run: |
+          export RESULT_REPO=mmtk/ci-perf-result
+          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+          export FROM_DATE=2020-07-10
+          ./ci-perf-kit/scripts/openjdk-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
+      # deploy
+      - name: Deploy to Github Page
+        if: ${{ env.DEPLOY == 'true' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+          external_repository: mmtk/ci-perf-result
+          publish_dir: ./reports
+          publish_branch: gh-pages
+          keep_files: true
 
-  # openjdk-mutator-perf:
-  #   runs-on: [self-hosted, Linux, freq-scaling-off]
-  #   steps:
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: mmtk-core
-  #     - name: Checkout OpenJDK Binding
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: mmtk/mmtk-openjdk
-  #         path: mmtk-openjdk
-  #     - name: Checkout OpenJDK
-  #       working-directory: mmtk-openjdk
-  #       run: |
-  #         ./.github/scripts/ci-checkout.sh
-  #     # checkout perf-kit
-  #     - name: Checkout Perf Kit
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: mmtk/ci-perf-kit
-  #         ref: "branch-0.6.9"
-  #         path: ci-perf-kit
-  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         submodules: true
-  #     # setup
-  #     - name: Overwrite MMTk core in openjdk binding
-  #       run: cp -r mmtk-core mmtk-openjdk/repos/
-  #     - name: Setup Rust Toolchain
-  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-  #     # cleanup previosu build
-  #     - name: Cleanup previous build
-  #       run: |
-  #         rm -rf mmtk-openjdk/repos/openjdk/scratch
-  #         rm -rf mmtk-openjdk/repos/openjdk/build
-  #     - id: branch
-  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-  #       run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
-  #     - name: Setup
-  #       run: |
-  #         ./ci-perf-kit/scripts/history-run-setup.sh
-  #         mkdir -p ci-perf-kit/running/benchmarks/dacapo
-  #         cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
-  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
-  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
-  #     # run
-  #     - name: Performance Run
-  #       run: |
-  #         export RESULT_REPO=mmtk/ci-perf-result
-  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-  #         export FROM_DATE=2020-08-03
-  #         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
-  #         ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
-  #     # deploy
-  #     - name: Deploy to Github Page
-  #       if: ${{ env.DEPLOY == 'true' }}
-  #       uses: peaceiris/actions-gh-pages@v3
-  #       with:
-  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         external_repository: mmtk/ci-perf-result
-  #         publish_dir: ./reports
-  #         publish_branch: gh-pages
-  #         keep_files: true
+  openjdk-mutator-perf:
+    runs-on: [self-hosted, Linux, freq-scaling-off]
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v2
+        with:
+          path: mmtk-core
+      - name: Checkout OpenJDK Binding
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/mmtk-openjdk
+          path: mmtk-openjdk
+      - name: Checkout OpenJDK
+        working-directory: mmtk-openjdk
+        run: |
+          ./.github/scripts/ci-checkout.sh
+      # checkout perf-kit
+      - name: Checkout Perf Kit
+        uses: actions/checkout@v2
+        with:
+          repository: mmtk/ci-perf-kit
+          ref: "branch-0.6.9"
+          path: ci-perf-kit
+          token: ${{ secrets.CI_ACCESS_TOKEN }}
+          submodules: true
+      # setup
+      - name: Overwrite MMTk core in openjdk binding
+        run: cp -r mmtk-core mmtk-openjdk/repos/
+      - name: Setup Rust Toolchain
+        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+      # cleanup previosu build
+      - name: Cleanup previous build
+        run: |
+          rm -rf mmtk-openjdk/repos/openjdk/scratch
+          rm -rf mmtk-openjdk/repos/openjdk/build
+      - id: branch
+        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+      - name: Setup
+        run: |
+          ./ci-perf-kit/scripts/history-run-setup.sh
+          mkdir -p ci-perf-kit/running/benchmarks/dacapo
+          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
+          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
+          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
+      # run
+      - name: Performance Run
+        run: |
+          export RESULT_REPO=mmtk/ci-perf-result
+          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+          export FROM_DATE=2020-08-03
+          export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+          ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
+      # deploy
+      - name: Deploy to Github Page
+        if: ${{ env.DEPLOY == 'true' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+          external_repository: mmtk/ci-perf-result
+          publish_dir: ./reports
+          publish_branch: gh-pages
+          keep_files: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -198,6 +198,7 @@ jobs:
           export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
           export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
           export FROM_DATE=2020-08-03
+          export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
           ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page


### PR DESCRIPTION
This PR updates to https://github.com/mmtk/ci-perf-kit/releases/tag/0.6.9. This allows us to run performance tests for each commit in `master`. The remaining broken tests are: 1. running performance tests per PR, and 2. running baseline performance for JikesRVM and OpenJDK weekly (low priority). They will be fixed separately.