### PR TITLE
Do not reset ImmixAllocator when preparing mutator

### DIFF
--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -15,16 +15,7 @@ use crate::{
 };
 use enum_map::EnumMap;
 
-pub fn immix_mutator_prepare<VM: VMBinding>(mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {
-    let immix_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<ImmixAllocator<VM>>()
-    .unwrap();
-    immix_allocator.reset();
-}
+pub fn immix_mutator_prepare<VM: VMBinding>(_mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {}
 
 pub fn immix_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {
     let immix_allocator = unsafe {


### PR DESCRIPTION
It is unnecessary to reset the ImmixAllocator of a mutator when preparing mutator because the mutator's ImmixAllocator is not used during GC.  When a worker defragments the heap and promotes young objects, it uses the ImmixAllocator in ImmixCopyContext or ImmixHybridCopyContext.

The ImmixAllocator of a mutator still needs to be reset after GC (when releasing mutators) because the blocks it was allocating into could have been defragmented or recycled.  So it needs to reset the bump pointers.

Fixes: https://github.com/mmtk/mmtk-core/issues/959