### PR TITLE
Refactor derive macros and add HasSpaces trait

### DIFF
--- a/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
@@ -23,7 +23,7 @@ impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext2<VM> {
     type PlanType = MyGC<VM>;
     type ProcessEdgesWorkType = PlanProcessEdges<Self::VM, MyGC<VM>, DEFAULT_TRACE>;
 }
-// ANCHOR: workcontext_plan
+// ANCHOR_END: workcontext_plan
 
 use crate::util::ObjectReference;
 use crate::util::copy::CopySemantics;

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -24,11 +24,11 @@ use std::sync::atomic::{AtomicBool, Ordering}; // Add
 // Remove #[allow(unused_imports)].
 // Remove handle_user_collection_request().
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
 // Modify
 // ANCHOR: plan_def
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct MyGC<VM: VMBinding> {
     pub hi: AtomicBool,
     #[space]

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -31,11 +31,13 @@ use mmtk_macros::PlanTraceObject;
 #[derive(PlanTraceObject)]
 pub struct MyGC<VM: VMBinding> {
     pub hi: AtomicBool,
-    #[trace(CopySemantics::DefaultCopy)]
+    #[space]
+#[copy_semantics(CopySemantics::DefaultCopy)]
     pub copyspace0: CopySpace<VM>,
-    #[trace(CopySemantics::DefaultCopy)]
+    #[space]
+#[copy_semantics(CopySemantics::DefaultCopy)]
     pub copyspace1: CopySpace<VM>,
-    #[fallback_trace]
+    #[parent]
     pub common: CommonPlan<VM>,
 }
 // ANCHOR_END: plan_def

--- a/docs/userguide/src/tutorial/mygc/ss/alloc.md
+++ b/docs/userguide/src/tutorial/mygc/ss/alloc.md
@@ -72,7 +72,7 @@ you can implement object tracing, in this tutorial we use the macros, as it is t
 Make sure you import the macros. We will discuss on what those attributes mean in later sections.
 
 ```rust
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 ```
 
 ### Implement the Plan trait for MyGC

--- a/docs/userguide/src/tutorial/mygc/ss/alloc.md
+++ b/docs/userguide/src/tutorial/mygc/ss/alloc.md
@@ -66,10 +66,13 @@ Finished code (step 2):
 {{#include ../../code/mygc_semispace/global.rs:plan_def}}
 ```
 
-Note that we have attributes on some fields. These attributes tell MMTk's macros on
-how to generate code to trace objects in this plan. Although there are other approaches that
-you can implement object tracing, in this tutorial we use the macros, as it is the simplest.
-Make sure you import the macros. We will discuss on what those attributes mean in later sections.
+Note that `MyGC` now also derives `PlanTraceObject` besides `HasSpaces`, and we
+have attributes on some fields. These attributes tell MMTk's macros how to
+generate code to visit each space of this plan as well as trace objects in this
+plan.  Although there are other approaches that you can implement object
+tracing, in this tutorial we use the macros, as it is the simplest.  Make sure
+you import the macros. We will discuss on what those attributes mean in later
+sections.
 
 ```rust
 use mmtk_macros::{HasSpaces, PlanTraceObject};

--- a/docs/userguide/src/tutorial/mygc/ss/collection.md
+++ b/docs/userguide/src/tutorial/mygc/ss/collection.md
@@ -182,9 +182,10 @@ it can use `PlanProcessEdges`.
 You can manually provide an implementation of `PlanTraceObject` for `MyGC`. But you can also use the derive macro MMTK provides,
 and the macro will generate an implementation of `PlanTraceObject`:
 * add `#[derive(PlanTraceObject)]` for `MyGC` (import the macro properly: `use mmtk_macros::PlanTraceObject`)
-* add `#[trace(CopySemantics::Default)]` to both copy space fields, `copyspace0` and `copyspace1`. This tells the macro to generate
+* add `#[space]
+#[copy_semantics(CopySemantics::Default)]` to both copy space fields, `copyspace0` and `copyspace1`. This tells the macro to generate
   trace code for both spaces, and for any copying in the spaces, use `CopySemantics::DefaultCopy` that we have configured early.
-* add `#[fallback_trace]` to `common`. This tells the macro that if an object is not found in any space with `#[trace]` in ths plan,
+* add `#[parent]` to `common`. This tells the macro that if an object is not found in any space with `#[space]` in ths plan,
   try find the space for the object in the 'parent' plan. In our case, we fall back to the `CommonPlan`, as the object may be
   in large object space or immortal space in the common plan. `CommonPlan` also implements `PlanTraceObject`, so it knows how to
   find a space for the object and trace it in the same way.

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.37"
-syn = { version = "1.0.91", features = ["extra-traits"] }
+syn = { version = "2.0.29", features = ["extra-traits"] }
 quote = "1.0.18"
 proc-macro-error = "1.0.4"

--- a/macros/src/has_spaces_impl.rs
+++ b/macros/src/has_spaces_impl.rs
@@ -22,7 +22,9 @@ pub fn derive(input: DeriveInput) -> TokenStream2 {
     let items = generate_impl_items(&spaces, &parent);
 
     let output = quote! {
-        impl #impl_generics crate::plan::HasSpaces #ty_generics for #ident #ty_generics #where_clause {
+        impl #impl_generics crate::plan::HasSpaces for #ident #ty_generics #where_clause {
+            type VM = VM;
+
             #items
         }
     };
@@ -58,10 +60,10 @@ pub(crate) fn generate_impl_items<'a>(
     let (parent_visitor, parent_visitor_mut) = if let Some(f) = parent_field {
         let f_ident = f.ident.as_ref().unwrap();
         let visitor = quote! {
-            self.#f_ident.for_each_space(&mut __func)
+            self.#f_ident.for_each_space(__func)
         };
         let visitor_mut = quote! {
-            self.#f_ident.for_each_space_mut(&mut __func)
+            self.#f_ident.for_each_space_mut(__func)
         };
         (visitor, visitor_mut)
     } else {
@@ -69,12 +71,12 @@ pub(crate) fn generate_impl_items<'a>(
     };
 
     quote! {
-        fn for_each_space(&self, mut __func: impl FnMut(&dyn Space<VM>)) {
+        fn for_each_space(&self, __func: &mut dyn FnMut(&dyn Space<VM>)) {
             #(#space_visitors)*
             #parent_visitor
         }
 
-        fn for_each_space_mut(&mut self, mut __func: impl FnMut(&mut dyn Space<VM>)) {
+        fn for_each_space_mut(&mut self, __func: &mut dyn FnMut(&mut dyn Space<VM>)) {
             #(#space_visitors_mut)*
             #parent_visitor_mut
         }

--- a/macros/src/has_spaces_impl.rs
+++ b/macros/src/has_spaces_impl.rs
@@ -5,7 +5,7 @@ use syn::{DeriveInput, Field};
 
 use crate::util;
 
-pub fn derive(input: DeriveInput) -> TokenStream2 {
+pub(crate) fn derive(input: DeriveInput) -> TokenStream2 {
     let ident = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 

--- a/macros/src/has_spaces_impl.rs
+++ b/macros/src/has_spaces_impl.rs
@@ -1,0 +1,82 @@
+use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
+use quote::quote;
+use syn::{DeriveInput, Field};
+
+use crate::util;
+
+pub fn derive(input: DeriveInput) -> TokenStream2 {
+    let ident = input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let syn::Data::Struct(syn::DataStruct {
+        fields: syn::Fields::Named(ref fields),
+        ..
+    }) = input.data else {
+        abort_call_site!("`#[derive(HasSpaces)]` only supports structs with named fields.");
+    };
+
+    let spaces = util::get_fields_with_attribute(fields, "space");
+    let parent = util::get_unique_field_with_attribute(fields, "parent");
+
+    let items = generate_impl_items(&spaces, &parent);
+
+    let output = quote! {
+        impl #impl_generics crate::plan::HasSpaces #ty_generics for #ident #ty_generics #where_clause {
+            #items
+        }
+    };
+
+    output.into()
+}
+
+pub(crate) fn generate_impl_items<'a>(
+    space_fields: &[&'a Field],
+    parent_field: &Option<&'a Field>,
+) -> TokenStream2 {
+    // Currently we implement callback-style visitor methods.
+    // Iterators should be more powerful, but is more difficult to implement.
+
+    let mut space_visitors = vec![];
+    let mut space_visitors_mut = vec![];
+
+    for f in space_fields {
+        let f_ident = f.ident.as_ref().unwrap();
+
+        let visitor = quote! {
+            __func(&self.#f_ident);
+        };
+
+        let visitor_mut = quote! {
+            __func(&mut self.#f_ident);
+        };
+
+        space_visitors.push(visitor);
+        space_visitors_mut.push(visitor_mut);
+    }
+
+    let (parent_visitor, parent_visitor_mut) = if let Some(f) = parent_field {
+        let f_ident = f.ident.as_ref().unwrap();
+        let visitor = quote! {
+            self.#f_ident.for_each_space(&mut __func)
+        };
+        let visitor_mut = quote! {
+            self.#f_ident.for_each_space_mut(&mut __func)
+        };
+        (visitor, visitor_mut)
+    } else {
+        (quote! {}, quote! {})
+    };
+
+    quote! {
+        fn for_each_space(&self, mut __func: impl FnMut(&dyn Space<VM>)) {
+            #(#space_visitors)*
+            #parent_visitor
+        }
+
+        fn for_each_space_mut(&mut self, mut __func: impl FnMut(&mut dyn Space<VM>)) {
+            #(#space_visitors_mut)*
+            #parent_visitor_mut
+        }
+    }
+}

--- a/macros/src/has_spaces_impl.rs
+++ b/macros/src/has_spaces_impl.rs
@@ -21,15 +21,13 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream2 {
 
     let items = generate_impl_items(&spaces, &parent);
 
-    let output = quote! {
+    quote! {
         impl #impl_generics crate::plan::HasSpaces for #ident #ty_generics #where_clause {
             type VM = VM;
 
             #items
         }
-    };
-
-    output.into()
+    }
 }
 
 pub(crate) fn generate_impl_items<'a>(

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,10 +10,20 @@ use quote::quote;
 use syn::parse_macro_input;
 use syn::DeriveInput;
 
+mod has_spaces_impl;
 mod plan_trace_object_impl;
 mod util;
 
 const DEBUG_MACRO_OUTPUT: bool = false;
+
+#[proc_macro_error]
+#[proc_macro_derive(HasSpaces, attributes(space, parent))]
+pub fn derive_has_spaces(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let output = has_spaces_impl::derive(input);
+
+    output.into()
+}
 
 /// Generally a plan needs to add these attributes in order for the macro to work. The macro will
 /// generate an implementation of `PlanTraceObject` for the plan. With `PlanTraceObject`, the plan use

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,9 +4,7 @@ extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
-use proc_macro_error::abort_call_site;
 use proc_macro_error::proc_macro_error;
-use quote::quote;
 use syn::parse_macro_input;
 use syn::DeriveInput;
 
@@ -16,6 +14,18 @@ mod util;
 
 const DEBUG_MACRO_OUTPUT: bool = false;
 
+/// This macro will generate an implementation of `HasSpaces` for a plan or any structs that
+/// contain spaces, including `Gen`, `CommonPlan` and `BasePlan`.
+///
+/// The `HasSpaces` trait is responsible for enumerating spaces in a struct.  When using this
+/// derive macro, the user should do the following.
+///
+/// * Make sure the struct has a generic type parameter named `VM` which requires `VMBinding`.
+///   For example, `struct MyPlan<VM: VMBinding>` will work.
+/// * Add `#[space]` for each space field in the struct.
+/// * Add `#[parent]` to the field that contain more space fields.  This attribute is usually
+///   added to `Gen`, `CommonPlan` or `BasePlan` fields.  There can be at most one parent in
+///   a struct.
 #[proc_macro_error]
 #[proc_macro_derive(HasSpaces, attributes(space, parent))]
 pub fn derive_has_spaces(input: TokenStream) -> TokenStream {
@@ -25,52 +35,29 @@ pub fn derive_has_spaces(input: TokenStream) -> TokenStream {
     output.into()
 }
 
-/// Generally a plan needs to add these attributes in order for the macro to work. The macro will
-/// generate an implementation of `PlanTraceObject` for the plan. With `PlanTraceObject`, the plan use
-/// `PlanProcessEdges` for GC tracing. The attributes only affects code generation in the macro, thus
-/// only affects the generated `PlanTraceObject` implementation.
-/// * add `#[derive(PlanTraceObject)]` to the plan struct.
-/// * add `#[trace]` to each space field the plan struct has. If the policy is a copying policy,
-///   it needs to further specify the copy semantic (`#[trace(CopySemantics::X)]`)
-/// * add `#[fallback_trace]` to the parent plan if the plan is composed with other plans (or parent plans).
-///   For example, `GenImmix` is composed with `Gen`, `Gen` is composed with `CommonPlan`, `CommonPlan` is composed
-///   with `BasePlan`.
-/// * add `#[post_scan]` to any space field that has some policy-specific post_scan_object(). For objects in those spaces,
-///   `post_scan_object()` in the policy will be called after `VM::VMScanning::scan_object()`.
+/// The macro will generate an implementation of `PlanTraceObject` for the plan. With
+/// `PlanTraceObject`, the plan will be able to use `PlanProcessEdges` for GC tracing.
+///
+/// The user should add `#[space]` and `#[parent]` attributes to fields as specified by the
+/// `HasSpaces` trait.  When using this derive macro, all spaces must implement the
+/// `PolicyTraceObject` trait.  The generated `trace_object` method will check for spaces in the
+/// current plan and, if the object is not in any of them, check for plans in the parent struct.
+/// The parent struct must also implement the `PlanTraceObject` trait.
+///
+/// In addition, the user can add the following attributes to fields in order to control the
+/// behavior of the generated `trace_object` method.
+///
+/// * Add `#[copy_semantics(CopySemantics::X)]` to a space field to specify that when tracing
+///   objects in that space, `Some(CopySemantics::X)` will be passed to the `Space::trace_object`
+///   method as the `copy` argument.
+/// * Add `#[post_scan]` to any space field that has some policy-specific `post_scan_object()`. For
+///   objects in those spaces, `post_scan_object()` in the policy will be called after
+///   `VM::VMScanning::scan_object()`.
 #[proc_macro_error]
 #[proc_macro_derive(PlanTraceObject, attributes(space, parent, copy_semantics, post_scan))]
 pub fn derive_plan_trace_object(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let ident = input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-
-    let syn::Data::Struct(syn::DataStruct {
-        fields: syn::Fields::Named(ref fields),
-        ..
-    }) = input.data else {
-        abort_call_site!("`#[derive(PlanTraceObject)]` only supports structs with named fields.");
-    };
-
-    let spaces = util::get_fields_with_attribute(fields, "space");
-    let post_scan_spaces = util::get_fields_with_attribute(fields, "post_scan");
-    let parent = util::get_unique_field_with_attribute(fields, "parent");
-
-    let trace_object_function =
-        plan_trace_object_impl::generate_trace_object(&spaces, &parent, &ty_generics);
-    let post_scan_object_function =
-        plan_trace_object_impl::generate_post_scan_object(&post_scan_spaces, &parent, &ty_generics);
-    let may_move_objects_function =
-        plan_trace_object_impl::generate_may_move_objects(&spaces, &parent, &ty_generics);
-
-    let output = quote! {
-        impl #impl_generics crate::plan::PlanTraceObject #ty_generics for #ident #ty_generics #where_clause {
-            #trace_object_function
-
-            #post_scan_object_function
-
-            #may_move_objects_function
-        }
-    };
+    let output = plan_trace_object_impl::derive(input);
 
     // Debug the output - use the following code to debug the generated code (when cargo exapand is not working)
     if DEBUG_MACRO_OUTPUT {

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -5,11 +5,11 @@ pub fn get_field_attribute<'f>(field: &'f Field, attr_name: &str) -> Option<&'f 
     let attrs = field
         .attrs
         .iter()
-        .filter(|a| a.path.is_ident(attr_name))
+        .filter(|a| a.path().is_ident(attr_name))
         .collect::<Vec<_>>();
     if attrs.len() > 1 {
         let second_attr = attrs.get(1).unwrap();
-        abort! { second_attr.path.span(), "Duplicated attribute: #[{}]", attr_name }
+        abort! { second_attr.path().span(), "Duplicated attribute: #[{}]", attr_name }
     };
 
     attrs.get(0).cloned()
@@ -35,7 +35,7 @@ pub fn get_unique_field_with_attribute<'f>(
                 result = Some(field);
                 continue;
             } else {
-                let span = attr.path.span();
+                let span = attr.path().span();
                 abort! { span, "At most one field in a struct can have the #[{}] attribute.", attr_name };
             }
         }

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -92,7 +92,10 @@ pub fn mmtk_init<VM: VMBinding>(builder: &MMTKBuilder) -> Box<MMTK<VM>> {
 /// Currently we do not allow removing regions from VM space.
 #[cfg(feature = "vm_space")]
 pub fn set_vm_space<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, start: Address, size: usize) {
-    unsafe { mmtk.get_plan_mut() }.base_mut().vm_space.set_vm_region(start, size);
+    unsafe { mmtk.get_plan_mut() }
+        .base_mut()
+        .vm_space
+        .set_vm_region(start, size);
 }
 
 /// Request MMTk to create a mutator for the given thread. The ownership

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -27,9 +27,9 @@ use crate::ObjectQueue;
 use enum_map::EnumMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct GenCopy<VM: VMBinding> {
     #[parent]
     pub gen: CommonGenPlan<VM>,

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -45,8 +45,6 @@ pub struct GenCopy<VM: VMBinding> {
 pub const GENCOPY_CONSTRAINTS: PlanConstraints = crate::plan::generational::GEN_CONSTRAINTS;
 
 impl<VM: VMBinding> Plan for GenCopy<VM> {
-    type VM = VM;
-
     fn constraints(&self) -> &'static PlanConstraints {
         &GENCOPY_CONSTRAINTS
     }

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -72,13 +72,6 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         self.gen.collection_required(self, space_full, space)
     }
 
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.gen.get_spaces();
-        ret.push(&self.copyspace0);
-        ret.push(&self.copyspace1);
-        ret
-    }
-
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
         let is_full_heap = self.requires_full_heap_collection();
         self.base().set_collection_kind::<Self>(self);

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -31,12 +31,14 @@ use mmtk_macros::PlanTraceObject;
 
 #[derive(PlanTraceObject)]
 pub struct GenCopy<VM: VMBinding> {
-    #[fallback_trace]
+    #[parent]
     pub gen: CommonGenPlan<VM>,
     pub hi: AtomicBool,
-    #[trace(CopySemantics::Mature)]
+    #[space]
+    #[copy_semantics(CopySemantics::Mature)]
     pub copyspace0: CopySpace<VM>,
-    #[trace(CopySemantics::Mature)]
+    #[space]
+    #[copy_semantics(CopySemantics::Mature)]
     pub copyspace1: CopySpace<VM>,
 }
 

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -18,7 +18,6 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::VMRequest;
-use crate::util::metadata::side_metadata::SideMetadataSanity;
 use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
@@ -220,17 +219,7 @@ impl<VM: VMBinding> GenCopy<VM> {
             copyspace1,
         };
 
-        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
-        // side metadata in extreme_assertions.
-        {
-            let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-            res.gen
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-            res.copyspace0
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-            res.copyspace1
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        }
+        res.verify_side_metadata_sanity();
 
         res
     }

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -17,11 +17,11 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
 /// Common implementation for generational plans. Each generational plan
 /// should include this type, and forward calls to it where possible.
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct CommonGenPlan<VM: VMBinding> {
     /// The nursery space.
     #[space]

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -7,7 +7,6 @@ use crate::policy::space::Space;
 use crate::scheduler::*;
 use crate::util::copy::CopySemantics;
 use crate::util::heap::VMRequest;
-use crate::util::metadata::side_metadata::SideMetadataSanity;
 use crate::util::statistics::counter::EventCounter;
 use crate::util::Address;
 use crate::util::ObjectReference;
@@ -58,12 +57,6 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
             next_gc_full_heap: AtomicBool::new(false),
             full_heap_gc_count,
         }
-    }
-
-    /// Verify side metadata specs used in the spaces in Gen.
-    pub fn verify_side_metadata_sanity(&self, sanity: &mut SideMetadataSanity) {
-        self.common.verify_side_metadata_sanity(sanity);
-        self.nursery.verify_side_metadata_sanity(sanity);
     }
 
     /// Prepare Gen. This should be called by a single thread in GC prepare work.

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -66,13 +66,6 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
         self.nursery.verify_side_metadata_sanity(sanity);
     }
 
-    /// Get spaces in generation plans
-    pub fn get_spaces(&self) -> Vec<&dyn Space<VM>> {
-        let mut ret = self.common.get_spaces();
-        ret.push(&self.nursery);
-        ret
-    }
-
     /// Prepare Gen. This should be called by a single thread in GC prepare work.
     pub fn prepare(&mut self, tls: VMWorkerThread) {
         let full_heap = !self.is_current_gc_nursery();

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -24,10 +24,11 @@ use mmtk_macros::PlanTraceObject;
 #[derive(PlanTraceObject)]
 pub struct CommonGenPlan<VM: VMBinding> {
     /// The nursery space.
-    #[trace(CopySemantics::PromoteToMature)]
+    #[space]
+    #[copy_semantics(CopySemantics::PromoteToMature)]
     pub nursery: CopySpace<VM>,
     /// The common plan.
-    #[fallback_trace]
+    #[parent]
     pub common: CommonPlan<VM>,
     /// Is this GC full heap?
     pub gc_full_heap: AtomicBool,

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -66,8 +66,6 @@ pub const GENIMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for GenImmix<VM> {
-    type VM = VM;
-
     fn constraints(&self) -> &'static PlanConstraints {
         &GENIMMIX_CONSTRAINTS
     }

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -252,18 +252,7 @@ impl<VM: VMBinding> GenImmix<VM> {
             last_gc_was_full_heap: AtomicBool::new(false),
         };
 
-        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
-        // side metadata in extreme_assertions.
-        {
-            use crate::util::metadata::side_metadata::SideMetadataSanity;
-            let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-            genimmix
-                .gen
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-            genimmix
-                .immix_space
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        }
+        genimmix.verify_side_metadata_sanity();
 
         genimmix
     }

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -38,11 +38,12 @@ use mmtk_macros::PlanTraceObject;
 #[derive(PlanTraceObject)]
 pub struct GenImmix<VM: VMBinding> {
     /// Generational plan, which includes a nursery space and operations related with nursery.
-    #[fallback_trace]
+    #[parent]
     pub gen: CommonGenPlan<VM>,
     /// An immix space as the mature space.
     #[post_scan]
-    #[trace(CopySemantics::Mature)]
+    #[space]
+    #[copy_semantics(CopySemantics::Mature)]
     pub immix_space: ImmixSpace<VM>,
     /// Whether the last GC was a defrag GC for the immix space.
     pub last_gc_was_defrag: AtomicBool,

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -29,13 +29,13 @@ use enum_map::EnumMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
 /// Generational immix. This implements the functionality of a two-generation copying
 /// collector where the higher generation is an immix space.
 /// See the PLDI'08 paper by Blackburn and McKinley for a description
 /// of the algorithm: <http://doi.acm.org/10.1145/1375581.1375586>.
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct GenImmix<VM: VMBinding> {
     /// Generational plan, which includes a nursery space and operations related with nursery.
     #[parent]

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -97,12 +97,6 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         self.gen.collection_required(self, space_full, space)
     }
 
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.gen.get_spaces();
-        ret.push(&self.immix_space);
-        ret
-    }
-
     // GenImmixMatureProcessEdges<VM, { TraceKind::Defrag }> and GenImmixMatureProcessEdges<VM, { TraceKind::Fast }>
     // are different types. However, it seems clippy does not recognize the constant type parameter and thinks we have identical blocks
     // in different if branches.

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -190,9 +190,6 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
         &self.base().options
     }
 
-    /// get all the spaces in the plan
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>>;
-
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector>;
 
     #[cfg(feature = "sanity")]
@@ -562,19 +559,6 @@ impl<VM: VMBinding> BasePlan<VM> {
         }
     }
 
-    pub fn get_spaces(&self) -> Vec<&dyn Space<VM>> {
-        vec![
-            #[cfg(feature = "code_space")]
-            &self.code_space,
-            #[cfg(feature = "code_space")]
-            &self.code_lo_space,
-            #[cfg(feature = "ro_space")]
-            &self.ro_space,
-            #[cfg(feature = "vm_space")]
-            &self.vm_space,
-        ]
-    }
-
     /// The application code has requested a collection.
     pub fn handle_user_collection_request(&self, tls: VMMutatorThread, force: bool) {
         if force || !*self.options.ignore_system_gc {
@@ -924,14 +908,6 @@ impl<VM: VMBinding> CommonPlan<VM> {
             )),
             base: BasePlan::new(args),
         }
-    }
-
-    pub fn get_spaces(&self) -> Vec<&dyn Space<VM>> {
-        let mut ret = self.base.get_spaces();
-        ret.push(&self.immortal);
-        ret.push(&self.los);
-        ret.push(&self.nonmoving);
-        ret
     }
 
     pub fn get_used_pages(&self) -> usize {

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -431,13 +431,13 @@ pub struct BasePlan<VM: VMBinding> {
 
     // Spaces in base plan
     #[cfg(feature = "code_space")]
-    #[trace]
+    #[space]
     pub code_space: ImmortalSpace<VM>,
     #[cfg(feature = "code_space")]
-    #[trace]
+    #[space]
     pub code_lo_space: ImmortalSpace<VM>,
     #[cfg(feature = "ro_space")]
-    #[trace]
+    #[space]
     pub ro_space: ImmortalSpace<VM>,
 
     /// A VM space is a space allocated and populated by the VM.  Currently it is used by JikesRVM
@@ -453,7 +453,7 @@ pub struct BasePlan<VM: VMBinding> {
     /// -   The `is_in_mmtk_spaces` currently returns `true` if the given object reference is in
     ///     the VM space.
     #[cfg(feature = "vm_space")]
-    #[trace]
+    #[space]
     pub vm_space: VMSpace<VM>,
 }
 
@@ -898,14 +898,14 @@ CommonPlan is for representing state and features used by _many_ plans, but that
 */
 #[derive(PlanTraceObject)]
 pub struct CommonPlan<VM: VMBinding> {
-    #[trace]
+    #[space]
     pub immortal: ImmortalSpace<VM>,
-    #[trace]
+    #[space]
     pub los: LargeObjectSpace<VM>,
     // TODO: We should use a marksweep space for nonmoving.
-    #[trace]
+    #[space]
     pub nonmoving: ImmortalSpace<VM>,
-    #[fallback_trace]
+    #[parent]
     pub base: BasePlan<VM>,
 }
 

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -366,6 +366,7 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
         true
     }
 
+    /// Call `space.verify_side_metadata_sanity` for all spaces in this plan.
     fn verify_side_metadata_sanity(&self) {
         let mut side_metadata_sanity_checker = SideMetadataSanity::new();
         self.for_each_space(&mut |space| {
@@ -965,30 +966,31 @@ use crate::vm::VMBinding;
 
 /// A trait for anything that contains spaces.
 /// Examples include concrete plans as well as `Gen`, `CommonPlan` and `BasePlan`.
+/// All plans must implement this trait.
 ///
-/// This trait provides methods for enumerating spaces in a struct, including nested struct such as
-/// `Gen`, `CommonPlan` and `BasePlan`.
+/// This trait provides methods for enumerating spaces in a struct, including spaces in nested
+/// struct.
 ///
-/// This trait can be implemented automatically using `#[derive(HasSpaces)]` defined in the
-/// `mmtk-macros` crate.
+/// This trait can be implemented automatically by adding the `#[derive(HasSpaces)]` attribute to a
+/// struct.  It uses the derive macro defined in the `mmtk-macros` crate.
 ///
 /// This trait visits spaces as `dyn`, so it should only be used when performance is not critical.
 /// For performance critical methods that visit spaces in a plan, such as `trace_object`, it is
 /// recommended to define a trait (such as `PlanTraceObject`) for concrete plans to implement, and
 /// implement (by hand or automatically) the method without `dyn`.
 pub trait HasSpaces {
-    // The type of the VM used by HasSpaces.  So named so that Plan<VM = VM> will not be ambiguous.
+    // The type of the VM.
     type VM: VMBinding;
 
     /// Visit each space field immutably.
     ///
-    /// If `Self` contains a parent field that contain more spaces, this method will visit spaces
+    /// If `Self` contains nested fields that contain more spaces, this method shall visit spaces
     /// in the outer struct first.
     fn for_each_space(&self, func: &mut dyn FnMut(&dyn Space<Self::VM>));
 
     /// Visit each space field mutably.
     ///
-    /// If `Self` contains a parent field that contain more spaces, this method will visit spaces
+    /// If `Self` contains nested fields that contain more spaces, this method shall visit spaces
     /// in the outer struct first.
     fn for_each_space_mut(&mut self, func: &mut dyn FnMut(&mut dyn Space<Self::VM>));
 }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -29,9 +29,10 @@ use mmtk_macros::PlanTraceObject;
 #[derive(PlanTraceObject)]
 pub struct Immix<VM: VMBinding> {
     #[post_scan]
-    #[trace(CopySemantics::DefaultCopy)]
+    #[space]
+    #[copy_semantics(CopySemantics::DefaultCopy)]
     pub immix_space: ImmixSpace<VM>,
-    #[fallback_trace]
+    #[parent]
     pub common: CommonPlan<VM>,
     last_gc_was_defrag: AtomicBool,
 }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -24,9 +24,9 @@ use std::sync::atomic::AtomicBool;
 use atomic::Ordering;
 use enum_map::EnumMap;
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct Immix<VM: VMBinding> {
     #[post_scan]
     #[space]

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -16,7 +16,6 @@ use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataContext;
-use crate::util::metadata::side_metadata::SideMetadataSanity;
 use crate::vm::VMBinding;
 use crate::{policy::immix::ImmixSpace, util::opaque_pointer::VMWorkerThread};
 use std::sync::atomic::AtomicBool;
@@ -149,15 +148,7 @@ impl<VM: VMBinding> Immix<VM> {
             last_gc_was_defrag: AtomicBool::new(false),
         };
 
-        {
-            let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-            immix
-                .common
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-            immix
-                .immix_space
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        }
+        immix.verify_side_metadata_sanity();
 
         immix
     }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -48,8 +48,6 @@ pub const IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for Immix<VM> {
-    type VM = VM;
-
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         self.base().collection_required(self, space_full)
     }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -72,12 +72,6 @@ impl<VM: VMBinding> Plan for Immix<VM> {
         }
     }
 
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.common.get_spaces();
-        ret.push(&self.immix_space);
-        ret
-    }
-
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
         self.base().set_collection_kind::<Self>(self);
         self.base().set_gc_status(GcStatus::GcPrepare);

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -25,9 +25,9 @@ use crate::vm::VMBinding;
 
 use enum_map::EnumMap;
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct MarkCompact<VM: VMBinding> {
     #[space]
     #[copy_semantics(CopySemantics::DefaultCopy)]

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -50,12 +50,6 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         &MARKCOMPACT_CONSTRAINTS
     }
 
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.common.get_spaces();
-        ret.push(&self.mc_space);
-        ret
-    }
-
     fn base(&self) -> &BasePlan<VM> {
         &self.common.base
     }

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -29,9 +29,10 @@ use mmtk_macros::PlanTraceObject;
 
 #[derive(PlanTraceObject)]
 pub struct MarkCompact<VM: VMBinding> {
-    #[trace(CopySemantics::DefaultCopy)]
+    #[space]
+    #[copy_semantics(CopySemantics::DefaultCopy)]
     pub mc_space: MarkCompactSpace<VM>,
-    #[fallback_trace]
+    #[parent]
     pub common: CommonPlan<VM>,
 }
 

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -17,7 +17,7 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::CopySemantics;
 use crate::util::heap::VMRequest;
-use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
+use crate::util::metadata::side_metadata::SideMetadataContext;
 #[cfg(not(feature = "vo_bit"))]
 use crate::util::metadata::vo_bit::VO_BIT_SIDE_METADATA_SPEC;
 use crate::util::opaque_pointer::*;
@@ -201,13 +201,7 @@ impl<VM: VMBinding> MarkCompact<VM> {
             common: CommonPlan::new(plan_args),
         };
 
-        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
-        // side metadata in extreme_assertions.
-        let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-        res.common
-            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        res.mc_space
-            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+        res.verify_side_metadata_sanity();
 
         res
     }

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -46,8 +46,6 @@ pub const MARKCOMPACT_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for MarkCompact<VM> {
-    type VM = VM;
-
     fn constraints(&self) -> &'static PlanConstraints {
         &MARKCOMPACT_CONSTRAINTS
     }

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -16,7 +16,7 @@ use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSani
 use crate::util::VMWorkerThread;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
 #[cfg(feature = "malloc_mark_sweep")]
 pub type MarkSweepSpace<VM> = crate::policy::marksweepspace::malloc_ms::MallocSpace<VM>;
@@ -28,7 +28,7 @@ pub type MarkSweepSpace<VM> = crate::policy::marksweepspace::native_ms::MarkSwee
 #[cfg(not(feature = "malloc_mark_sweep"))]
 use crate::policy::marksweepspace::native_ms::MAX_OBJECT_SIZE;
 
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct MarkSweep<VM: VMBinding> {
     #[parent]
     common: CommonPlan<VM>,

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -47,8 +47,6 @@ pub const MS_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for MarkSweep<VM> {
-    type VM = VM;
-
     fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
         let mut ret = self.common.get_spaces();
         ret.push(&self.ms);

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -12,7 +12,7 @@ use crate::policy::space::Space;
 use crate::scheduler::GCWorkScheduler;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::heap::VMRequest;
-use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
+use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::VMWorkerThread;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
@@ -112,11 +112,8 @@ impl<VM: VMBinding> MarkSweep<VM> {
             common: CommonPlan::new(plan_args),
         };
 
-        let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-        res.common
-            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        res.ms
-            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+        res.verify_side_metadata_sanity();
+
         res
     }
 

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -47,12 +47,6 @@ pub const MS_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for MarkSweep<VM> {
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.common.get_spaces();
-        ret.push(&self.ms);
-        ret
-    }
-
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
         self.base().set_collection_kind::<Self>(self);
         self.base().set_gc_status(GcStatus::GcPrepare);

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -30,9 +30,9 @@ use crate::policy::marksweepspace::native_ms::MAX_OBJECT_SIZE;
 
 #[derive(PlanTraceObject)]
 pub struct MarkSweep<VM: VMBinding> {
-    #[fallback_trace]
+    #[parent]
     common: CommonPlan<VM>,
-    #[trace]
+    #[space]
     ms: MarkSweepSpace<VM>,
 }
 

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use global::create_mutator;
 pub(crate) use global::create_plan;
 pub use global::AllocationSemantics;
 pub(crate) use global::GcStatus;
+pub(crate) use global::HasSpaces;
 pub use global::Plan;
 pub(crate) use global::PlanTraceObject;
 

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -15,16 +15,22 @@ use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSani
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
+use mmtk_macros::HasSpaces;
 
 #[cfg(not(feature = "nogc_lock_free"))]
 use crate::policy::immortalspace::ImmortalSpace as NoGCImmortalSpace;
 #[cfg(feature = "nogc_lock_free")]
 use crate::policy::lockfreeimmortalspace::LockFreeImmortalSpace as NoGCImmortalSpace;
 
+#[derive(HasSpaces)]
 pub struct NoGC<VM: VMBinding> {
+    #[parent]
     pub base: BasePlan<VM>,
+    #[space]
     pub nogc_space: NoGCImmortalSpace<VM>,
+    #[space]
     pub immortal: ImmortalSpace<VM>,
+    #[space]
     pub los: ImmortalSpace<VM>,
 }
 

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -11,7 +11,7 @@ use crate::scheduler::GCWorkScheduler;
 use crate::util::alloc::allocators::AllocatorSelector;
 #[allow(unused_imports)]
 use crate::util::heap::VMRequest;
-use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
+use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
 use enum_map::EnumMap;
@@ -113,13 +113,7 @@ impl<VM: VMBinding> NoGC<VM> {
             base: BasePlan::new(plan_args),
         };
 
-        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
-        // side metadata in extreme_assertions.
-        let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-        res.base()
-            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        res.nogc_space
-            .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
+        res.verify_side_metadata_sanity();
 
         res
     }

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -37,8 +37,6 @@ pub struct NoGC<VM: VMBinding> {
 pub const NOGC_CONSTRAINTS: PlanConstraints = PlanConstraints::default();
 
 impl<VM: VMBinding> Plan for NoGC<VM> {
-    type VM = VM;
-
     fn constraints(&self) -> &'static PlanConstraints {
         &NOGC_CONSTRAINTS
     }

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -41,14 +41,6 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &NOGC_CONSTRAINTS
     }
 
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.base.get_spaces();
-        ret.push(&self.nogc_space);
-        ret.push(&self.immortal);
-        ret.push(&self.los);
-        ret
-    }
-
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         self.base().collection_required(self, space_full)
     }

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -33,8 +33,6 @@ pub const CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for PageProtect<VM> {
-    type VM = VM;
-
     fn constraints(&self) -> &'static PlanConstraints {
         &CONSTRAINTS
     }

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -37,12 +37,6 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         &CONSTRAINTS
     }
 
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.common.get_spaces();
-        ret.push(&self.space);
-        ret
-    }
-
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
         self.base().set_collection_kind::<Self>(self);
         self.base().set_gc_status(GcStatus::GcPrepare);

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -22,7 +22,7 @@ use mmtk_macros::PlanTraceObject;
 
 #[derive(PlanTraceObject)]
 pub struct PageProtect<VM: VMBinding> {
-    #[trace]
+    #[space]
     pub space: LargeObjectSpace<VM>,
     pub common: CommonPlan<VM>,
 }

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -18,9 +18,9 @@ use crate::{
 };
 use enum_map::EnumMap;
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct PageProtect<VM: VMBinding> {
     #[space]
     pub space: LargeObjectSpace<VM>,

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -24,6 +24,7 @@ use mmtk_macros::{HasSpaces, PlanTraceObject};
 pub struct PageProtect<VM: VMBinding> {
     #[space]
     pub space: LargeObjectSpace<VM>,
+    #[parent]
     pub common: CommonPlan<VM>,
 }
 

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -106,16 +106,7 @@ impl<VM: VMBinding> PageProtect<VM> {
             common: CommonPlan::new(plan_args),
         };
 
-        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
-        // side metadata in extreme_assertions.
-        {
-            use crate::util::metadata::side_metadata::SideMetadataSanity;
-            let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-            ret.common
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-            ret.space
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        }
+        ret.verify_side_metadata_sanity();
 
         ret
     }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -18,11 +18,11 @@ use crate::util::opaque_pointer::VMWorkerThread;
 use crate::{plan::global::BasePlan, vm::VMBinding};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
 use enum_map::EnumMap;
 
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct SemiSpace<VM: VMBinding> {
     pub hi: AtomicBool,
     #[space]

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -13,7 +13,7 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::VMRequest;
-use crate::util::metadata::side_metadata::{SideMetadataContext, SideMetadataSanity};
+use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::opaque_pointer::VMWorkerThread;
 use crate::{plan::global::BasePlan, vm::VMBinding};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -152,17 +152,7 @@ impl<VM: VMBinding> SemiSpace<VM> {
             common: CommonPlan::new(plan_args),
         };
 
-        // Use SideMetadataSanity to check if each spec is valid. This is also needed for check
-        // side metadata in extreme_assertions.
-        {
-            let mut side_metadata_sanity_checker = SideMetadataSanity::new();
-            res.common
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-            res.copyspace0
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-            res.copyspace1
-                .verify_side_metadata_sanity(&mut side_metadata_sanity_checker);
-        }
+        res.verify_side_metadata_sanity();
 
         res
     }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -65,13 +65,6 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         }
     }
 
