### PR TITLE
Fix broken links in README and cargo doc warnings

### DIFF
--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -4,7 +4,7 @@
 # If the output path is changed in this script, we need to update rustdoc.yml as well.
 
 # deny warnings for rustdoc
-export RUSTFLAGS="-D warnings"
+export RUSTDOCFLAGS="-D warnings"
 
 # Check cargo doc
 # We document public and private items for MMTk developers (GC implementers).
@@ -22,6 +22,6 @@ if ! cat $project_root/src/plan/mod.rs | grep -q "pub mod mygc;"; then
 fi
 cargo build
 
-# Install mdbook using the stable toolchain (mdbook uses scoped-tls which requires rust 1.59.0)
+# Install mdbook using the stable toolchain
 cargo +stable install mdbook
 mdbook build $project_root/docs/userguide

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ example of how to make a PGO build.
 MMTk does not run standalone. You would need to integrate MMTk with a language implementation.
 You can either try out one of the VM bindings we have been working on, or implement your own binding in your VM for MMTk.
 You can also implement your own GC algorithm in MMTk, and run it with supported VMs.
-You can find up-to-date full API documentation for mmtk-core [here](https://docs.mmtk.io/api).
+You can find up-to-date full API documentation for mmtk-core [here](https://docs.mmtk.io/api/mmtk).
 
 ### Try out our current bindings
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ MMTk provides a bi-directional interface with the language VM.
 To integrate MMTk with your language implementation, you need to provide an implementation of `VMBinding`, and
 you can optionally call MMTk's API for your needs.
 
-For more information, you can refer to our [porting guide](https://docs.mmtk.io/userguide/prefix.html) for VM implementors.
+For more information, you can refer to our [porting guide](https://docs.mmtk.io/portingguide/prefix.html) for VM implementors.
 
 ### Implement your GC
 

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -67,3 +67,4 @@ pub use nogc::NOGC_CONSTRAINTS;
 pub use pageprotect::PP_CONSTRAINTS;
 pub use semispace::SS_CONSTRAINTS;
 pub use sticky::immix::STICKY_IMMIX_CONSTRAINTS;
+pub mod mygc;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -67,4 +67,3 @@ pub use nogc::NOGC_CONSTRAINTS;
 pub use pageprotect::PP_CONSTRAINTS;
 pub use semispace::SS_CONSTRAINTS;
 pub use sticky::immix::STICKY_IMMIX_CONSTRAINTS;
-pub mod mygc;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -7,9 +7,10 @@
 /// descendants) may have the same policy (eg there could be numerous
 /// instances of CopySpace, each with different roles). Spaces are
 /// defined in terms of a unique region of virtual memory, so no two
-/// space instances ever share any virtual memory.<p>
+/// space instances ever share any virtual memory.
+/// 
 /// In addition to tracking virtual memory use and the mapping to
-/// policy, spaces also manage memory consumption (<i>used</i> virtual
+/// policy, spaces also manage memory consumption (*used* virtual
 /// memory).
 pub mod space;
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -8,7 +8,7 @@
 /// instances of CopySpace, each with different roles). Spaces are
 /// defined in terms of a unique region of virtual memory, so no two
 /// space instances ever share any virtual memory.
-/// 
+///
 /// In addition to tracking virtual memory use and the mapping to
 /// policy, spaces also manage memory consumption (*used* virtual
 /// memory).

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -149,7 +149,7 @@ impl Address {
     /// creates a null Address (0)
     /// # Safety
     /// It is unsafe and the user needs to be aware that they are creating an invalid address.
-    /// The zero address should only be used as unininitialized or sentinel values in performance critical code (where you dont want to use Option<Address>).
+    /// The zero address should only be used as unininitialized or sentinel values in performance critical code (where you dont want to use `Option<Address>`).
     pub const unsafe fn zero() -> Address {
         Address(0)
     }
@@ -157,7 +157,7 @@ impl Address {
     /// creates an Address of (usize::MAX)
     /// # Safety
     /// It is unsafe and the user needs to be aware that they are creating an invalid address.
-    /// The max address should only be used as unininitialized or sentinel values in performance critical code (where you dont want to use Option<Address>).
+    /// The max address should only be used as unininitialized or sentinel values in performance critical code (where you dont want to use `Option<Address>`).
     pub unsafe fn max() -> Address {
         use std::usize;
         Address(usize::MAX)

--- a/src/util/erase_vm.rs
+++ b/src/util/erase_vm.rs
@@ -3,7 +3,7 @@
 //! However, in some cases, using generic types is not allowed. For example, in an object-safe trait,
 //! the methods cannot be generic, thus the method's parameters cannot be generic types.
 //!
-//! This module defines macros that can be used to create a special ref type that erases the <VM> type parameter.
+//! This module defines macros that can be used to create a special ref type that erases the `<VM>` type parameter.
 //! For example, we create a type `TErasedRef` for `&T<VM>`. `TErasedRef` has no type parameter, and
 //! can be used in places where a type parameter is undesired. The type `TErasedRef` can be cast back to `&T<VM>`
 //! when we supply a type parameter `<VM>`. This works under the assumption that

--- a/src/util/heap/layout/mmapper.rs
+++ b/src/util/heap/layout/mmapper.rs
@@ -38,11 +38,11 @@ pub trait Mmapper: Sync {
 
     /// Ensure that a range of pages is mmapped (or equivalent).  If the
     /// pages are not yet mapped, demand-zero map them. Note that mapping
-    /// occurs at chunk granularity, not page granularity.<p>
+    /// occurs at chunk granularity, not page granularity.
     ///
-    /// Argumetns:
-    /// `start`: The start of the range to be mapped.
-    /// `pages`: The size of the range to be mapped, in pages
+    /// Arguments:
+    /// * `start`: The start of the range to be mapped.
+    /// * `pages`: The size of the range to be mapped, in pages
     // NOTE: There is a monotonicity assumption so that only updates require lock
     // acquisition.
     // TODO: Fix the above to support unmapping.

--- a/src/util/heap/layout/vm_layout_constants.rs
+++ b/src/util/heap/layout/vm_layout_constants.rs
@@ -14,7 +14,7 @@ pub const LOG_ADDRESS_SPACE: usize = 47;
 pub const LOG_ADDRESS_SPACE: usize = 32;
 /**
  * log_2 of the coarsest unit of address space allocation.
- * 
+ *
  * In the 32-bit VM layout, this determines the granularity of
  * allocation in a discontigouous space.  In the 64-bit layout,
  * this determines the growth factor of the large contiguous spaces

--- a/src/util/heap/layout/vm_layout_constants.rs
+++ b/src/util/heap/layout/vm_layout_constants.rs
@@ -14,7 +14,7 @@ pub const LOG_ADDRESS_SPACE: usize = 47;
 pub const LOG_ADDRESS_SPACE: usize = 32;
 /**
  * log_2 of the coarsest unit of address space allocation.
- * <p>
+ * 
  * In the 32-bit VM layout, this determines the granularity of
  * allocation in a discontigouous space.  In the 64-bit layout,
  * this determines the growth factor of the large contiguous spaces

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -35,7 +35,7 @@ pub(crate) mod analysis;
 /// Logging edges to check duplicated edges in GC.
 #[cfg(feature = "extreme_assertions")]
 pub(crate) mod edge_logger;
-/// Non-generic refs to generic types of <VM>.
+/// Non-generic refs to generic types of `<VM>`.
 pub(crate) mod erase_vm;
 /// Finalization implementation.
 pub(crate) mod finalizable_processor;

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -394,8 +394,8 @@ impl NurserySize {
         }
     }
 
-    /// Returns a NurserySize or String containing error. Expects nursery size to be formatted as
-    /// "<NurseryKind>:<size in bytes>". For example, "Fixed:8192" creates a Fixed nursery of size
+    /// Returns a [`NurserySize`] or [`String`] containing error. Expects nursery size to be formatted as
+    /// `<NurseryKind>:<size in bytes>`. For example, `Fixed:8192` creates a [`NurseryKind::Fixed`] nursery of size
     /// 8192 bytes.
     pub fn parse(s: &str) -> Result<NurserySize, String> {
         let ns: Vec<&str> = s.split(':').collect();

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -202,7 +202,7 @@ pub trait Scanning<VM: VMBinding> {
     /// scan them while enumerating, but cannot scan stacks individually when given
     /// the references of threads.
     /// In that case, it can leave this method empty, and deal with stack
-    /// roots in [`Collection::scan_vm_specific_roots`]. However, in that case, MMTk
+    /// roots in [`Scanning::scan_vm_specific_roots`]. However, in that case, MMTk
     /// does not know those roots are stack roots, and cannot perform any possible
     /// optimization for the stack roots.
     ///


### PR DESCRIPTION
This PR fixes broken links in READ and cargo doc warnings. It also fixes our check for warnings in `ci-doc.sh` (`RUSTDOCFLAGS="-D warnings"`).