### PR TITLE
Add comma as an alternative options string separator

### DIFF
--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -196,7 +196,7 @@ macro_rules! options {
             /// This method returns false if the option string is invalid, or if it includes any invalid option.
             ///
             /// Arguments:
-            /// * `options`: a string that is key value pairs separated by white spaces, e.g. "threads=1 stress_factor=4096"
+            /// * `options`: a string that is key value pairs separated by white spaces or commas, e.g. "threads=1 stress_factor=4096"
             pub fn set_bulk_from_command_line(&mut self, options: &str) -> bool {
                 for opt in options.replace(",", " ").split_ascii_whitespace() {
                     let kv_pair: Vec<&str> = opt.split('=').collect();

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -198,7 +198,7 @@ macro_rules! options {
             /// Arguments:
             /// * `options`: a string that is key value pairs separated by white spaces, e.g. "threads=1 stress_factor=4096"
             pub fn set_bulk_from_command_line(&mut self, options: &str) -> bool {
-                for opt in options.split_ascii_whitespace() {
+                for opt in options.replace(",", " ").split_ascii_whitespace() {
                     let kv_pair: Vec<&str> = opt.split('=').collect();
                     if kv_pair.len() != 2 {
                         return false;

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -196,7 +196,8 @@ macro_rules! options {
             /// This method returns false if the option string is invalid, or if it includes any invalid option.
             ///
             /// Arguments:
-            /// * `options`: a string that is key value pairs separated by white spaces or commas, e.g. "threads=1 stress_factor=4096"
+            /// * `options`: a string that is key value pairs separated by white spaces or commas, e.g. `threads=1 stress_factor=4096`,
+            /// or `threads=1,stress_factor=4096`
             pub fn set_bulk_from_command_line(&mut self, options: &str) -> bool {
                 for opt in options.replace(",", " ").split_ascii_whitespace() {
                     let kv_pair: Vec<&str> = opt.split('=').collect();


### PR DESCRIPTION
Add comma as an alternative options string separator, in addition to whitespace.

This is useful for multi-level nested bash scripts. Google has some of these for building GoogleJDK or running benchmarks. Using comma separators can simplify the script a lot,  and can keep options as a single argument without dealing with any string or whitespace escaping.