-    fn get_spaces(&self) -> Vec<&dyn Space<Self::VM>> {
-        let mut ret = self.common.get_spaces();
-        ret.push(&self.copyspace0);
-        ret.push(&self.copyspace1);
-        ret
-    }
-
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
         self.base().set_collection_kind::<Self>(self);
         self.base().set_gc_status(GcStatus::GcPrepare);

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -46,8 +46,6 @@ pub const SS_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for SemiSpace<VM> {
-    type VM = VM;
-
     fn constraints(&self) -> &'static PlanConstraints {
         &SS_CONSTRAINTS
     }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -25,11 +25,13 @@ use enum_map::EnumMap;
 #[derive(PlanTraceObject)]
 pub struct SemiSpace<VM: VMBinding> {
     pub hi: AtomicBool,
-    #[trace(CopySemantics::DefaultCopy)]
+    #[space]
+    #[copy_semantics(CopySemantics::DefaultCopy)]
     pub copyspace0: CopySpace<VM>,
-    #[trace(CopySemantics::DefaultCopy)]
+    #[space]
+    #[copy_semantics(CopySemantics::DefaultCopy)]
     pub copyspace1: CopySpace<VM>,
-    #[fallback_trace]
+    #[parent]
     pub common: CommonPlan<VM>,
 }
 

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -21,12 +21,12 @@ use atomic::Ordering;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
-use mmtk_macros::PlanTraceObject;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
 
 use super::gc_work::StickyImmixMatureGCWorkContext;
 use super::gc_work::StickyImmixNurseryGCWorkContext;
 
