### PR TITLE
implement a feature to allocate an extra word ahead of each individua…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,9 @@ is_mmtk_object = ["vo_bit"]
 # Enable object pinning, in particular, enable pinning/unpinning, and its metadata
 object_pinning = []
 
+# Enable allocate extra header of each individual object
+extra_header = []
+
 # The following two features are useful for using Immix for VMs that do not support moving GC.
 
 # Disable any object copying in Immix. This makes Immix a non-moving policy.

--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -285,9 +285,12 @@ impl Block {
         let mut cell = self.start();
         let mut last = unsafe { Address::zero() };
         while cell + cell_size <= self.start() + Block::BYTES {
+            #[cfg(not(feature = "extra_header"))]
             // The invariants we checked earlier ensures that we can use cell and object reference interchangably
             // We may not really have an object in this cell, but if we do, this object reference is correct.
             let potential_object = ObjectReference::from_raw_address(cell);
+            #[cfg(feature = "extra_header")]
+            let potential_object = ObjectReference::from_raw_address(cell + VM::EXTRA_HEADER_BYTES);
 
             if !VM::VMObjectModel::LOCAL_MARK_BIT_SPEC
                 .is_marked::<VM>(potential_object, Ordering::SeqCst)

--- a/src/util/alloc/malloc_allocator.rs
+++ b/src/util/alloc/malloc_allocator.rs
@@ -25,6 +25,12 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
         self.plan
     }
 
+    #[cfg(feature = "extra_header")]
+    fn alloc(&mut self, _size: usize, _align: usize, _offset: usize) -> Address {
+        unimplemented!()
+    }
+
+    #[cfg(not(feature = "extra_header"))]
     fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address {
         self.alloc_slow(size, align, offset)
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -71,4 +71,13 @@ where
     /// Note that MMTk does not attempt to do anything to align the cursor to this value, but
     /// it merely asserts with this constant.
     const ALLOC_END_ALIGNMENT: usize = 1;
+
+    #[cfg(feature = "extra_header")]
+    const EXTRA_HEADER_BYTES: usize =
+        if Self::MAX_ALIGNMENT > crate::util::constants::BYTES_IN_WORD {
+            Self::MAX_ALIGNMENT
+        } else {
+            crate::util::constants::BYTES_IN_WORD
+        }
+        .next_power_of_two();
 }


### PR DESCRIPTION
It does not support malloc marksweep 