### PR TITLE
Run ready to merge check for PRs

### DIFF
--- a/.github/workflows/cargo-msrv.yml
+++ b/.github/workflows/cargo-msrv.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
+    branches:
+      - master
 
 concurrency:
   # Cancels pending runs when a PR gets updated.

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -19,11 +19,9 @@ jobs:
           # Ignore some actions (based on what merge_group triggers):
           # - this action
           # - pre code review checks for stable Rust (we allow them to fail)
-          ignoreActions: "ready-to-merge,check-public-api-changes,pre-code-review-checks/x86_64-unknown-linux-gnu/stable,pre-code-review-checks/i686-unknown-linux-gnu/stable,pre-code-review-checks/x86_64-apple-darwin/stable"
-          # This action uses API. We have a quota of 1000 per day.
-          # We normally run tests within 1 hours (excluding binding tests).
-          # If we check every 10 mins, we use roughly 6 API calls per trigger.
-          # We can handle ~160 triggers.
+          # - binding tests (it may take long to run)
+          ignoreActions: "ready-to-merge,check-public-api-changes,pre-code-review-checks/x86_64-unknown-linux-gnu/stable,pre-code-review-checks/i686-unknown-linux-gnu/stable,pre-code-review-checks/x86_64-apple-darwin/stable,v8-binding-test,openjdk-binding-test,jikesrvm-binding-test,julia-binding-test,ruby-binding-test"
+          # This action uses API. We have a quota of 1000 per hour.
           checkInterval: 600
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -1,5 +1,8 @@
 name: Merge Check
 on:
+  pull_request:
+    branches:
+      - master
   merge_group:
     branches:
       - master
@@ -16,7 +19,7 @@ jobs:
           # Ignore some actions (based on what merge_group triggers):
           # - this action
           # - pre code review checks for stable Rust (we allow them to fail)
-          ignoreActions: "ready-to-merge,pre-code-review-checks/x86_64-unknown-linux-gnu/stable,pre-code-review-checks/i686-unknown-linux-gnu/stable,pre-code-review-checks/x86_64-apple-darwin/stable"
+          ignoreActions: "ready-to-merge,check-public-api-changes,pre-code-review-checks/x86_64-unknown-linux-gnu/stable,pre-code-review-checks/i686-unknown-linux-gnu/stable,pre-code-review-checks/x86_64-apple-darwin/stable"
           # This action uses API. We have a quota of 1000 per day.
           # We normally run tests within 1 hours (excluding binding tests).
           # If we check every 10 mins, we use roughly 6 API calls per trigger.


### PR DESCRIPTION
This PR does two changes:
* Run msrv check for merge group. We want this test to pass in order to merge a PR.
* Run ready-to-merge check for pull requests. As we want to set `ready-to-merge` as the required check for merging, we have to run this check for a PR.