-#[derive(PlanTraceObject)]
+#[derive(HasSpaces, PlanTraceObject)]
 pub struct StickyImmix<VM: VMBinding> {
     #[parent]
     immix: immix::Immix<VM>,

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -102,10 +102,6 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
         }
     }
 
-    fn get_spaces(&self) -> Vec<&dyn crate::policy::space::Space<Self::VM>> {
-        self.immix.get_spaces()
-    }
-
     fn get_allocator_mapping(
         &self,
     ) -> &'static enum_map::EnumMap<crate::AllocationSemantics, crate::util::alloc::AllocatorSelector>

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -45,8 +45,6 @@ pub const STICKY_IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for StickyImmix<VM> {
-    type VM = VM;
-
     fn constraints(&self) -> &'static crate::plan::PlanConstraints {
         &STICKY_IMMIX_CONSTRAINTS
     }

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -28,7 +28,7 @@ use super::gc_work::StickyImmixNurseryGCWorkContext;
 
 #[derive(PlanTraceObject)]
 pub struct StickyImmix<VM: VMBinding> {
-    #[fallback_trace]
+    #[parent]
     immix: immix::Immix<VM>,
     gc_full_heap: AtomicBool,
     next_gc_full_heap: AtomicBool,

--- a/src/util/heap/layout/map64.rs
+++ b/src/util/heap/layout/map64.rs
@@ -56,7 +56,9 @@ impl Map64 {
                 // elide the storing of 0 for each of the element.  Using standard vector creation,
                 // such as `vec![SpaceDescriptor::UNINITIALIZED; MAX_CHUNKS]`, will cause severe
                 // slowdown during start-up.
-                descriptor_map: unsafe { new_zeroed_vec::<SpaceDescriptor>(vm_layout().max_chunks()) },
+                descriptor_map: unsafe {
+                    new_zeroed_vec::<SpaceDescriptor>(vm_layout().max_chunks())
+                },
                 high_water,
                 base_address,
                 fl_page_resources: vec![None; MAX_SPACES],

--- a/src/util/metadata/side_metadata/sanity.rs
+++ b/src/util/metadata/side_metadata/sanity.rs
@@ -433,7 +433,7 @@ pub fn verify_bzero(metadata_spec: &SideMetadataSpec, start: Address, size: usiz
             }
         }
         None => {
-            panic!("Invalid Metadata Spec!");
+            panic!("Invalid Metadata Spec: {}", metadata_spec.name);
         }
     }
 }


