### PR TITLE
Add CARGO_INCREMENTAL=0 to work around clippy 1.72 bug

### DIFF
--- a/.github/scripts/ci-style.sh
+++ b/.github/scripts/ci-style.sh
@@ -1,6 +1,9 @@
 . $(dirname "$0")/ci-common.sh
 
 export RUSTFLAGS="-D warnings -A unknown-lints"
+# Workaround the clippy issue on Rust 1.72: https://github.com/mmtk/mmtk-core/issues/929.
+# If we are not testing with Rust 1.72, or there is no problem running the following clippy checks, we can remove this export.
+export CARGO_INCREMENTAL=0
 
 # --- Check main crate ---
 

--- a/.github/scripts/ci-style.sh
+++ b/.github/scripts/ci-style.sh
@@ -1,9 +1,13 @@
 . $(dirname "$0")/ci-common.sh
 
 export RUSTFLAGS="-D warnings -A unknown-lints"
+
 # Workaround the clippy issue on Rust 1.72: https://github.com/mmtk/mmtk-core/issues/929.
 # If we are not testing with Rust 1.72, or there is no problem running the following clippy checks, we can remove this export.
-export CARGO_INCREMENTAL=0
+CLIPPY_VERSION=$(cargo clippy --version)
+if [[ $CLIPPY_VERSION == "clippy 0.1.72"* ]]; then
+    export CARGO_INCREMENTAL=0
+fi
 
 # --- Check main crate ---
 

--- a/src/util/metadata/side_metadata/spec_defs.rs
+++ b/src/util/metadata/side_metadata/spec_defs.rs
@@ -100,6 +100,9 @@ define_side_metadata_specs!(
 
 #[cfg(test)]
 mod tests {
+    // We assert on constants to test if the macro is working properly.
+    #![allow(clippy::assertions_on_constants)]
+
     use super::*;
     #[test]
     fn first_global_spec() {


### PR DESCRIPTION
This PR works around the issue https://github.com/mmtk/mmtk-core/issues/929, using the suggestion in https://github.com/rust-lang/rust/issues/83085#issuecomment-1504033603.