### PR TITLE
Feature/packet size

### DIFF
--- a/src/plan/generational/gc_work.rs
+++ b/src/plan/generational/gc_work.rs
@@ -112,6 +112,10 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ProcessModBuf<E> {
             )
         }
     }
+
+    fn debug_get_size(&self) -> Option<usize> {
+        Some(self.modbuf.len())
+    }
 }
 
 /// The array-copy modbuf contains a list of array slices in mature space(s) that
@@ -146,5 +150,9 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ProcessRegionModBuf<E> {
             // Forward entries
             GCWork::do_work(&mut E::new(edges, false, mmtk), worker, mmtk)
         }
+    }
+
+    fn debug_get_size(&self) -> Option<usize> {
+        Some(self.modbuf.len())
     }
 }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -689,6 +689,10 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for E {
         }
         trace!("ProcessEdgesWork End");
     }
+
+    fn debug_get_size(&self) -> Option<usize> {
+        Some(self.edges.len())
+    }
 }
 
 /// A general process edges implementation using SFT. A plan can always implement their own process edges. However,
@@ -944,6 +948,10 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanObjects<E> {
         self.do_work_common(&self.buffer, worker, mmtk);
         trace!("ScanObjects End");
     }
+
+    fn debug_get_size(&self) -> Option<usize> {
+        Some(self.buffer.len())
+    }
 }
 
 use crate::mmtk::MMTK;
@@ -1072,5 +1080,9 @@ impl<E: ProcessEdgesWork, P: Plan<VM = E::VM> + PlanTraceObject<E::VM>> GCWork<E
         trace!("PlanScanObjects");
         self.do_work_common(&self.buffer, worker, mmtk);
         trace!("PlanScanObjects End");
+    }
+
+    fn debug_get_size(&self) -> Option<usize> {
+        Some(self.buffer.len())
     }
 }

--- a/src/scheduler/work.rs
+++ b/src/scheduler/work.rs
@@ -40,6 +40,18 @@ pub trait GCWork<VM: VMBinding>: 'static + Send {
     fn get_type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
     }
+
+    /// Get a human-readable size of the work packet if it makes sense.
+    ///
+    /// This method is useful for debug purposes, and is especially useful when visualising the
+    /// work packets during a GC.
+    ///
+    /// The semantics is unspecified.  For work packets that contains a list of work items, such as
+    /// object references or edges, the size should usually be the number of items.  If size does
+    /// not make sense for the work packet, this method may return `None`.
+    fn debug_get_size(&self) -> Option<usize> {
+        None
+    }
 }
 
 use super::gc_work::ProcessEdgesWork;

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -383,7 +383,9 @@ impl<VM: VMBinding> GCWorker<VM> {
             // probe! expands to an empty block on unsupported platforms
             #[allow(unused_variables)]
             let typename = work.get_type_name();
-            probe!(mmtk, work, typename.as_ptr(), typename.len());
+            #[allow(unused_variables)]
+            let size = work.debug_get_size().unwrap_or(0);
+            probe!(mmtk, work, typename.as_ptr(), typename.len(), size);
             work.do_work_with_stat(self, mmtk);
         }
     }


### PR DESCRIPTION
This PR adds a method in the `GCWork` trait to allow each work packet to report its size for debug purpose.

The primary intention is for using with the EBPF-based visualisation tool.  The work packet size will be reported at USDT trace points.  With proper scripting, this information can be captured and displayed in a graphical timeline such as Perfetto UI.  An example is given below:

![image](https://github.com/mmtk/mmtk-core/assets/370317/a4bef612-e9e4-44cb-8c41-b50fb9cdb679)

There is an alternative approach for getting the packet size via USDT: **Executing a dedicated USDT trace point during the execution of a work packet to report he size, and using scripts to match this trace point with the surrounding work packet.**  Comparing with this approach,

The advantages of this PR are:
-   Easy to use.  The work packet implementer simply overrides a method, and it will be properly displayed uniformly by existing tools.

The disadvantages of this PR are:
-   The size must be available in the content of the work packet.
    -   `ProcessEdgesWork` contains a `Vec<Edge>`. `ScanObjects` and `ProcessModBuf` contain a `Vec<ObjectReference>`.  It is straightforward to the the size of those packets.
    -   However, for other work packets, such as `WeakRefProcessing` and  `ScanStackRoot`, those work packets can only report their sizes in the middle or at the end of their executions.  Such work packets can only use the alternative method.
    -   Some work packets contain multiple sub-tasks.  For example, `ProcessEdgesWork` processes edges and then scans objects.  To accurately visualise the execution time of such work packets, we should add finer-grained trace points to show the execution time and work item sizes of each sub-task.
-   It can only report a numerical size, but not other properties.  Some work packets have other interesting properties that should be shown in the visualisation.  For example, `ScanObjects` has a field `root: bool` to show if this work packet contains roots.  If we use the size to represent the number of objects, we have to use an alternative method to show the `root` field.