### PR DESCRIPTION
The main part of this PR is adding a `HasSpaces` trait that enumerates spaces in a plan.  This trait can be automatically generated using derive macro and attributes, saving the effort to enumerate spaces by hand.

-   This PR adds a `HasSpaces` trait that enumerates spaces of a plan.  Plans (including NoGC) are now required to implement this trait.
-   This PR implements derived macro for `HasSpaces`
-   The `#[trace]` and `#[fallback_trace]` attributes are replaced by the `#[space]` and `#[parent]` attributes for generality.  A dedicated `#[copy_semantics(xxxxx)]` attribute is added to specify copy semantics for `trace_object`.
-   The manually written `Plan::get_spaces()` method is removed in favor for the automatically generated `HasSpace::for_each_space` method.
-   Added a `Plan::verify_side_metadata_sanity` that calls `Space::verify_side_metadata_sanity` for all spaces in the plan.  This replaces the manual invocations of `Space::verify_side_metadata_sanity` in the constructors of plans.

This PR also slightly refactors the mmtk-macros crate.
-   The `syn` dependency is one major version behind the latest.  This PR bumps the version and refactors the code to adapt to this change.
-   `mmtk-core/macros/src/lib.rs` is cleaned up so that it only contains functions with minimum function bodies.  Those functions for derive macros are required to be in the root module of the crate.  Their function bodies are off-loaded to other modules.

This PR is a stepping stone for https://github.com/mmtk/mmtk-core/pull/925.  This PR makes it possible to enumerate spaces of a plan without resorting to unsafe global maps.