### PR TITLE
Remove descriptor_map

### DIFF
--- a/src/util/heap/layout/map.rs
+++ b/src/util/heap/layout/map.rs
@@ -4,8 +4,6 @@ use crate::util::heap::space_descriptor::SpaceDescriptor;
 use crate::util::Address;
 
 pub trait VMMap: Sync {
-    fn insert(&self, start: Address, extent: usize, descriptor: SpaceDescriptor);
-
     /// Create a free-list for a discontiguous space. Must only be called at boot time.
     /// bind_freelist() must be called by the caller after this method.
     fn create_freelist(&self, start: Address) -> Box<dyn FreeList>;
@@ -60,8 +58,6 @@ pub trait VMMap: Sync {
     fn finalize_static_space_map(&self, from: Address, to: Address);
 
     fn is_finalized(&self) -> bool;
-
-    fn get_descriptor_for_address(&self, address: Address) -> SpaceDescriptor;
 
     fn add_to_cumulative_committed_pages(&self, pages: usize);
 }


### PR DESCRIPTION
**DRAFT**: This PR has two problems:

1. The current implementation of `address_in_space` in this PR has noticeable performance overhead.  From benchmark results, it looks like the check of having SFT entry and the 128-bit load is a bottleneck.
2. The semantics of casting the 128-bit `*const dyn SFT` to `*const ()` is unclear, and may be unreliable.

So I decide to postpone this PR until two other things are done:

1.  Refactoring the `SFT_MAP` implementation to eliminate 128-bit atomic read.  See https://github.com/mmtk/mmtk-core/issues/945
2.  Merging the compressed pointer support in the OpenJDK binding so that we will have a more realistic use case to evaluate.  See https://github.com/mmtk/mmtk-openjdk/pull/235

# Description

This PR removes the `descriptor_map` from both `Map32` and `Map64`.

Currently, the `descriptor_map` is only used by `Space::address_in_space` when using `Map32`, and not used (except in some assertions about newly acquired pages) when using `Map64`.  With `descriptor_map` removed, `Space::address_in_space` will use the SFT to find the space of a given address.

Performance: The `Space::in_space` function (which calls `Space::address_in_space`) is used by the derive macro of the `trait PlanTraceObject`.  Therefore, this PR will affect the performance of tracing for plans that use `PlanTraceObject` when using `Map32`.  This needs to be tested.

Related PRs:
-   https://github.com/mmtk/mmtk-core/pull/951: If `descriptor_map` were moved into the `Mutex`, it would be inefficient.  This PR removes `descriptor_map`, instead, so that https://github.com/mmtk/mmtk-core/pull/951 can move other fields into the `Mutex`.