### PR TITLE
Fix vo-bit reset for discontiguous space

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -192,7 +192,9 @@ impl<VM: VMBinding> CopySpace<VM> {
                 );
             }
         } else {
-            unimplemented!();
+            for (start, size) in self.pr.iterate_allocated_regions() {
+                crate::util::metadata::vo_bit::bzero_vo_bit(start, size);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes `CpoySpace::reset_vo_bit` and vo-bit reset implementation for discontiguous space 