### PR TITLE
Make MarkCompact LOS support 2nd transitive closure

### DIFF
--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -44,8 +44,7 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         VM::VMScanning::prepare_for_roots_re_scanning();
         mmtk.get_plan().base().prepare_for_stack_scanning();
         // Prepare common and base spaces for the 2nd round of transitive closure
-        let plan_mut =
-            unsafe { &mut *(self.plan as *const MarkCompact<VM> as *mut MarkCompact<VM>) };
+        let plan_mut = unsafe { &mut *(self.plan as *mut MarkCompact<VM>) };
         plan_mut.common.release(worker.tls, true);
         plan_mut.common.prepare(worker.tls, true);
         #[cfg(feature = "extreme_assertions")]

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -101,7 +101,7 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         scheduler.work_buckets[WorkBucketStage::CalculateForwarding]
             .add(CalculateForwardingAddress::<VM>::new(&self.mc_space));
         // do another trace to update references
-        scheduler.work_buckets[WorkBucketStage::SecondRoots].add(UpdateReferences::<VM>::new());
+        scheduler.work_buckets[WorkBucketStage::SecondRoots].add(UpdateReferences::<VM>::new(self));
         scheduler.work_buckets[WorkBucketStage::Compact].add(Compact::<VM>::new(&self.mc_space));
 
         // Release global/collectors/mutators


### PR DESCRIPTION
#939 makes MarkCompact GC allocate large objects into LOS, instead of mark-compacting everything. However, LOS should be released and re-prepared properly, otherwise marking in the pointer forwarding trace will not behave correctly.

This should fix the OpenJDK binding test failures.