### PR TITLE
Introduce `ArcFlexMut` for Space references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ itertools = "0.10.5"
 jemalloc-sys = { version = "0.5.3", features = ["disable_initial_exec_tls"], optional = true }
 lazy_static = "1.1"
 libc = "0.2"
-log = { version = "0.4", features = ["max_level_trace"] }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
 memoffset = "0.9"
 mimalloc-sys = { version = "0.1.6", optional = true }
 # MMTk macros
@@ -50,8 +50,8 @@ strum = "0.24"
 strum_macros = "0.24"
 sysinfo = "0.29"
 
-parking_lot = { version = "0.12", features = ["deadlock_detection"] }
-peace-lock = { version = "0.1.2", features = ["check"] }
+parking_lot = { version = "0.12", features = [] }
+peace-lock = { version = "0.1.2", features = [] }
 
 [dev-dependencies]
 paste = "1.0.8"
@@ -74,6 +74,9 @@ perf_counter = ["pfm"]
 
 # Do not modify the following line - ci-common.sh matches it
 # -- Non mutually exclusive features --
+
+# Turn on checks in peace-lock to check race conditions
+peace_lock_race_check = ["peace-lock/check"]
 
 # spaces with different semantics
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ mimalloc-sys = { version = "0.1.6", optional = true }
 mmtk-macros = { version = "0.19.0", path = "macros/" }
 num_cpus = "1.8"
 num-traits = "0.2"
+peace-lock = "0.1.3"
 pfm = { version = "0.1.0-beta.3", optional = true }
 probe = "0.5"
 portable-atomic = "1.4.3"
@@ -49,10 +50,6 @@ static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
 sysinfo = "0.29"
-
-parking_lot = { version = "0.12", features = [] }
-peace-lock = "0.1.3"
-# peace-lock = { path = "../peace-lock" }
 
 [dev-dependencies]
 paste = "1.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ strum_macros = "0.24"
 sysinfo = "0.29"
 
 parking_lot = { version = "0.12", features = [] }
-peace-lock = { version = "0.1.2", features = [] }
+peace-lock = { git = "https://github.com/qinsoon/peace-lock.git", rev = "b91104c295ff60f815a931c670a69858dfdafbe5" }
+# peace-lock = { path = "../peace-lock" }
 
 [dev-dependencies]
 paste = "1.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ strum_macros = "0.24"
 sysinfo = "0.29"
 
 parking_lot = { version = "0.12", features = [] }
-peace-lock = { git = "https://github.com/qinsoon/peace-lock.git", rev = "b91104c295ff60f815a931c670a69858dfdafbe5" }
+peace-lock = "0.1.3"
 # peace-lock = { path = "../peace-lock" }
 
 [dev-dependencies]
@@ -76,8 +76,8 @@ perf_counter = ["pfm"]
 # Do not modify the following line - ci-common.sh matches it
 # -- Non mutually exclusive features --
 
-# Turn on checks in peace-lock to check race conditions
-peace_lock_race_check = ["peace-lock/check"]
+# Turn on checks for the type ArcFlexMut (we use peace-lock for the type so just turn on check for peace-lock).
+check_flex_mut = ["peace-lock/check"]
 
 # spaces with different semantics
 
@@ -136,7 +136,7 @@ nogc_no_zeroing = ["nogc_lock_free"]
 single_worker = []
 
 # To run expensive comprehensive runtime checks, such as checking duplicate edges
-extreme_assertions = []
+extreme_assertions = ["check_flex_mut"]
 
 # Enable multiple spaces for NoGC, each allocator maps to an individual ImmortalSpace.
 nogc_multi_space = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ itertools = "0.10.5"
 jemalloc-sys = { version = "0.5.3", features = ["disable_initial_exec_tls"], optional = true }
 lazy_static = "1.1"
 libc = "0.2"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
+log = { version = "0.4", features = ["max_level_trace"] }
 memoffset = "0.9"
 mimalloc-sys = { version = "0.1.6", optional = true }
 # MMTk macros
@@ -49,6 +49,9 @@ static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
 sysinfo = "0.29"
+
+parking_lot = { version = "0.12", features = ["deadlock_detection"] }
+peace-lock = { version = "0.1.2", features = ["check"] }
 
 [dev-dependencies]
 paste = "1.0.8"

--- a/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
@@ -61,15 +61,15 @@ impl<VM: VMBinding> ProcessEdgesWork for MyGCProcessEdges<VM> {
         }
         let worker = self.worker();
         let queue = &mut self.base.nodes;
-        if self.plan.tospace().in_space(object) {
-            self.plan.tospace().trace_object(
+        if self.plan.tospace().read().in_space(object) {
+            self.plan.tospace().read().trace_object(
                 queue,
                 object,
                 Some(CopySemantics::DefaultCopy),
                 worker,
             )
-        } else if self.plan.fromspace().in_space(object) {
-            self.plan.fromspace().trace_object(
+        } else if self.plan.fromspace().read().in_space(object) {
+            self.plan.fromspace().read().trace_object(
                 queue,
                 object,
                 Some(CopySemantics::DefaultCopy),

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -1,7 +1,6 @@
 // ANCHOR: imports_no_gc_work
 use crate::plan::global::BasePlan; //Modify
 use crate::plan::global::CommonPlan; // Add
-use crate::global_state::GcStatus; // Add
 use crate::plan::global::{CreateGeneralPlanArgs, CreateSpecificPlanArgs};
 use crate::plan::mygc::mutator::ALLOCATOR_MAPPING;
 use crate::plan::mygc::gc_work::MyGCWorkContext;
@@ -77,17 +76,9 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
     // Modify
     // ANCHOR: schedule_collection
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
-        self.base().set_collection_kind::<Self>(self);
-        self.base().set_gc_status(GcStatus::GcPrepare);
         scheduler.schedule_common_work::<MyGCWorkContext<VM>>(self);
     }
     // ANCHOR_END: schedule_collection
-
-    // ANCHOR: collection_required()
-    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        self.base().collection_required(self, space_full)
-    }
-    // ANCHOR_END: collection_required()
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
         &*ALLOCATOR_MAPPING

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -1,7 +1,7 @@
 // ANCHOR: imports_no_gc_work
 use crate::plan::global::BasePlan; //Modify
 use crate::plan::global::CommonPlan; // Add
-use crate::plan::global::GcStatus; // Add
+use crate::global_state::GcStatus; // Add
 use crate::plan::global::{CreateGeneralPlanArgs, CreateSpecificPlanArgs};
 use crate::plan::mygc::mutator::ALLOCATOR_MAPPING;
 use crate::plan::mygc::gc_work::MyGCWorkContext;

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -80,6 +80,12 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
     }
     // ANCHOR_END: schedule_collection
 
+    // ANCHOR: collection_required()
+    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+    // ANCHOR_END: collection_required()
+
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
         &*ALLOCATOR_MAPPING
     }

--- a/docs/userguide/src/tutorial/code/mygc_semispace/mutator.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/mutator.rs
@@ -44,7 +44,7 @@ pub fn mygc_mutator_release<VM: VMBinding>(
             .plan
             .downcast_ref::<MyGC<VM>>()
             .unwrap()
-            .tospace(),
+            .tospace().clone().into_dyn_space(),
     );
 }
 // ANCHOR_END: release
@@ -78,7 +78,7 @@ pub fn create_mygc_mutator<VM: VMBinding>(
         // ANCHOR: space_mapping
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, mygc);
-            vec.push((AllocatorSelector::BumpPointer(0), mygc.tospace()));
+            vec.push((AllocatorSelector::BumpPointer(0), mygc.tospace().clone().into_dyn_space()));
             vec
         }),
         // ANCHOR_END: space_mapping

--- a/docs/userguide/src/tutorial/mygc/ss/alloc.md
+++ b/docs/userguide/src/tutorial/mygc/ss/alloc.md
@@ -56,8 +56,11 @@ Change `pub struct MyGC<VM: VMBinding>` to add new instance variables.
    1. Delete the existing fields in the constructor.
    2. Add `pub hi: AtomicBool,`. This is a thread-safe bool, indicating which 
    copyspace is the tospace.
-   3. Add `pub copyspace0: CopySpace<VM>,` 
-   and `pub copyspace1: CopySpace<VM>,`. These are the two copyspaces.
+   3. Add `pub copyspace0: ArcFlexMut<CopySpace<VM>>,` 
+   and `pub copyspace1: ArcFlexMut<CopySpace<VM>>,`. These are the two copyspaces.
+   We use the type `ArcFlexMut` from `mmtk::util::rust_util::flex_mut`, which
+   allows us to share the reference among different types and allows us to
+   flexibly acquire mutable references.
    4. Add `pub common: CommonPlan<VM>,`.
     This holds an instance of the common plan.
 

--- a/docs/userguide/src/tutorial/mygc/ss/alloc.md
+++ b/docs/userguide/src/tutorial/mygc/ss/alloc.md
@@ -139,6 +139,14 @@ base plan *through* the common plan.
 {{#include ../../code/mygc_semispace/global.rs:plan_base}}
 ```
 
+The trait `Plan` requires `collection_required()` method to know when
+we should trigger a collection. We can just use the implementation
+in the `BasePlan`.
+
+```rust
+{{#include ../../code/mygc_semispace/global.rs:collection_required}}
+```
+
 Find the method `get_pages_used`. Replace the current body with 
 `self.tospace().reserved_pages() + self.common.get_pages_used()`, to 
 correctly count the pages contained in the tospace and the common plan 

--- a/docs/userguide/src/tutorial/mygc/ss/alloc.md
+++ b/docs/userguide/src/tutorial/mygc/ss/alloc.md
@@ -139,14 +139,6 @@ base plan *through* the common plan.
 {{#include ../../code/mygc_semispace/global.rs:plan_base}}
 ```
 
-The trait `Plan` requires `collection_required()` method to know when
-we should trigger a collection. We can just use the implementation
-in the `BasePlan`.
-
-```rust
-{{#include ../../code/mygc_semispace/global.rs:collection_required}}
-```
-
 Find the method `get_pages_used`. Replace the current body with 
 `self.tospace().reserved_pages() + self.common.get_pages_used()`, to 
 correctly count the pages contained in the tospace and the common plan 

--- a/macros/src/has_spaces_impl.rs
+++ b/macros/src/has_spaces_impl.rs
@@ -45,12 +45,12 @@ pub(crate) fn generate_impl_items<'a>(
         let f_ident = f.ident.as_ref().unwrap();
 
         let visitor = quote! {
-            let space = crate::space_ref_read!(&self.#f_ident);
+            let space = self.#f_ident.read();
             __func(&*space);
         };
 
         let visitor_mut = quote! {
-            let mut space = crate::space_ref_write!(&self.#f_ident);
+            let mut space = self.#f_ident.write();
             __func(&mut *space);
         };
 

--- a/macros/src/has_spaces_impl.rs
+++ b/macros/src/has_spaces_impl.rs
@@ -45,11 +45,13 @@ pub(crate) fn generate_impl_items<'a>(
         let f_ident = f.ident.as_ref().unwrap();
 
         let visitor = quote! {
-            __func(&self.#f_ident);
+            let space = crate::space_ref_read!(&self.#f_ident);
+            __func(&*space);
         };
 
         let visitor_mut = quote! {
-            __func(&mut self.#f_ident);
+            let mut space = crate::space_ref_write!(&self.#f_ident);
+            __func(&mut *space);
         };
 
         space_visitors.push(visitor);
@@ -75,7 +77,7 @@ pub(crate) fn generate_impl_items<'a>(
             #parent_visitor
         }
 
-        fn for_each_space_mut(&mut self, __func: &mut dyn FnMut(&mut dyn Space<VM>)) {
+        fn for_each_space_mut(&self, __func: &mut dyn FnMut(&mut dyn Space<VM>)) {
             #(#space_visitors_mut)*
             #parent_visitor_mut
         }

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -1,0 +1,243 @@
+use crate::util::statistics::stats::Stats;
+use crate::util::options::Options;
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+pub struct GlobalState {
+    /// Whether MMTk is now ready for collection. This is set to true when initialize_collection() is called.
+    pub initialized: AtomicBool,
+    /// Should we trigger a GC when the heap is full? It seems this should always be true. However, we allow
+    /// bindings to temporarily disable GC, at which point, we do not trigger GC even if the heap is full.
+    pub trigger_gc_when_heap_is_full: AtomicBool,
+    pub gc_status: Mutex<GcStatus>,
+    pub emergency_collection: AtomicBool,
+    pub user_triggered_collection: AtomicBool,
+    pub internal_triggered_collection: AtomicBool,
+    pub last_internal_triggered_collection: AtomicBool,
+    // Has an allocation succeeded since the emergency collection?
+    pub allocation_success: AtomicBool,
+    // Maximum number of failed attempts by a single thread
+    pub max_collection_attempts: AtomicUsize,
+    // Current collection attempt
+    pub cur_collection_attempts: AtomicUsize,
+    // pub gc_requester: Arc<GCRequester<VM>>, ???
+    pub stats: Stats,
+    // pub vm_map: &'static dyn Map,
+    // pub options: Arc<Options>, ???
+    // pub heap: HeapMeta, ???
+    // pub gc_trigger: Arc<GCTrigger<VM>>, ???
+    #[cfg(feature = "sanity")]
+    pub inside_sanity: AtomicBool,
+    /// A counter for per-mutator stack scanning
+    pub scanned_stacks: AtomicUsize,
+    /// Have we scanned all the stacks?
+    pub stacks_prepared: AtomicBool,
+    /// A counter that keeps tracks of the number of bytes allocated since last stress test
+    pub allocation_bytes: AtomicUsize,
+    /// A counteer that keeps tracks of the number of bytes allocated by malloc
+    #[cfg(feature = "malloc_counted_size")]
+    pub malloc_bytes: AtomicUsize,
+    /// This stores the size in bytes for all the live objects in last GC. This counter is only updated in the GC release phase.
+    #[cfg(feature = "count_live_bytes_in_gc")]
+    pub live_bytes_in_last_gc: AtomicUsize,
+    /// Wrapper around analysis counters
+    #[cfg(feature = "analysis")]
+    pub analysis_manager: AnalysisManager<VM>,
+}
+
+impl GlobalState {
+    pub fn new(options: &Options) -> Self {
+        Self {
+            initialized: AtomicBool::new(false),
+            trigger_gc_when_heap_is_full: AtomicBool::new(true),
+            gc_status: Mutex::new(GcStatus::NotInGC),
+            stacks_prepared: AtomicBool::new(false),
+            emergency_collection: AtomicBool::new(false),
+            user_triggered_collection: AtomicBool::new(false),
+            internal_triggered_collection: AtomicBool::new(false),
+            last_internal_triggered_collection: AtomicBool::new(false),
+            allocation_success: AtomicBool::new(false),
+            max_collection_attempts: AtomicUsize::new(0),
+            cur_collection_attempts: AtomicUsize::new(0),
+            // gc_requester: Arc::new(GCRequester::new()),
+            stats: Stats::new(&options),
+            // heap: args.global_args.heap,
+            // gc_trigger: args.global_args.gc_trigger,
+            // options: args.global_args.options,
+            #[cfg(feature = "sanity")]
+            inside_sanity: AtomicBool::new(false),
+            scanned_stacks: AtomicUsize::new(0),
+            allocation_bytes: AtomicUsize::new(0),
+            #[cfg(feature = "malloc_counted_size")]
+            malloc_bytes: AtomicUsize::new(0),
+            #[cfg(feature = "count_live_bytes_in_gc")]
+            live_bytes_in_last_gc: AtomicUsize::new(0),
+            #[cfg(feature = "analysis")]
+            analysis_manager,      
+        }
+    }
+
+    pub(crate) fn set_gc_status(&self, s: GcStatus) {
+        let mut gc_status = self.gc_status.lock().unwrap();
+        if *gc_status == GcStatus::NotInGC {
+            self.stacks_prepared.store(false, Ordering::SeqCst);
+            // FIXME stats
+            self.stats.start_gc();
+        }
+        *gc_status = s;
+        if *gc_status == GcStatus::NotInGC {
+            // FIXME stats
+            if self.stats.get_gathering_stats() {
+                self.stats.end_gc();
+            }
+        }
+    }
+
+    pub fn gc_in_progress(&self) -> bool {
+        *self.gc_status.lock().unwrap() != GcStatus::NotInGC
+    }
+
+    pub fn gc_in_progress_proper(&self) -> bool {
+        *self.gc_status.lock().unwrap() == GcStatus::GcProper
+    }
+
+    pub fn set_collection_kind(&self, last_collection_was_exhaustive: bool, heap_can_grow: bool) -> bool {
+        self.cur_collection_attempts.store(
+            if self.user_triggered_collection.load(Ordering::Relaxed) {
+                1
+            } else {
+                self.determine_collection_attempts()
+            },
+            Ordering::Relaxed,
+        );
+
+        let emergency_collection = !self.is_internal_triggered_collection()
+            && last_collection_was_exhaustive
+            && self.cur_collection_attempts.load(Ordering::Relaxed) > 1
+            && !heap_can_grow;
+        self.emergency_collection
+            .store(emergency_collection, Ordering::Relaxed);
+
+        emergency_collection
+    }
+
+    fn determine_collection_attempts(&self) -> usize {
+        if !self.allocation_success.load(Ordering::Relaxed) {
+            self.max_collection_attempts.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.allocation_success.store(false, Ordering::Relaxed);
+            self.max_collection_attempts.store(1, Ordering::Relaxed);
+        }
+
+        self.max_collection_attempts.load(Ordering::Relaxed)
+    }
+
+    fn is_internal_triggered_collection(&self) -> bool {
+        let is_internal_triggered = self
+            .last_internal_triggered_collection
+            .load(Ordering::SeqCst);
+        // Remove this assertion when we have concurrent GC.
+        assert!(
+            !is_internal_triggered,
+            "We have no concurrent GC implemented. We should not have internally triggered GC"
+        );
+        is_internal_triggered
+    }
+
+    pub fn is_emergency_collection(&self) -> bool {
+        self.emergency_collection.load(Ordering::Relaxed)
+    }
+
+    /// Return true if this collection was triggered by application code.
+    pub fn is_user_triggered_collection(&self) -> bool {
+        self.user_triggered_collection.load(Ordering::Relaxed)
+    }
+
+    /// Reset collection state information.
+    pub fn reset_collection_trigger(&self) {
+        self.last_internal_triggered_collection.store(
+            self.internal_triggered_collection.load(Ordering::SeqCst),
+            Ordering::Relaxed,
+        );
+        self.internal_triggered_collection
+            .store(false, Ordering::SeqCst);
+        self.user_triggered_collection
+            .store(false, Ordering::Relaxed);
+    }
+
+    /// Are the stacks scanned?
+    pub fn stacks_prepared(&self) -> bool {
+        self.stacks_prepared.load(Ordering::SeqCst)
+    }
+
+    /// Prepare for stack scanning. This is usually used with `inform_stack_scanned()`.
+    /// This should be called before doing stack scanning.
+    pub fn prepare_for_stack_scanning(&self) {
+        self.scanned_stacks.store(0, Ordering::SeqCst);
+        self.stacks_prepared.store(false, Ordering::SeqCst);
+    }
+
+    /// Inform that 1 stack has been scanned. The argument `n_mutators` indicates the
+    /// total stacks we should scan. This method returns true if the number of scanned
+    /// stacks equals the total mutator count. Otherwise it returns false. This method
+    /// is thread safe and we guarantee only one thread will return true.
+    pub fn inform_stack_scanned(&self, n_mutators: usize) -> bool {
+        let old = self.scanned_stacks.fetch_add(1, Ordering::SeqCst);
+        debug_assert!(
+            old < n_mutators,
+            "The number of scanned stacks ({}) is more than the number of mutators ({})",
+            old,
+            n_mutators
+        );
+        let scanning_done = old + 1 == n_mutators;
+        if scanning_done {
+            self.stacks_prepared.store(true, Ordering::SeqCst);
+        }
+        scanning_done
+    }
+
+    /// Increase the allocation bytes and return the current allocation bytes after increasing
+    pub fn increase_allocation_bytes_by(&self, size: usize) -> usize {
+        let old_allocation_bytes = self.allocation_bytes.fetch_add(size, Ordering::SeqCst);
+        trace!(
+            "Stress GC: old_allocation_bytes = {}, size = {}, allocation_bytes = {}",
+            old_allocation_bytes,
+            size,
+            self.allocation_bytes.load(Ordering::Relaxed),
+        );
+        old_allocation_bytes + size
+    }
+
+    #[cfg(feature = "malloc_counted_size")]
+    pub fn get_malloc_bytes_in_pages(&self) -> usize {
+        crate::util::conversions::bytes_to_pages_up(self.malloc_bytes.load(Ordering::Relaxed))
+    }
+
+    #[cfg(feature = "malloc_counted_size")]
+    pub(crate) fn increase_malloc_bytes_by(&self, size: usize) {
+        self.malloc_bytes.fetch_add(size, Ordering::SeqCst);
+    }
+
+    #[cfg(feature = "malloc_counted_size")]
+    pub(crate) fn decrease_malloc_bytes_by(&self, size: usize) {
+        self.malloc_bytes.fetch_sub(size, Ordering::SeqCst);
+    }
+
+    #[cfg(feature = "count_live_bytes_in_gc")]
+    pub fn get_live_bytes_in_last_gc(&self) -> usize {
+        self.live_bytes_in_last_gc.load(Ordering::SeqCst)
+    }
+
+    #[cfg(feature = "count_live_bytes_in_gc")]
+    pub fn set_live_bytes_in_last_gc(&self, size: usize) {
+        self.live_bytes_in_last_gc.store(size, Ordering::SeqCst);
+    }
+}
+
+#[derive(PartialEq)]
+pub enum GcStatus {
+    NotInGC,
+    GcPrepare,
+    GcProper,
+}

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 // actually are not related with a plan, they are just global states for MMTK. So we refactored
 // those fields to this separate struct. For components that access the state, they just need
 // a reference to the struct, and are no longer dependent on the plan.
-// We may consider further break down the fields into smaller structs. 
+// We may consider further break down the fields into smaller structs.
 pub struct GlobalState {
     /// Whether MMTk is now ready for collection. This is set to true when initialize_collection() is called.
     pub(crate) initialized: AtomicBool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ pub use mmtk::MMTKBuilder;
 pub(crate) use mmtk::MMAPPER;
 pub use mmtk::MMTK;
 
+mod global_state;
+
 mod policy;
 
 pub mod build_info;

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -95,6 +95,7 @@ pub fn set_vm_space<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, start: Address, 
     unsafe { mmtk.get_plan_mut() }
         .base_mut()
         .vm_space
+        .write()
         .set_vm_region(start, size);
 }
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -707,17 +707,6 @@ pub fn is_mapped_address(address: Address) -> bool {
     address.is_mapped()
 }
 
-// /// Check that if a garbage collection is in progress and if the given
-// /// object is not movable.  If it is movable error messages are
-// /// logged and the system exits.
-// ///
-// /// Arguments:
-// /// * `mmtk`: A reference to an MMTk instance.
-// /// * `object`: The object to check.
-// pub fn modify_check<VM: VMBinding>(mmtk: &MMTK<VM>, object: ObjectReference) {
-//     mmtk.get_plan().modify_check(object);
-// }
-
 /// Add a reference to the list of weak references. A binding may
 /// call this either when a weak reference is created, or when a weak reference is traced during GC.
 ///

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -478,9 +478,7 @@ pub fn initialize_collection<VM: VMBinding>(mmtk: &'static MMTK<VM>, tls: VMThre
         "MMTk collection has been initialized (was initialize_collection() already called before?)"
     );
     mmtk.scheduler.spawn_gc_threads(mmtk, tls);
-    mmtk.get_plan()
-        .base()
-        .initialized
+    mmtk.state.initialized
         .store(true, Ordering::SeqCst);
     probe!(mmtk, collection_initialized);
 }
@@ -496,9 +494,7 @@ pub fn enable_collection<VM: VMBinding>(mmtk: &'static MMTK<VM>) {
         !mmtk.get_plan().should_trigger_gc_when_heap_is_full(),
         "enable_collection() is called when GC is already enabled."
     );
-    mmtk.get_plan()
-        .base()
-        .trigger_gc_when_heap_is_full
+    mmtk.state.trigger_gc_when_heap_is_full
         .store(true, Ordering::SeqCst);
 }
 
@@ -517,9 +513,7 @@ pub fn disable_collection<VM: VMBinding>(mmtk: &'static MMTK<VM>) {
         mmtk.get_plan().should_trigger_gc_when_heap_is_full(),
         "disable_collection() is called when GC is not enabled."
     );
-    mmtk.get_plan()
-        .base()
-        .trigger_gc_when_heap_is_full
+    mmtk.state.trigger_gc_when_heap_is_full
         .store(false, Ordering::SeqCst);
 }
 
@@ -568,9 +562,7 @@ pub fn free_bytes<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
 /// to call this method is at the end of a GC (e.g. when the runtime is about to resume threads).
 #[cfg(feature = "count_live_bytes_in_gc")]
 pub fn live_bytes_in_last_gc<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
-    mmtk.get_plan()
-        .base()
-        .live_bytes_in_last_gc
+    mmtk.state.live_bytes_in_last_gc
         .load(Ordering::SeqCst)
 }
 
@@ -600,8 +592,7 @@ pub fn total_bytes<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
 /// * `mmtk`: A reference to an MMTk instance.
 /// * `tls`: The thread that triggers this collection request.
 pub fn handle_user_collection_request<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMMutatorThread) {
-    mmtk.get_plan()
-        .handle_user_collection_request(tls, false, false);
+    mmtk.handle_user_collection_request(tls, false, false);
 }
 
 /// Is the object alive?

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -92,8 +92,8 @@ pub fn mmtk_init<VM: VMBinding>(builder: &MMTKBuilder) -> Box<MMTK<VM>> {
 /// Currently we do not allow removing regions from VM space.
 #[cfg(feature = "vm_space")]
 pub fn set_vm_space<VM: VMBinding>(mmtk: &'static mut MMTK<VM>, start: Address, size: usize) {
-    unsafe { mmtk.get_plan_mut() }
-        .base_mut()
+    mmtk.get_plan()
+        .base()
         .vm_space
         .write()
         .set_vm_region(start, size);

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -23,7 +23,6 @@ use crate::util::sanity::sanity_checker::SanityChecker;
 use crate::util::statistics::stats::Stats;
 use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
-use std::cell::UnsafeCell;
 use std::default::Default;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -98,7 +97,7 @@ impl Default for MMTKBuilder {
 pub struct MMTK<VM: VMBinding> {
     pub(crate) options: Arc<Options>,
     pub(crate) state: Arc<GlobalState>,
-    pub(crate) plan: UnsafeCell<Box<dyn Plan<VM = VM>>>,
+    pub(crate) plan: Box<dyn Plan<VM = VM>>,
     pub(crate) reference_processors: ReferenceProcessors,
     pub(crate) finalizable_processor:
         Mutex<FinalizableProcessor<<VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType>>,
@@ -189,7 +188,7 @@ impl<VM: VMBinding> MMTK<VM> {
         MMTK {
             options,
             state,
-            plan: UnsafeCell::new(plan),
+            plan,
             reference_processors: ReferenceProcessors::new(),
             finalizable_processor: Mutex::new(FinalizableProcessor::<
                 <VM::VMReferenceGlue as ReferenceGlue<VM>>::FinalizableType,
@@ -312,17 +311,7 @@ impl<VM: VMBinding> MMTK<VM> {
     }
 
     pub fn get_plan(&self) -> &dyn Plan<VM = VM> {
-        unsafe { &**(self.plan.get()) }
-    }
-
-    /// Get the plan as mutable reference.
-    ///
-    /// # Safety
-    ///
-    /// This is unsafe because the caller must ensure that the plan is not used by other threads.
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn get_plan_mut(&self) -> &mut dyn Plan<VM = VM> {
-        &mut **(self.plan.get())
+        &*self.plan
     }
 
     pub fn get_options(&self) -> &Options {

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -1,11 +1,15 @@
 //! MMTk instance.
+use crate::global_state::GlobalState;
 use crate::plan::Plan;
+use crate::plan::gc_requester::GCRequester;
 use crate::policy::sft_map::{create_sft_map, SFTMap};
 use crate::scheduler::GCWorkScheduler;
 
 #[cfg(feature = "extreme_assertions")]
 use crate::util::edge_logger::EdgeLogger;
 use crate::util::finalizable_processor::FinalizableProcessor;
+use crate::util::heap::HeapMeta;
+use crate::util::heap::gc_trigger::GCTrigger;
 use crate::util::heap::layout::vm_layout::VMLayout;
 use crate::util::heap::layout::{self, Mmapper, VMMap};
 use crate::util::opaque_pointer::*;
@@ -13,6 +17,7 @@ use crate::util::options::Options;
 use crate::util::reference_processor::ReferenceProcessors;
 #[cfg(feature = "sanity")]
 use crate::util::sanity::sanity_checker::SanityChecker;
+use crate::util::statistics::stats::Stats;
 use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 use std::cell::UnsafeCell;
@@ -89,6 +94,7 @@ impl Default for MMTKBuilder {
 /// *Note that multi-instances is not fully supported yet*
 pub struct MMTK<VM: VMBinding> {
     pub(crate) options: Arc<Options>,
+    pub(crate) state: Arc<GlobalState>,
     pub(crate) plan: UnsafeCell<Box<dyn Plan<VM = VM>>>,
     pub(crate) reference_processors: ReferenceProcessors,
     pub(crate) finalizable_processor:
@@ -98,7 +104,13 @@ pub struct MMTK<VM: VMBinding> {
     pub(crate) sanity_checker: Mutex<SanityChecker<VM::VMEdge>>,
     #[cfg(feature = "extreme_assertions")]
     pub(crate) edge_logger: EdgeLogger<VM::VMEdge>,
+    pub(crate) gc_trigger: Arc<GCTrigger<VM>>,
+    pub(crate) gc_requester: Arc<GCRequester<VM>>,
+    pub(crate) stats: Stats,
+    pub(crate) heap: HeapMeta,
     inside_harness: AtomicBool,
+    #[cfg(feature = "sanity")]
+    inside_sanity: AtomicBool,
 }
 
 unsafe impl<VM: VMBinding> Sync for MMTK<VM> {}
@@ -119,20 +131,44 @@ impl<VM: VMBinding> MMTK<VM> {
 
         let scheduler = GCWorkScheduler::new(num_workers, (*options.thread_affinity).clone());
 
+        let state = Arc::new(GlobalState::new(&options));
+
+        let gc_trigger = Arc::new(GCTrigger::new(options.clone(), state.clone()));
+
+        let gc_requester = Arc::new(GCRequester::new());
+
+        let stats = Stats::new(&options);
+
+        let mut heap = HeapMeta::new();
+
         let plan = crate::plan::create_plan(
             *options.plan,
             VM_MAP.as_ref(),
             MMAPPER.as_ref(),
             options.clone(),
+            state.clone(),
+            gc_trigger.clone(),
             scheduler.clone(),
+            &stats,
+            &mut heap,
         );
+
+        // We haven't finished creating MMTk. No one is using the GC trigger. We cast the arc into a mutable reference.
+        {
+            // TODO: use Arc::get_mut_unchecked() when it is availble.
+            let gc_trigger: &mut GCTrigger<VM> = unsafe { &mut *(Arc::as_ptr(&gc_trigger) as *mut _) };
+            // We know the plan address will not change. Cast it to a static reference.
+            let static_plan: &'static dyn Plan<VM = VM> = unsafe { &*(&*plan as *const _) };
+            // Set the plan so we can trigger GC and check GC condition without using plan
+            gc_trigger.set_plan(static_plan);
+        }
 
         // TODO: This probably does not work if we have multiple MMTk instances.
         VM_MAP.boot();
         // This needs to be called after we create Plan. It needs to use HeapMeta, which is gradually built when we create spaces.
         VM_MAP.finalize_static_space_map(
-            plan.base().heap.get_discontig_start(),
-            plan.base().heap.get_discontig_end(),
+            heap.get_discontig_start(),
+            heap.get_discontig_end(),
         );
 
         if *options.transparent_hugepages {
@@ -141,6 +177,7 @@ impl<VM: VMBinding> MMTK<VM> {
 
         MMTK {
             options,
+            state,
             plan: UnsafeCell::new(plan),
             reference_processors: ReferenceProcessors::new(),
             finalizable_processor: Mutex::new(FinalizableProcessor::<
@@ -149,25 +186,85 @@ impl<VM: VMBinding> MMTK<VM> {
             scheduler,
             #[cfg(feature = "sanity")]
             sanity_checker: Mutex::new(SanityChecker::new()),
+            #[cfg(feature = "sanity")]
+            inside_sanity: AtomicBool::new(false),
             inside_harness: AtomicBool::new(false),
             #[cfg(feature = "extreme_assertions")]
             edge_logger: EdgeLogger::new(),
+            gc_trigger,
+            gc_requester,
+            stats,
+            heap,
         }
     }
 
     pub fn harness_begin(&self, tls: VMMutatorThread) {
         probe!(mmtk, harness_begin);
-        self.get_plan()
-            .handle_user_collection_request(tls, true, true);
+        self.handle_user_collection_request(tls, true, true);
         self.inside_harness.store(true, Ordering::SeqCst);
-        self.get_plan().base().stats.start_all();
+        self.stats.start_all();
         self.scheduler.enable_stat();
     }
 
     pub fn harness_end(&'static self) {
-        self.get_plan().base().stats.stop_all(self);
+        self.stats.stop_all(self);
         self.inside_harness.store(false, Ordering::SeqCst);
         probe!(mmtk, harness_end);
+    }
+
+    #[cfg(feature = "sanity")]
+    pub(crate) fn sanity_begin(&self) {
+        self.inside_sanity.store(true, Ordering::Relaxed)
+    }
+
+    #[cfg(feature = "sanity")]
+    pub(crate) fn sanity_end(&self) {
+        self.inside_sanity.store(false, Ordering::Relaxed)
+    }
+
+    #[cfg(feature = "sanity")]
+    pub(crate) fn is_in_sanity(&self) -> bool {
+        self.inside_sanity.load(Ordering::Relaxed)
+    }
+
+    /// The application code has requested a collection. This is just a GC hint, and
+    /// we may ignore it.
+    ///
+    /// # Arguments
+    /// * `tls`: The mutator thread that requests the GC
+    /// * `force`: The request cannot be ignored (except for NoGC)
+    /// * `exhaustive`: The requested GC should be exhaustive. This is also a hint.
+    pub fn handle_user_collection_request(&self, tls: VMMutatorThread, force: bool, exhaustive: bool) {
+        use crate::vm::Collection;
+        if !self.get_plan().constraints().collects_garbage {
+            warn!("User attempted a collection request, but the plan can not do GC. The request is ignored.");
+            return;
+        }
+
+        if force || !*self.options.ignore_system_gc {
+            info!("User triggering collection");
+            if exhaustive {
+                if let Some(gen) = self.get_plan().generational() {
+                    gen.force_full_heap_collection();
+                }
+            }
+
+            self.state.user_triggered_collection
+                .store(true, Ordering::Relaxed);
+            self.gc_requester.request();
+            VM::VMCollection::block_for_gc(tls);
+        }
+    }
+
+    /// MMTK has requested stop-the-world activity (e.g., stw within a concurrent gc).
+    // This is not used, as we do not have a concurrent plan.
+    #[allow(unused)]
+    pub fn trigger_internal_collection_request(&self) {
+        self.state.last_internal_triggered_collection
+            .store(true, Ordering::Relaxed);
+        self.state.internal_triggered_collection
+            .store(true, Ordering::Relaxed);
+        self.gc_requester.request();
     }
 
     pub fn get_plan(&self) -> &dyn Plan<VM = VM> {

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -113,7 +113,7 @@ pub struct MMTK<VM: VMBinding> {
     inside_harness: AtomicBool,
     #[cfg(feature = "sanity")]
     inside_sanity: AtomicBool,
-    /// Wrapper around analysis counters
+    /// Analysis counters. The feature analysis allows us to periodically stop the world and collect some statistics.
     #[cfg(feature = "analysis")]
     pub(crate) analysis_manager: Arc<AnalysisManager<VM>>,
 }

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -63,14 +63,11 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         }
     }
 
-    fn collection_required(&self) -> bool {
-        self.gen.collection_required(self)
-    }
-
-    fn notify_collection_required(&self, space_full: bool, space: Option<&dyn Space<Self::VM>>) {
-        if space_full && space.is_some() && self.is_nursery_space(space.unwrap()) {
-            self.force_full_heap_collection();
-        }
+    fn collection_required(&self, space_full: bool, space: Option<&dyn Space<Self::VM>>) -> bool
+    where
+        Self: Sized,
+    {
+        self.gen.collection_required(self, space_full, space)
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -87,7 +87,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         &ALLOCATOR_MAPPING
     }
 
-    fn prepare(&mut self, tls: VMWorkerThread) {
+    fn prepare(&self, tls: VMWorkerThread) {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.prepare(tls);
         if full_heap {
@@ -109,7 +109,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
             .rebind(self.tospace().clone());
     }
 
-    fn release(&mut self, tls: VMWorkerThread) {
+    fn release(&self, tls: VMWorkerThread) {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.release(tls);
         if full_heap {
@@ -117,7 +117,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         }
     }
 
-    fn end_of_gc(&mut self, _tls: VMWorkerThread) {
+    fn end_of_gc(&self, _tls: VMWorkerThread) {
         self.gen
             .set_next_gc_full_heap(CommonGenPlan::should_next_gc_be_full_heap(self));
     }

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -17,6 +17,7 @@ use crate::scheduler::*;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::VMRequest;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
@@ -34,10 +35,10 @@ pub struct GenCopy<VM: VMBinding> {
     pub hi: AtomicBool,
     #[space]
     #[copy_semantics(CopySemantics::Mature)]
-    pub copyspace0: CopySpace<VM>,
+    pub copyspace0: ArcFlexMut<CopySpace<VM>>,
     #[space]
     #[copy_semantics(CopySemantics::Mature)]
-    pub copyspace1: CopySpace<VM>,
+    pub copyspace1: ArcFlexMut<CopySpace<VM>>,
 }
 
 pub const GENCOPY_CONSTRAINTS: PlanConstraints = crate::plan::generational::GEN_CONSTRAINTS;
@@ -57,7 +58,10 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
             },
             space_mapping: vec![
                 // The tospace argument doesn't matter, we will rebind before a GC anyway.
-                (CopySelector::CopySpace(0), self.tospace()),
+                (
+                    CopySelector::CopySpace(0),
+                    self.tospace().clone().into_dyn_space(),
+                ),
             ],
             constraints: &GENCOPY_CONSTRAINTS,
         }
@@ -91,23 +95,25 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
                 .store(!self.hi.load(Ordering::SeqCst), Ordering::SeqCst); // flip the semi-spaces
         }
         let hi = self.hi.load(Ordering::SeqCst);
-        self.copyspace0.prepare(hi);
-        self.copyspace1.prepare(!hi);
+        self.copyspace0.read().prepare(hi);
+        self.copyspace1.read().prepare(!hi);
 
-        self.fromspace_mut()
+        self.fromspace()
+            .write()
             .set_copy_for_sft_trace(Some(CopySemantics::Mature));
-        self.tospace_mut().set_copy_for_sft_trace(None);
+        self.tospace().write().set_copy_for_sft_trace(None);
     }
 
     fn prepare_worker(&self, worker: &mut GCWorker<Self::VM>) {
-        unsafe { worker.get_copy_context_mut().copy[0].assume_init_mut() }.rebind(self.tospace());
+        unsafe { worker.get_copy_context_mut().copy[0].assume_init_mut() }
+            .rebind(self.tospace().clone());
     }
 
     fn release(&mut self, tls: VMWorkerThread) {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.release(tls);
         if full_heap {
-            self.fromspace().release();
+            self.fromspace().read().release();
         }
     }
 
@@ -117,11 +123,11 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
     }
 
     fn get_collection_reserved_pages(&self) -> usize {
-        self.gen.get_collection_reserved_pages() + self.tospace().reserved_pages()
+        self.gen.get_collection_reserved_pages() + self.tospace().read().reserved_pages()
     }
 
     fn get_used_pages(&self) -> usize {
-        self.gen.get_used_pages() + self.tospace().reserved_pages()
+        self.gen.get_used_pages() + self.tospace().read().reserved_pages()
     }
 
     /// Return the number of pages available for allocation. Assuming all future allocations goes to nursery.
@@ -156,23 +162,23 @@ impl<VM: VMBinding> GenerationalPlan for GenCopy<VM> {
     }
 
     fn is_object_in_nursery(&self, object: ObjectReference) -> bool {
-        self.gen.nursery.in_space(object)
+        self.gen.nursery.read().in_space(object)
     }
 
     fn is_nursery_space(&self, space: &dyn Space<Self::VM>) -> bool {
-        space.common().descriptor == self.gen.nursery.common().descriptor
+        space.common().descriptor == self.gen.nursery.read().common().descriptor
     }
 
     fn is_address_in_nursery(&self, addr: Address) -> bool {
-        self.gen.nursery.address_in_space(addr)
+        self.gen.nursery.read().address_in_space(addr)
     }
 
     fn get_mature_physical_pages_available(&self) -> usize {
-        self.tospace().available_physical_pages()
+        self.tospace().read().available_physical_pages()
     }
 
     fn get_mature_reserved_pages(&self) -> usize {
-        self.tospace().reserved_pages()
+        self.tospace().read().reserved_pages()
     }
 
     fn force_full_heap_collection(&self) {
@@ -204,14 +210,14 @@ impl<VM: VMBinding> GenCopy<VM> {
                 crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
         };
 
-        let copyspace0 = CopySpace::new(
+        let copyspace0 = ArcFlexMut::new(CopySpace::new(
             plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
             false,
-        );
-        let copyspace1 = CopySpace::new(
+        ));
+        let copyspace1 = ArcFlexMut::new(CopySpace::new(
             plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
             true,
-        );
+        ));
 
         let res = GenCopy {
             gen: CommonGenPlan::new(plan_args),
@@ -229,7 +235,7 @@ impl<VM: VMBinding> GenCopy<VM> {
         self.gen.requires_full_heap_collection(self)
     }
 
-    pub fn tospace(&self) -> &CopySpace<VM> {
+    pub fn tospace(&self) -> &ArcFlexMut<CopySpace<VM>> {
         if self.hi.load(Ordering::SeqCst) {
             &self.copyspace1
         } else {
@@ -237,27 +243,11 @@ impl<VM: VMBinding> GenCopy<VM> {
         }
     }
 
-    pub fn tospace_mut(&mut self) -> &mut CopySpace<VM> {
-        if self.hi.load(Ordering::SeqCst) {
-            &mut self.copyspace1
-        } else {
-            &mut self.copyspace0
-        }
-    }
-
-    pub fn fromspace(&self) -> &CopySpace<VM> {
+    pub fn fromspace(&self) -> &ArcFlexMut<CopySpace<VM>> {
         if self.hi.load(Ordering::SeqCst) {
             &self.copyspace0
         } else {
             &self.copyspace1
-        }
-    }
-
-    pub fn fromspace_mut(&mut self) -> &mut CopySpace<VM> {
-        if self.hi.load(Ordering::SeqCst) {
-            &mut self.copyspace0
-        } else {
-            &mut self.copyspace1
         }
     }
 }

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -8,7 +8,6 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::global_state::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -8,7 +8,7 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::plan::global::GcStatus;
+use crate::global_state::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;
@@ -73,8 +73,6 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
         let is_full_heap = self.requires_full_heap_collection();
-        self.base().set_collection_kind::<Self>(self);
-        self.base().set_gc_status(GcStatus::GcPrepare);
         if is_full_heap {
             scheduler.schedule_common_work::<GenCopyGCWorkContext<VM>>(self);
         } else {

--- a/src/plan/generational/copying/mutator.rs
+++ b/src/plan/generational/copying/mutator.rs
@@ -37,7 +37,7 @@ pub fn create_gencopy_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new(create_gen_space_mapping(
             mmtk.get_plan(),
-            &gencopy.gen.nursery,
+            gencopy.gen.nursery.clone(),
         )),
         prepare_func: &gencopy_mutator_prepare,
         release_func: &gencopy_mutator_release,

--- a/src/plan/generational/copying/mutator.rs
+++ b/src/plan/generational/copying/mutator.rs
@@ -44,7 +44,7 @@ pub fn create_gencopy_mutator<VM: VMBinding>(
     };
 
     Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk.get_plan(), &config.space_mapping),
+        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         barrier: Box::new(ObjectBarrier::new(GenObjectBarrierSemantics::new(
             mmtk, gencopy,
         ))),

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -46,9 +46,9 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
             ),
             true,
         );
+        let full_heap_gc_count = args.global_args.stats.new_event_counter("majorGC", true, true);
         let common = CommonPlan::new(args);
 
-        let full_heap_gc_count = common.base.stats.new_event_counter("majorGC", true, true);
 
         CommonGenPlan {
             nursery,
@@ -127,7 +127,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
             self.next_gc_full_heap.store(true, Ordering::SeqCst);
         }
 
-        self.common.base.collection_required(plan, space_full)
+        false
     }
 
     pub fn force_full_heap_collection(&self) {
@@ -151,7 +151,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
         } else if self
             .common
             .base
-            .user_triggered_collection
+            .global_state.user_triggered_collection
             .load(Ordering::SeqCst)
             && *self.common.base.options.full_heap_system_gc
         {
@@ -162,7 +162,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
             || self
                 .common
                 .base
-                .cur_collection_attempts
+                .global_state.cur_collection_attempts
                 .load(Ordering::SeqCst)
                 > 1
         {
@@ -171,7 +171,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
                 self.next_gc_full_heap.load(Ordering::SeqCst),
                 self.common
                     .base
-                    .cur_collection_attempts
+                    .global_state.cur_collection_attempts
                     .load(Ordering::SeqCst)
             );
             // Forces full heap collection

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -46,9 +46,11 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
             ),
             true,
         );
-        let full_heap_gc_count = args.global_args.stats.new_event_counter("majorGC", true, true);
+        let full_heap_gc_count = args
+            .global_args
+            .stats
+            .new_event_counter("majorGC", true, true);
         let common = CommonPlan::new(args);
-
 
         CommonGenPlan {
             nursery,
@@ -151,7 +153,8 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
         } else if self
             .common
             .base
-            .global_state.user_triggered_collection
+            .global_state
+            .user_triggered_collection
             .load(Ordering::SeqCst)
             && *self.common.base.options.full_heap_system_gc
         {
@@ -162,7 +165,8 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
             || self
                 .common
                 .base
-                .global_state.cur_collection_attempts
+                .global_state
+                .cur_collection_attempts
                 .load(Ordering::SeqCst)
                 > 1
         {
@@ -171,7 +175,8 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
                 self.next_gc_full_heap.load(Ordering::SeqCst),
                 self.common
                     .base
-                    .global_state.cur_collection_attempts
+                    .global_state
+                    .cur_collection_attempts
                     .load(Ordering::SeqCst)
             );
             // Forces full heap collection

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -63,7 +63,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
     }
 
     /// Prepare Gen. This should be called by a single thread in GC prepare work.
-    pub fn prepare(&mut self, tls: VMWorkerThread) {
+    pub fn prepare(&self, tls: VMWorkerThread) {
         let full_heap = !self.is_current_gc_nursery();
         if full_heap {
             self.full_heap_gc_count.lock().unwrap().inc();
@@ -75,7 +75,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
     }
 
     /// Release Gen. This should be called by a single thread in GC release work.
-    pub fn release(&mut self, tls: VMWorkerThread) {
+    pub fn release(&self, tls: VMWorkerThread) {
         let full_heap = !self.is_current_gc_nursery();
         self.common.release(tls, full_heap);
         self.nursery.write().release();

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -4,10 +4,10 @@ use crate::plan::ObjectQueue;
 use crate::plan::Plan;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::scheduler::*;
 use crate::util::copy::CopySemantics;
 use crate::util::heap::VMRequest;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::statistics::counter::EventCounter;
 use crate::util::Address;
 use crate::util::ObjectReference;
@@ -26,7 +26,7 @@ pub struct CommonGenPlan<VM: VMBinding> {
     /// The nursery space.
     #[space]
     #[copy_semantics(CopySemantics::PromoteToMature)]
-    pub nursery: SharedRef<CopySpace<VM>>,
+    pub nursery: ArcFlexMut<CopySpace<VM>>,
     /// The common plan.
     #[parent]
     pub common: CommonPlan<VM>,
@@ -54,7 +54,7 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
         let common = CommonPlan::new(args);
 
         CommonGenPlan {
-            nursery: SharedRef::new(nursery),
+            nursery: ArcFlexMut::new(nursery),
             common,
             gc_full_heap: AtomicBool::default(),
             next_gc_full_heap: AtomicBool::new(false),

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -89,14 +89,11 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
             )
     }
 
-    fn collection_required(&self) -> bool {
-        self.gen.collection_required(self)
-    }
-
-    fn notify_collection_required(&self, space_full: bool, space: Option<&dyn Space<Self::VM>>) {
-        if space_full && space.is_some() && self.is_nursery_space(space.unwrap()) {
-            self.force_full_heap_collection();
-        }
+    fn collection_required(&self, space_full: bool, space: Option<&dyn Space<Self::VM>>) -> bool
+    where
+        Self: Sized,
+    {
+        self.gen.collection_required(self, space_full, space)
     }
 
     // GenImmixMatureProcessEdges<VM, { TraceKind::Defrag }> and GenImmixMatureProcessEdges<VM, { TraceKind::Fast }>

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -18,6 +18,7 @@ use crate::scheduler::GCWorker;
 use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::copy::*;
 use crate::util::heap::VMRequest;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
@@ -43,7 +44,7 @@ pub struct GenImmix<VM: VMBinding> {
     #[post_scan]
     #[space]
     #[copy_semantics(CopySemantics::Mature)]
-    pub immix_space: ImmixSpace<VM>,
+    pub immix_space: ArcFlexMut<ImmixSpace<VM>>,
     /// Whether the last GC was a defrag GC for the immix space.
     pub last_gc_was_defrag: AtomicBool,
     /// Whether the last GC was a full heap GC
@@ -77,7 +78,10 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
                 CopySemantics::Mature => CopySelector::ImmixHybrid(0),
                 _ => CopySelector::Unused,
             },
-            space_mapping: vec![(CopySelector::ImmixHybrid(0), &self.immix_space)],
+            space_mapping: vec![(
+                CopySelector::ImmixHybrid(0),
+                self.immix_space.clone().into_dyn_space(),
+            )],
             constraints: &GENIMMIX_CONSTRAINTS,
         }
     }
@@ -112,7 +116,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
                 GenImmix<VM>,
                 GenImmixMatureGCWorkContext<VM, TRACE_KIND_FAST>,
                 GenImmixMatureGCWorkContext<VM, TRACE_KIND_DEFRAG>,
-            >(self, &self.immix_space, scheduler);
+            >(self, &self.immix_space.read(), scheduler);
         }
     }
 
@@ -124,7 +128,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.prepare(tls);
         if full_heap {
-            self.immix_space.prepare(
+            self.immix_space.write().prepare(
                 full_heap,
                 crate::policy::immix::defrag::PlanStatsForDefrag::collect(self),
             );
@@ -135,7 +139,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.release(tls);
         if full_heap {
-            let did_defrag = self.immix_space.release(full_heap);
+            let did_defrag = self.immix_space.write().release(full_heap);
             self.last_gc_was_defrag.store(did_defrag, Ordering::Relaxed);
         } else {
             self.last_gc_was_defrag.store(false, Ordering::Relaxed);
@@ -150,11 +154,11 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
     }
 
     fn get_collection_reserved_pages(&self) -> usize {
-        self.gen.get_collection_reserved_pages() + self.immix_space.defrag_headroom_pages()
+        self.gen.get_collection_reserved_pages() + self.immix_space.read().defrag_headroom_pages()
     }
 
     fn get_used_pages(&self) -> usize {
-        self.gen.get_used_pages() + self.immix_space.reserved_pages()
+        self.gen.get_used_pages() + self.immix_space.read().reserved_pages()
     }
 
     /// Return the number of pages available for allocation. Assuming all future allocations goes to nursery.
@@ -189,23 +193,23 @@ impl<VM: VMBinding> GenerationalPlan for GenImmix<VM> {
     }
 
     fn is_object_in_nursery(&self, object: ObjectReference) -> bool {
-        self.gen.nursery.in_space(object)
+        self.gen.nursery.read().in_space(object)
     }
 
     fn is_nursery_space(&self, space: &dyn Space<Self::VM>) -> bool {
-        space.common().descriptor == self.gen.nursery.common().descriptor
+        space.common().descriptor == self.gen.nursery.read().common().descriptor
     }
 
     fn is_address_in_nursery(&self, addr: Address) -> bool {
-        self.gen.nursery.address_in_space(addr)
+        self.gen.nursery.read().address_in_space(addr)
     }
 
     fn get_mature_physical_pages_available(&self) -> usize {
-        self.immix_space.available_physical_pages()
+        self.immix_space.read().available_physical_pages()
     }
 
     fn get_mature_reserved_pages(&self) -> usize {
-        self.immix_space.reserved_pages()
+        self.immix_space.read().reserved_pages()
     }
 
     fn force_full_heap_collection(&self) {
@@ -236,7 +240,7 @@ impl<VM: VMBinding> GenImmix<VM> {
             global_side_metadata_specs:
                 crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
         };
-        let immix_space = ImmixSpace::new(
+        let immix_space = ArcFlexMut::new(ImmixSpace::new(
             plan_args.get_space_args("immix_mature", true, VMRequest::discontiguous()),
             ImmixSpaceArgs {
                 reset_log_bit_in_major_gc: false,
@@ -246,7 +250,7 @@ impl<VM: VMBinding> GenImmix<VM> {
                 // In GenImmix, young objects are not allocated in ImmixSpace directly.
                 mixed_age: false,
             },
-        );
+        ));
 
         let genimmix = GenImmix {
             gen: CommonGenPlan::new(plan_args),

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -124,7 +124,10 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.prepare(tls);
         if full_heap {
-            self.immix_space.prepare(full_heap);
+            self.immix_space.prepare(
+                full_heap,
+                crate::policy::immix::defrag::PlanStatsForDefrag::collect(self),
+            );
         }
     }
 

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -6,7 +6,7 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::plan::global::GcStatus;
+use crate::global_state::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;
@@ -104,9 +104,6 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
     #[allow(clippy::branches_sharing_code)]
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<Self::VM>) {
         let is_full_heap = self.requires_full_heap_collection();
-
-        self.base().set_collection_kind::<Self>(self);
-        self.base().set_gc_status(GcStatus::GcPrepare);
 
         if !is_full_heap {
             debug!("Nursery GC");

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -6,7 +6,6 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::global_state::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -89,11 +89,14 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
             )
     }
 
-    fn collection_required(&self, space_full: bool, space: Option<&dyn Space<Self::VM>>) -> bool
-    where
-        Self: Sized,
-    {
-        self.gen.collection_required(self, space_full, space)
+    fn collection_required(&self) -> bool {
+        self.gen.collection_required(self)
+    }
+
+    fn notify_collection_required(&self, space_full: bool, space: Option<&dyn Space<Self::VM>>) {
+        if space_full && space.is_some() && self.is_nursery_space(space.unwrap()) {
+            self.force_full_heap_collection();
+        }
     }
 
     // GenImmixMatureProcessEdges<VM, { TraceKind::Defrag }> and GenImmixMatureProcessEdges<VM, { TraceKind::Fast }>
@@ -190,6 +193,10 @@ impl<VM: VMBinding> GenerationalPlan for GenImmix<VM> {
 
     fn is_object_in_nursery(&self, object: ObjectReference) -> bool {
         self.gen.nursery.in_space(object)
+    }
+
+    fn is_nursery_space(&self, space: &dyn Space<Self::VM>) -> bool {
+        space.common().descriptor == self.gen.nursery.common().descriptor
     }
 
     fn is_address_in_nursery(&self, addr: Address) -> bool {

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -124,7 +124,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         &super::mutator::ALLOCATOR_MAPPING
     }
 
-    fn prepare(&mut self, tls: VMWorkerThread) {
+    fn prepare(&self, tls: VMWorkerThread) {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.prepare(tls);
         if full_heap {
@@ -135,7 +135,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         }
     }
 
-    fn release(&mut self, tls: VMWorkerThread) {
+    fn release(&self, tls: VMWorkerThread) {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.release(tls);
         if full_heap {
@@ -148,7 +148,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
             .store(full_heap, Ordering::Relaxed);
     }
 
-    fn end_of_gc(&mut self, _tls: VMWorkerThread) {
+    fn end_of_gc(&self, _tls: VMWorkerThread) {
         self.gen
             .set_next_gc_full_heap(CommonGenPlan::should_next_gc_be_full_heap(self));
     }

--- a/src/plan/generational/immix/mutator.rs
+++ b/src/plan/generational/immix/mutator.rs
@@ -35,7 +35,7 @@ pub fn create_genimmix_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new(create_gen_space_mapping(
             mmtk.get_plan(),
-            &genimmix.gen.nursery,
+            genimmix.gen.nursery.clone(),
         )),
         prepare_func: &genimmix_mutator_prepare,
         release_func: &genimmix_mutator_release,

--- a/src/plan/generational/immix/mutator.rs
+++ b/src/plan/generational/immix/mutator.rs
@@ -42,7 +42,7 @@ pub fn create_genimmix_mutator<VM: VMBinding>(
     };
 
     Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk.get_plan(), &config.space_mapping),
+        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         barrier: Box::new(ObjectBarrier::new(GenObjectBarrierSemantics::new(
             mmtk, genimmix,
         ))),

--- a/src/plan/generational/mod.rs
+++ b/src/plan/generational/mod.rs
@@ -8,7 +8,7 @@ use crate::plan::AllocationSemantics;
 use crate::plan::PlanConstraints;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
-use crate::policy::space_ref::SpaceRef;
+use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::alloc::AllocatorSelector;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
@@ -85,9 +85,9 @@ lazy_static! {
 
 fn create_gen_space_mapping<VM: VMBinding>(
     plan: &'static dyn Plan<VM = VM>,
-    nursery: SpaceRef<CopySpace<VM>>,
-) -> Vec<(AllocatorSelector, SpaceRef<dyn Space<VM> + Send>)> {
+    nursery: SharedRef<CopySpace<VM>>,
+) -> Vec<(AllocatorSelector, SharedRef<dyn Space<VM>>)> {
     let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, plan);
-    vec.push((AllocatorSelector::BumpPointer(0), nursery));
+    vec.push((AllocatorSelector::BumpPointer(0), nursery.to_dyn_space()));
     vec
 }

--- a/src/plan/generational/mod.rs
+++ b/src/plan/generational/mod.rs
@@ -8,6 +8,7 @@ use crate::plan::AllocationSemantics;
 use crate::plan::PlanConstraints;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
+use crate::policy::space_ref::SpaceRef;
 use crate::util::alloc::AllocatorSelector;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
@@ -21,10 +22,10 @@ use super::mutator_context::ReservedAllocators;
 // Generational plans:
 
 pub mod barrier;
-/// Generational copying (GenCopy)
-pub mod copying;
-/// Generational immix (GenImmix)
-pub mod immix;
+// /// Generational copying (GenCopy)
+// pub mod copying;
+// /// Generational immix (GenImmix)
+// pub mod immix;
 
 // Common generational code
 
@@ -84,8 +85,8 @@ lazy_static! {
 
 fn create_gen_space_mapping<VM: VMBinding>(
     plan: &'static dyn Plan<VM = VM>,
-    nursery: &'static CopySpace<VM>,
-) -> Vec<(AllocatorSelector, &'static dyn Space<VM>)> {
+    nursery: SpaceRef<CopySpace<VM>>,
+) -> Vec<(AllocatorSelector, SpaceRef<dyn Space<VM> + Send>)> {
     let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, plan);
     vec.push((AllocatorSelector::BumpPointer(0), nursery));
     vec

--- a/src/plan/generational/mod.rs
+++ b/src/plan/generational/mod.rs
@@ -8,10 +8,10 @@ use crate::plan::AllocationSemantics;
 use crate::plan::PlanConstraints;
 use crate::policy::copyspace::CopySpace;
 use crate::policy::space::Space;
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::alloc::AllocatorSelector;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use crate::Plan;
@@ -22,10 +22,10 @@ use super::mutator_context::ReservedAllocators;
 // Generational plans:
 
 pub mod barrier;
-// /// Generational copying (GenCopy)
-// pub mod copying;
-// /// Generational immix (GenImmix)
-// pub mod immix;
+/// Generational copying (GenCopy)
+pub mod copying;
+/// Generational immix (GenImmix)
+pub mod immix;
 
 // Common generational code
 
@@ -85,9 +85,9 @@ lazy_static! {
 
 fn create_gen_space_mapping<VM: VMBinding>(
     plan: &'static dyn Plan<VM = VM>,
-    nursery: SharedRef<CopySpace<VM>>,
-) -> Vec<(AllocatorSelector, SharedRef<dyn Space<VM>>)> {
+    nursery: ArcFlexMut<CopySpace<VM>>,
+) -> Vec<(AllocatorSelector, ArcFlexMut<dyn Space<VM>>)> {
     let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, plan);
-    vec.push((AllocatorSelector::BumpPointer(0), nursery.to_dyn_space()));
+    vec.push((AllocatorSelector::BumpPointer(0), nursery.into_dyn_space()));
     vec
 }

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -8,6 +8,7 @@ use crate::plan::Mutator;
 use crate::policy::immortalspace::ImmortalSpace;
 use crate::policy::largeobjectspace::LargeObjectSpace;
 use crate::policy::space::{PlanCreateSpaceArgs, Space};
+use crate::policy::space_ref::SpaceRef;
 #[cfg(feature = "vm_space")]
 use crate::policy::vmspace::VMSpace;
 use crate::scheduler::*;
@@ -38,25 +39,26 @@ pub fn create_mutator<VM: VMBinding>(
     mmtk: &'static MMTK<VM>,
 ) -> Box<Mutator<VM>> {
     Box::new(match *mmtk.options.plan {
-        PlanSelector::NoGC => crate::plan::nogc::mutator::create_nogc_mutator(tls, mmtk),
-        PlanSelector::SemiSpace => crate::plan::semispace::mutator::create_ss_mutator(tls, mmtk),
-        PlanSelector::GenCopy => {
-            crate::plan::generational::copying::mutator::create_gencopy_mutator(tls, mmtk)
-        }
-        PlanSelector::GenImmix => {
-            crate::plan::generational::immix::mutator::create_genimmix_mutator(tls, mmtk)
-        }
-        PlanSelector::MarkSweep => crate::plan::marksweep::mutator::create_ms_mutator(tls, mmtk),
+        // PlanSelector::NoGC => crate::plan::nogc::mutator::create_nogc_mutator(tls, mmtk),
+        // PlanSelector::SemiSpace => crate::plan::semispace::mutator::create_ss_mutator(tls, mmtk),
+        // PlanSelector::GenCopy => {
+        //     crate::plan::generational::copying::mutator::create_gencopy_mutator(tls, mmtk)
+        // }
+        // PlanSelector::GenImmix => {
+        //     crate::plan::generational::immix::mutator::create_genimmix_mutator(tls, mmtk)
+        // }
+        // PlanSelector::MarkSweep => crate::plan::marksweep::mutator::create_ms_mutator(tls, mmtk),
         PlanSelector::Immix => crate::plan::immix::mutator::create_immix_mutator(tls, mmtk),
-        PlanSelector::PageProtect => {
-            crate::plan::pageprotect::mutator::create_pp_mutator(tls, mmtk)
-        }
-        PlanSelector::MarkCompact => {
-            crate::plan::markcompact::mutator::create_markcompact_mutator(tls, mmtk)
-        }
-        PlanSelector::StickyImmix => {
-            crate::plan::sticky::immix::mutator::create_stickyimmix_mutator(tls, mmtk)
-        }
+        // PlanSelector::PageProtect => {
+        //     crate::plan::pageprotect::mutator::create_pp_mutator(tls, mmtk)
+        // }
+        // PlanSelector::MarkCompact => {
+        //     crate::plan::markcompact::mutator::create_markcompact_mutator(tls, mmtk)
+        // }
+        // PlanSelector::StickyImmix => {
+        //     crate::plan::sticky::immix::mutator::create_stickyimmix_mutator(tls, mmtk)
+        // }
+        _ => unimplemented!()
     })
 }
 
@@ -65,31 +67,32 @@ pub fn create_plan<VM: VMBinding>(
     args: CreateGeneralPlanArgs<VM>,
 ) -> Box<dyn Plan<VM = VM>> {
     let plan = match plan {
-        PlanSelector::NoGC => {
-            Box::new(crate::plan::nogc::NoGC::new(args)) as Box<dyn Plan<VM = VM>>
-        }
-        PlanSelector::SemiSpace => {
-            Box::new(crate::plan::semispace::SemiSpace::new(args)) as Box<dyn Plan<VM = VM>>
-        }
-        PlanSelector::GenCopy => Box::new(crate::plan::generational::copying::GenCopy::new(args))
-            as Box<dyn Plan<VM = VM>>,
-        PlanSelector::GenImmix => Box::new(crate::plan::generational::immix::GenImmix::new(args))
-            as Box<dyn Plan<VM = VM>>,
-        PlanSelector::MarkSweep => {
-            Box::new(crate::plan::marksweep::MarkSweep::new(args)) as Box<dyn Plan<VM = VM>>
-        }
+        // PlanSelector::NoGC => {
+        //     Box::new(crate::plan::nogc::NoGC::new(args)) as Box<dyn Plan<VM = VM>>
+        // }
+        // PlanSelector::SemiSpace => {
+        //     Box::new(crate::plan::semispace::SemiSpace::new(args)) as Box<dyn Plan<VM = VM>>
+        // }
+        // PlanSelector::GenCopy => Box::new(crate::plan::generational::copying::GenCopy::new(args))
+        //     as Box<dyn Plan<VM = VM>>,
+        // PlanSelector::GenImmix => Box::new(crate::plan::generational::immix::GenImmix::new(args))
+        //     as Box<dyn Plan<VM = VM>>,
+        // PlanSelector::MarkSweep => {
+        //     Box::new(crate::plan::marksweep::MarkSweep::new(args)) as Box<dyn Plan<VM = VM>>
+        // }
         PlanSelector::Immix => {
             Box::new(crate::plan::immix::Immix::new(args)) as Box<dyn Plan<VM = VM>>
         }
-        PlanSelector::PageProtect => {
-            Box::new(crate::plan::pageprotect::PageProtect::new(args)) as Box<dyn Plan<VM = VM>>
-        }
-        PlanSelector::MarkCompact => {
-            Box::new(crate::plan::markcompact::MarkCompact::new(args)) as Box<dyn Plan<VM = VM>>
-        }
-        PlanSelector::StickyImmix => {
-            Box::new(crate::plan::sticky::immix::StickyImmix::new(args)) as Box<dyn Plan<VM = VM>>
-        }
+        // PlanSelector::PageProtect => {
+        //     Box::new(crate::plan::pageprotect::PageProtect::new(args)) as Box<dyn Plan<VM = VM>>
+        // }
+        // PlanSelector::MarkCompact => {
+        //     Box::new(crate::plan::markcompact::MarkCompact::new(args)) as Box<dyn Plan<VM = VM>>
+        // }
+        // PlanSelector::StickyImmix => {
+        //     Box::new(crate::plan::sticky::immix::StickyImmix::new(args)) as Box<dyn Plan<VM = VM>>
+        // }
+        _ => unimplemented!()
     };
 
     // We have created Plan in the heap, and we won't explicitly move it.
@@ -539,12 +542,12 @@ CommonPlan is for representing state and features used by _many_ plans, but that
 #[derive(HasSpaces, PlanTraceObject)]
 pub struct CommonPlan<VM: VMBinding> {
     #[space]
-    pub immortal: ImmortalSpace<VM>,
+    pub immortal: SpaceRef<ImmortalSpace<VM>>,
     #[space]
-    pub los: LargeObjectSpace<VM>,
+    pub los: SpaceRef<LargeObjectSpace<VM>>,
     // TODO: We should use a marksweep space for nonmoving.
     #[space]
-    pub nonmoving: ImmortalSpace<VM>,
+    pub nonmoving: SpaceRef<ImmortalSpace<VM>>,
     #[parent]
     pub base: BasePlan<VM>,
 }
@@ -552,28 +555,28 @@ pub struct CommonPlan<VM: VMBinding> {
 impl<VM: VMBinding> CommonPlan<VM> {
     pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> CommonPlan<VM> {
         CommonPlan {
-            immortal: ImmortalSpace::new(args.get_space_args(
+            immortal: crate::policy::space_ref::new(ImmortalSpace::new(args.get_space_args(
                 "immortal",
                 true,
                 VMRequest::discontiguous(),
-            )),
-            los: LargeObjectSpace::new(
+            ))),
+            los: crate::policy::space_ref::new(LargeObjectSpace::new(
                 args.get_space_args("los", true, VMRequest::discontiguous()),
                 false,
-            ),
-            nonmoving: ImmortalSpace::new(args.get_space_args(
+            )),
+            nonmoving: crate::policy::space_ref::new(ImmortalSpace::new(args.get_space_args(
                 "nonmoving",
                 true,
                 VMRequest::discontiguous(),
-            )),
+            ))),
             base: BasePlan::new(args),
         }
     }
 
     pub fn get_used_pages(&self) -> usize {
-        self.immortal.reserved_pages()
-            + self.los.reserved_pages()
-            + self.nonmoving.reserved_pages()
+        crate::space_ref_read!(&self.immortal).reserved_pages()
+            + crate::space_ref_read!(&self.los).reserved_pages()
+            + crate::space_ref_read!(&self.nonmoving).reserved_pages()
             + self.base.get_used_pages()
     }
 
@@ -583,45 +586,60 @@ impl<VM: VMBinding> CommonPlan<VM> {
         object: ObjectReference,
         worker: &mut GCWorker<VM>,
     ) -> ObjectReference {
-        if self.immortal.in_space(object) {
-            trace!("trace_object: object in immortal space");
-            return self.immortal.trace_object(queue, object);
+        {
+            let space = crate::space_ref_read!(&self.immortal);
+            if space.in_space(object) {
+                trace!("trace_object: object in immortal space");
+                return space.trace_object(queue, object);
+            }
         }
-        if self.los.in_space(object) {
-            trace!("trace_object: object in los");
-            return self.los.trace_object(queue, object);
+        {
+            let space = crate::space_ref_read!(&self.los);
+            if space.in_space(object) {
+                trace!("trace_object: object in los space");
+                return space.trace_object(queue, object);
+            }
         }
-        if self.nonmoving.in_space(object) {
-            trace!("trace_object: object in nonmoving space");
-            return self.nonmoving.trace_object(queue, object);
+        {
+            let space = crate::space_ref_read!(&self.nonmoving);
+            if space.in_space(object) {
+                trace!("trace_object: object in nonmoving space");
+                return space.trace_object(queue, object);
+            }
         }
         self.base.trace_object::<Q>(queue, object, worker)
     }
 
     pub fn prepare(&mut self, tls: VMWorkerThread, full_heap: bool) {
-        self.immortal.prepare();
-        self.los.prepare(full_heap);
-        self.nonmoving.prepare();
+        {
+            let mut space = crate::space_ref_write!(&self.immortal);
+            space.prepare();
+        }
+        {
+            let mut space = crate::space_ref_write!(&self.los);
+            space.prepare(full_heap);
+        }
+        {
+            let mut space = crate::space_ref_write!(&self.nonmoving);
+            space.prepare();
+        }
         self.base.prepare(tls, full_heap)
     }
 
     pub fn release(&mut self, tls: VMWorkerThread, full_heap: bool) {
-        self.immortal.release();
-        self.los.release(full_heap);
-        self.nonmoving.release();
+        {
+            let mut space = crate::space_ref_write!(&self.immortal);
+            space.release();
+        }
+        {
+            let mut space = crate::space_ref_write!(&self.los);
+            space.release(full_heap);
+        }
+        {
+            let mut space = crate::space_ref_write!(&self.nonmoving);
+            space.release();
+        }
         self.base.release(tls, full_heap)
-    }
-
-    pub fn get_immortal(&self) -> &ImmortalSpace<VM> {
-        &self.immortal
-    }
-
-    pub fn get_los(&self) -> &LargeObjectSpace<VM> {
-        &self.los
-    }
-
-    pub fn get_nonmoving(&self) -> &ImmortalSpace<VM> {
-        &self.nonmoving
     }
 }
 
@@ -656,7 +674,7 @@ pub trait HasSpaces {
     ///
     /// If `Self` contains nested fields that contain more spaces, this method shall visit spaces
     /// in the outer struct first.
-    fn for_each_space_mut(&mut self, func: &mut dyn FnMut(&mut dyn Space<Self::VM>));
+    fn for_each_space_mut(&self, func: &mut dyn FnMut(&mut dyn Space<Self::VM>));
 }
 
 /// A plan that uses `PlanProcessEdges` needs to provide an implementation for this trait.

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -203,12 +203,20 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
     /// periodically during allocation. This method only needs to do plan-specific checks to see if it requires a GC,
     /// and the return value indicates if the plan would like to require a GC.
     /// If the method returns false, the GC trigger may still trigger a GC based on some general checks.
-    /// General checks are done in [`crate::util::heap::gc_trigger::GCTrigger::is_gc_required`].
+    /// General checks are done in `crate::util::heap::gc_trigger::GCTrigger::is_gc_required`.
+    fn collection_required(&self) -> bool {
+        false
+    }
+
+    /// Notify a plan that a collection will be triggered. This is called when the GC trigger decides to trigger
+    /// a GC.
     ///
     /// # Arguments
     /// * `space_full`: the allocation to a specific space failed, must recover pages within 'space'.
     /// * `space`: an option to indicate if there is a space that has failed in an allocation.
-    fn collection_required(&self, space_full: bool, space: Option<&dyn Space<Self::VM>>) -> bool;
+    fn notify_collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) {
+        // Do nothing.
+    }
 
     // Note: The following methods are about page accounting. The default implementation should
     // work fine for non-copying plans. For copying plans, the plan should override any of these methods

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -168,7 +168,7 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
 
     /// Prepare the plan before a GC. This is invoked in an initial step in the GC.
     /// This is invoked once per GC by one worker thread. `tls` is the worker thread that executes this method.
-    fn prepare(&mut self, tls: VMWorkerThread);
+    fn prepare(&self, tls: VMWorkerThread);
 
     /// Prepare a worker for a GC. Each worker has its own prepare method. This hook is for plan-specific
     /// per-worker preparation. This method is invoked once per worker by the worker thread passed as the argument.
@@ -177,11 +177,11 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
     /// Release the plan after transitive closure. A plan can implement this method to call each policy's release,
     /// or create any work packet that should be done in release.
     /// This is invoked once per GC by one worker thread. `tls` is the worker thread that executes this method.
-    fn release(&mut self, tls: VMWorkerThread);
+    fn release(&self, tls: VMWorkerThread);
 
     /// Inform the plan about the end of a GC. It is guaranteed that there is no further work for this GC.
     /// This is invoked once per GC by one worker thread. `tls` is the worker thread that executes this method.
-    fn end_of_gc(&mut self, _tls: VMWorkerThread) {}
+    fn end_of_gc(&self, _tls: VMWorkerThread) {}
 
     fn notify_emergency_collection(&self) {
         if let Some(gen) = self.generational() {
@@ -481,7 +481,7 @@ impl<VM: VMBinding> BasePlan<VM> {
         VM::VMActivePlan::vm_trace_object::<Q>(queue, object, worker)
     }
 
-    pub fn prepare(&mut self, _tls: VMWorkerThread, _full_heap: bool) {
+    pub fn prepare(&self, _tls: VMWorkerThread, _full_heap: bool) {
         #[cfg(feature = "code_space")]
         self.code_space.write().prepare();
         #[cfg(feature = "code_space")]
@@ -492,7 +492,7 @@ impl<VM: VMBinding> BasePlan<VM> {
         self.vm_space.write().prepare();
     }
 
-    pub fn release(&mut self, _tls: VMWorkerThread, _full_heap: bool) {
+    pub fn release(&self, _tls: VMWorkerThread, _full_heap: bool) {
         #[cfg(feature = "code_space")]
         self.code_space.write().release();
         #[cfg(feature = "code_space")]
@@ -608,7 +608,7 @@ impl<VM: VMBinding> CommonPlan<VM> {
         self.base.trace_object::<Q>(queue, object, worker)
     }
 
-    pub fn prepare(&mut self, tls: VMWorkerThread, full_heap: bool) {
+    pub fn prepare(&self, tls: VMWorkerThread, full_heap: bool) {
         {
             let mut space = self.immortal.write();
             space.prepare();
@@ -624,7 +624,7 @@ impl<VM: VMBinding> CommonPlan<VM> {
         self.base.prepare(tls, full_heap)
     }
 
-    pub fn release(&mut self, tls: VMWorkerThread, full_heap: bool) {
+    pub fn release(&self, tls: VMWorkerThread, full_heap: bool) {
         {
             let mut space = self.immortal.write();
             space.release();

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -2,6 +2,7 @@
 
 use super::gc_requester::GCRequester;
 use super::PlanConstraints;
+use crate::global_state::GlobalState;
 use crate::mmtk::MMTK;
 use crate::plan::tracing::ObjectQueue;
 use crate::plan::Mutator;
@@ -30,6 +31,7 @@ use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::*;
 use downcast_rs::Downcast;
 use enum_map::EnumMap;
+use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -73,17 +75,22 @@ pub fn create_plan<VM: VMBinding>(
     vm_map: &'static dyn VMMap,
     mmapper: &'static dyn Mmapper,
     options: Arc<Options>,
+    state: Arc<GlobalState>,
+    gc_trigger: Arc<GCTrigger<VM>>,
     scheduler: Arc<GCWorkScheduler<VM>>,
+    stats: &Stats,
+    heap: &mut HeapMeta,
 ) -> Box<dyn Plan<VM = VM>> {
     let args = CreateGeneralPlanArgs {
         vm_map,
         mmapper,
-        heap: HeapMeta::new(),
-        gc_trigger: Arc::new(GCTrigger::new(&options)),
         options,
+        state,
+        gc_trigger,
         scheduler,
+        stats,
+        heap,
     };
-    let gc_trigger = args.gc_trigger.clone();
 
     let plan = match plan {
         PlanSelector::NoGC => {
@@ -116,15 +123,15 @@ pub fn create_plan<VM: VMBinding>(
     // We have created Plan in the heap, and we won't explicitly move it.
 
     // The plan has a fixed address. Set plan in gc_trigger
-    {
-        // We haven't finished creating the plan. No one is using the GC trigger. We cast the arc into a mutable reference.
-        // TODO: use Arc::get_mut_unchecked() when it is availble.
-        let gc_trigger: &mut GCTrigger<VM> = unsafe { &mut *(Arc::as_ptr(&gc_trigger) as *mut _) };
-        // We know the plan address will not change. Cast it to a static reference.
-        let static_plan: &'static dyn Plan<VM = VM> = unsafe { &*(&*plan as *const _) };
-        // Set the plan so we can trigger GC and check GC condition without using plan
-        gc_trigger.set_plan(static_plan);
-    }
+    // {
+    //     // We haven't finished creating the plan. No one is using the GC trigger. We cast the arc into a mutable reference.
+    //     // TODO: use Arc::get_mut_unchecked() when it is availble.
+    //     let gc_trigger: &mut GCTrigger<VM> = unsafe { &mut *(Arc::as_ptr(&gc_trigger) as *mut _) };
+    //     // We know the plan address will not change. Cast it to a static reference.
+    //     let static_plan: &'static dyn Plan<VM = VM> = unsafe { &*(&*plan as *const _) };
+    //     // Set the plan so we can trigger GC and check GC condition without using plan
+    //     gc_trigger.set_plan(static_plan);
+    // }
 
     // Each space now has a fixed address for its lifetime. It is safe now to initialize SFT.
     let sft_map: &mut dyn crate::policy::sft_map::SFTMap =
@@ -198,27 +205,12 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector>;
 
-    #[cfg(feature = "sanity")]
-    fn enter_sanity(&self) {
-        self.base().inside_sanity.store(true, Ordering::Relaxed)
-    }
-
-    #[cfg(feature = "sanity")]
-    fn leave_sanity(&self) {
-        self.base().inside_sanity.store(false, Ordering::Relaxed)
-    }
-
-    #[cfg(feature = "sanity")]
-    fn is_in_sanity(&self) -> bool {
-        self.base().inside_sanity.load(Ordering::Relaxed)
-    }
-
     fn is_initialized(&self) -> bool {
-        self.base().initialized.load(Ordering::SeqCst)
+        self.base().global_state.initialized.load(Ordering::SeqCst)
     }
 
     fn should_trigger_gc_when_heap_is_full(&self) -> bool {
-        self.base()
+        self.base().global_state
             .trigger_gc_when_heap_is_full
             .load(Ordering::SeqCst)
     }
@@ -240,9 +232,17 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
     /// This is invoked once per GC by one worker thread. `tls` is the worker thread that executes this method.
     fn end_of_gc(&mut self, _tls: VMWorkerThread) {}
 
-    /// Ask the plan if they would trigger a GC. If MMTk is in charge of triggering GCs, this method is called
-    /// periodically during allocation. However, MMTk may delegate the GC triggering decision to the runtime,
-    /// in which case, this method may not be called. This method returns true to trigger a collection.
+    fn notify_emergency_collection(&self) {
+        if let Some(gen) = self.generational() {
+            gen.force_full_heap_collection();
+        }
+    }
+
+    /// Ask the plan if they would trigger a GC. If MMTk is in charge of triggering GCs, this method will be called
+    /// periodically during allocation. This method only needs to do plan-specific checks to see if it requires a GC,
+    /// and the return value indicates if the plan would like to require a GC.
+    /// If the method returns false, the GC trigger may still trigger a GC based on some general checks.
+    /// General checks are done in [`crate::util::heap::gc_trigger::GCTrigger::is_gc_required`].
     ///
     /// # Arguments
     /// * `space_full`: the allocation to a specific space failed, must recover pages within 'space'.
@@ -325,27 +325,27 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
         self.get_total_pages() - self.get_used_pages()
     }
 
-    fn is_emergency_collection(&self) -> bool {
-        self.base().emergency_collection.load(Ordering::Relaxed)
-    }
+    // fn is_emergency_collection(&self) -> bool {
+    //     self.base().emergency_collection.load(Ordering::Relaxed)
+    // }
 
-    /// The application code has requested a collection. This is just a GC hint, and
-    /// we may ignore it.
-    ///
-    /// # Arguments
-    /// * `tls`: The mutator thread that requests the GC
-    /// * `force`: The request cannot be ignored (except for NoGC)
-    /// * `exhaustive`: The requested GC should be exhaustive. This is also a hint.
-    fn handle_user_collection_request(&self, tls: VMMutatorThread, force: bool, exhaustive: bool) {
-        // For exhaustive on generational plans, we force a full heap GC.
-        // A plan may implement this method themselves to handle the exhaustive GC.
-        if exhaustive {
-            if let Some(gen) = self.generational() {
-                gen.force_full_heap_collection();
-            }
-        }
-        self.base().handle_user_collection_request(tls, force)
-    }
+    // /// The application code has requested a collection. This is just a GC hint, and
+    // /// we may ignore it.
+    // ///
+    // /// # Arguments
+    // /// * `tls`: The mutator thread that requests the GC
+    // /// * `force`: The request cannot be ignored (except for NoGC)
+    // /// * `exhaustive`: The requested GC should be exhaustive. This is also a hint.
+    // fn handle_user_collection_request(&self, tls: VMMutatorThread, force: bool, exhaustive: bool) {
+    //     // For exhaustive on generational plans, we force a full heap GC.
+    //     // A plan may implement this method themselves to handle the exhaustive GC.
+    //     if exhaustive {
+    //         if let Some(gen) = self.generational() {
+    //             gen.force_full_heap_collection();
+    //         }
+    //     }
+    //     self.base().handle_user_collection_request(tls, force)
+    // }
 
     /// Return whether last GC was an exhaustive attempt to collect the heap.
     /// For example, for generational GCs, minor collection is not an exhaustive collection.
@@ -356,7 +356,7 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
 
     fn modify_check(&self, object: ObjectReference) {
         assert!(
-            !(self.base().gc_in_progress_proper() && object.is_movable()),
+            !(self.base().global_state.gc_in_progress_proper() && object.is_movable()),
             "GC modifying a potentially moving object via Java (i.e. not magic) obj= {}",
             object
         );
@@ -382,56 +382,57 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
 
 impl_downcast!(Plan assoc VM);
 
-#[derive(PartialEq)]
-pub enum GcStatus {
-    NotInGC,
-    GcPrepare,
-    GcProper,
-}
+// #[derive(PartialEq)]
+// pub enum GcStatus {
+//     NotInGC,
+//     GcPrepare,
+//     GcProper,
+// }
 
 /**
 BasePlan should contain all plan-related state and functions that are _fundamental_ to _all_ plans.  These include VM-specific (but not plan-specific) features such as a code space or vm space, which are fundamental to all plans for a given VM.  Features that are common to _many_ (but not intrinsically _all_) plans should instead be included in CommonPlan.
 */
 #[derive(HasSpaces, PlanTraceObject)]
 pub struct BasePlan<VM: VMBinding> {
-    /// Whether MMTk is now ready for collection. This is set to true when initialize_collection() is called.
-    pub initialized: AtomicBool,
-    /// Should we trigger a GC when the heap is full? It seems this should always be true. However, we allow
-    /// bindings to temporarily disable GC, at which point, we do not trigger GC even if the heap is full.
-    pub trigger_gc_when_heap_is_full: AtomicBool,
-    pub gc_status: Mutex<GcStatus>,
-    pub last_stress_pages: AtomicUsize,
-    pub emergency_collection: AtomicBool,
-    pub user_triggered_collection: AtomicBool,
-    pub internal_triggered_collection: AtomicBool,
-    pub last_internal_triggered_collection: AtomicBool,
+    pub(crate) global_state: Arc<GlobalState>,
+
+    // /// Whether MMTk is now ready for collection. This is set to true when initialize_collection() is called.
+    // pub initialized: AtomicBool,
+    // /// Should we trigger a GC when the heap is full? It seems this should always be true. However, we allow
+    // /// bindings to temporarily disable GC, at which point, we do not trigger GC even if the heap is full.
+    // pub trigger_gc_when_heap_is_full: AtomicBool,
+    // pub gc_status: Mutex<GcStatus>,
+    // pub last_stress_pages: AtomicUsize,
+    // pub emergency_collection: AtomicBool,
+    // pub user_triggered_collection: AtomicBool,
+    // pub internal_triggered_collection: AtomicBool,
+    // pub last_internal_triggered_collection: AtomicBool,
     // Has an allocation succeeded since the emergency collection?
-    pub allocation_success: AtomicBool,
+    // pub allocation_success: AtomicBool,
     // Maximum number of failed attempts by a single thread
-    pub max_collection_attempts: AtomicUsize,
+    // pub max_collection_attempts: AtomicUsize,
     // Current collection attempt
-    pub cur_collection_attempts: AtomicUsize,
+    // pub cur_collection_attempts: AtomicUsize,
     pub gc_requester: Arc<GCRequester<VM>>,
-    pub stats: Stats,
+    // pub stats: Stats,
     // pub vm_map: &'static dyn Map,
     pub options: Arc<Options>,
-    pub heap: HeapMeta,
+    // pub heap: HeapMeta,
     pub gc_trigger: Arc<GCTrigger<VM>>,
-    #[cfg(feature = "sanity")]
-    pub inside_sanity: AtomicBool,
-    /// A counter for per-mutator stack scanning
-    scanned_stacks: AtomicUsize,
-    /// Have we scanned all the stacks?
-    stacks_prepared: AtomicBool,
-    pub mutator_iterator_lock: Mutex<()>,
-    /// A counter that keeps tracks of the number of bytes allocated since last stress test
-    allocation_bytes: AtomicUsize,
-    /// A counteer that keeps tracks of the number of bytes allocated by malloc
-    #[cfg(feature = "malloc_counted_size")]
-    malloc_bytes: AtomicUsize,
+    // #[cfg(feature = "sanity")]
+    // pub inside_sanity: AtomicBool,
+    // /// A counter for per-mutator stack scanning
+    // scanned_stacks: AtomicUsize,
+    // /// Have we scanned all the stacks?
+    // stacks_prepared: AtomicBool,
+    // /// A counter that keeps tracks of the number of bytes allocated since last stress test
+    // allocation_bytes: AtomicUsize,
+    // /// A counteer that keeps tracks of the number of bytes allocated by malloc
+    // #[cfg(feature = "malloc_counted_size")]
+    // malloc_bytes: AtomicUsize,
     /// This stores the size in bytes for all the live objects in last GC. This counter is only updated in the GC release phase.
-    #[cfg(feature = "count_live_bytes_in_gc")]
-    pub live_bytes_in_last_gc: AtomicUsize,
+    // #[cfg(feature = "count_live_bytes_in_gc")]
+    // pub live_bytes_in_last_gc: AtomicUsize,
     /// Wrapper around analysis counters
     #[cfg(feature = "analysis")]
     pub analysis_manager: AnalysisManager<VM>,
@@ -466,26 +467,28 @@ pub struct BasePlan<VM: VMBinding> {
 
 /// Args needed for creating any plan. This includes a set of contexts from MMTK or global. This
 /// is passed to each plan's constructor.
-pub struct CreateGeneralPlanArgs<VM: VMBinding> {
+pub struct CreateGeneralPlanArgs<'a, VM: VMBinding> {
     pub vm_map: &'static dyn VMMap,
     pub mmapper: &'static dyn Mmapper,
-    pub heap: HeapMeta,
     pub options: Arc<Options>,
+    pub state: Arc<GlobalState>,
     pub gc_trigger: Arc<crate::util::heap::gc_trigger::GCTrigger<VM>>,
     pub scheduler: Arc<GCWorkScheduler<VM>>,
+    pub stats: &'a Stats,
+    pub heap: &'a mut HeapMeta,
 }
 
 /// Args needed for creating a specific plan. This includes plan-specific args, such as plan constrainst
 /// and their global side metadata specs. This is created in each plan's constructor, and will be passed
 /// to `CommonPlan` or `BasePlan`. Also you can create `PlanCreateSpaceArg` from this type, and use that
 /// to create spaces.
-pub struct CreateSpecificPlanArgs<VM: VMBinding> {
-    pub global_args: CreateGeneralPlanArgs<VM>,
+pub struct CreateSpecificPlanArgs<'a, VM: VMBinding> {
+    pub global_args: CreateGeneralPlanArgs<'a, VM>,
     pub constraints: &'static PlanConstraints,
     pub global_side_metadata_specs: Vec<SideMetadataSpec>,
 }
 
-impl<VM: VMBinding> CreateSpecificPlanArgs<VM> {
+impl<'a, VM: VMBinding> CreateSpecificPlanArgs<'a, VM> {
     /// Get a PlanCreateSpaceArgs that can be used to create a space
     pub fn get_space_args(
         &mut self,
@@ -512,7 +515,6 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<VM> {
 impl<VM: VMBinding> BasePlan<VM> {
     #[allow(unused_mut)] // 'args' only needs to be mutable for certain features
     pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> BasePlan<VM> {
-        let stats = Stats::new(&args.global_args.options);
         // Initializing the analysis manager and routines
         #[cfg(feature = "analysis")]
         let analysis_manager = AnalysisManager::new(&stats);
@@ -542,70 +544,71 @@ impl<VM: VMBinding> BasePlan<VM> {
                 VMRequest::discontiguous(),
             )),
 
-            initialized: AtomicBool::new(false),
-            trigger_gc_when_heap_is_full: AtomicBool::new(true),
-            gc_status: Mutex::new(GcStatus::NotInGC),
-            last_stress_pages: AtomicUsize::new(0),
-            stacks_prepared: AtomicBool::new(false),
-            emergency_collection: AtomicBool::new(false),
-            user_triggered_collection: AtomicBool::new(false),
-            internal_triggered_collection: AtomicBool::new(false),
-            last_internal_triggered_collection: AtomicBool::new(false),
-            allocation_success: AtomicBool::new(false),
-            max_collection_attempts: AtomicUsize::new(0),
-            cur_collection_attempts: AtomicUsize::new(0),
+            global_state: args.global_args.state.clone(),
+
+            // initialized: AtomicBool::new(false),
+            // trigger_gc_when_heap_is_full: AtomicBool::new(true),
+            // gc_status: Mutex::new(GcStatus::NotInGC),
+            // last_stress_pages: AtomicUsize::new(0),
+            // stacks_prepared: AtomicBool::new(false),
+            // emergency_collection: AtomicBool::new(false),
+            // user_triggered_collection: AtomicBool::new(false),
+            // internal_triggered_collection: AtomicBool::new(false),
+            // last_internal_triggered_collection: AtomicBool::new(false),
+            // allocation_success: AtomicBool::new(false),
+            // max_collection_attempts: AtomicUsize::new(0),
+            // cur_collection_attempts: AtomicUsize::new(0),
             gc_requester: Arc::new(GCRequester::new()),
-            stats,
-            heap: args.global_args.heap,
+            // stats,
+            // heap: args.global_args.heap,
             gc_trigger: args.global_args.gc_trigger,
             options: args.global_args.options,
-            #[cfg(feature = "sanity")]
-            inside_sanity: AtomicBool::new(false),
-            scanned_stacks: AtomicUsize::new(0),
-            mutator_iterator_lock: Mutex::new(()),
-            allocation_bytes: AtomicUsize::new(0),
-            #[cfg(feature = "malloc_counted_size")]
-            malloc_bytes: AtomicUsize::new(0),
-            #[cfg(feature = "count_live_bytes_in_gc")]
-            live_bytes_in_last_gc: AtomicUsize::new(0),
+            // #[cfg(feature = "sanity")]
+            // inside_sanity: AtomicBool::new(false),
+            // scanned_stacks: AtomicUsize::new(0),
+            // allocation_bytes: AtomicUsize::new(0),
+            // #[cfg(feature = "malloc_counted_size")]
+            // malloc_bytes: AtomicUsize::new(0),
+            // #[cfg(feature = "count_live_bytes_in_gc")]
+            // live_bytes_in_last_gc: AtomicUsize::new(0),
             #[cfg(feature = "analysis")]
             analysis_manager,
         }
     }
 
-    /// The application code has requested a collection.
-    pub fn handle_user_collection_request(&self, tls: VMMutatorThread, force: bool) {
-        if force || !*self.options.ignore_system_gc {
-            info!("User triggering collection");
-            self.user_triggered_collection
-                .store(true, Ordering::Relaxed);
-            self.gc_requester.request();
-            VM::VMCollection::block_for_gc(tls);
-        }
-    }
+    // /// The application code has requested a collection.
+    // pub fn handle_user_collection_request(&self, tls: VMMutatorThread, force: bool) {
+    //     if force || !*self.options.ignore_system_gc {
+    //         info!("User triggering collection");
+    //         self.user_triggered_collection
+    //             .store(true, Ordering::Relaxed);
+    //         self.gc_requester.request();
+    //         VM::VMCollection::block_for_gc(tls);
+    //     }
+    // }
 
-    /// MMTK has requested stop-the-world activity (e.g., stw within a concurrent gc).
-    // This is not used, as we do not have a concurrent plan.
-    #[allow(unused)]
-    pub fn trigger_internal_collection_request(&self) {
-        self.last_internal_triggered_collection
-            .store(true, Ordering::Relaxed);
-        self.internal_triggered_collection
-            .store(true, Ordering::Relaxed);
-        self.gc_requester.request();
-    }
+    // /// MMTK has requested stop-the-world activity (e.g., stw within a concurrent gc).
+    // // This is not used, as we do not have a concurrent plan.
+    // #[allow(unused)]
+    // pub fn trigger_internal_collection_request(&self) {
+    //     self.last_internal_triggered_collection
+    //         .store(true, Ordering::Relaxed);
+    //     self.internal_triggered_collection
+    //         .store(true, Ordering::Relaxed);
+    //     self.gc_requester.request();
+    // }
 
-    /// Reset collection state information.
-    pub fn reset_collection_trigger(&self) {
-        self.last_internal_triggered_collection.store(
-            self.internal_triggered_collection.load(Ordering::SeqCst),
-            Ordering::Relaxed,
-        );
-        self.internal_triggered_collection
-            .store(false, Ordering::SeqCst);
-        self.user_triggered_collection
-            .store(false, Ordering::Relaxed);
-    }
+    // /// Reset collection state information.
+    // pub fn reset_collection_trigger(&self) {
+    //     self.last_internal_triggered_collection.store(
+    //         self.internal_triggered_collection.load(Ordering::SeqCst),
+    //         Ordering::Relaxed,
+    //     );
+    //     self.internal_triggered_collection
+    //         .store(false, Ordering::SeqCst);
+    //     self.user_triggered_collection
+    //         .store(false, Ordering::Relaxed);
+    // }
 
     // Depends on what base spaces we use, unsync may be unused.
     pub fn get_used_pages(&self) -> usize {
@@ -626,9 +629,7 @@ impl<VM: VMBinding> BasePlan<VM> {
         // If we need to count malloc'd size as part of our heap, we add it here.
         #[cfg(feature = "malloc_counted_size")]
         {
-            pages += crate::util::conversions::bytes_to_pages_up(
-                self.malloc_bytes.load(Ordering::SeqCst),
-            );
+            pages += self.global_state.get_malloc_bytes_in_pages();
         }
 
         // The VM space may be used as an immutable boot image, in which case, we should not count
@@ -691,183 +692,175 @@ impl<VM: VMBinding> BasePlan<VM> {
         self.vm_space.release();
     }
 
-    pub fn set_collection_kind<P: Plan>(&self, plan: &P) {
-        self.cur_collection_attempts.store(
-            if self.is_user_triggered_collection() {
-                1
-            } else {
-                self.determine_collection_attempts()
-            },
-            Ordering::Relaxed,
-        );
+    // pub fn set_collection_kind<P: Plan>(&self, plan: &P) {
+    //     self.cur_collection_attempts.store(
+    //         if self.is_user_triggered_collection() {
+    //             1
+    //         } else {
+    //             self.determine_collection_attempts()
+    //         },
+    //         Ordering::Relaxed,
+    //     );
 
-        let emergency_collection = !self.is_internal_triggered_collection()
-            && plan.last_collection_was_exhaustive()
-            && self.cur_collection_attempts.load(Ordering::Relaxed) > 1
-            && !self.gc_trigger.policy.can_heap_size_grow();
-        self.emergency_collection
-            .store(emergency_collection, Ordering::Relaxed);
+    //     let emergency_collection = !self.is_internal_triggered_collection()
+    //         && plan.last_collection_was_exhaustive()
+    //         && self.cur_collection_attempts.load(Ordering::Relaxed) > 1
+    //         && !self.gc_trigger.policy.can_heap_size_grow();
+    //     self.emergency_collection
+    //         .store(emergency_collection, Ordering::Relaxed);
 
-        if emergency_collection {
-            if let Some(gen) = plan.generational() {
-                gen.force_full_heap_collection();
-            }
-        }
-    }
+    //     if emergency_collection {
+    //         if let Some(gen) = plan.generational() {
+    //             gen.force_full_heap_collection();
+    //         }
+    //     }
+    // }
 
-    pub fn set_gc_status(&self, s: GcStatus) {
-        let mut gc_status = self.gc_status.lock().unwrap();
-        if *gc_status == GcStatus::NotInGC {
-            self.stacks_prepared.store(false, Ordering::SeqCst);
-            // FIXME stats
-            self.stats.start_gc();
-        }
-        *gc_status = s;
-        if *gc_status == GcStatus::NotInGC {
-            // FIXME stats
-            if self.stats.get_gathering_stats() {
-                self.stats.end_gc();
-            }
-        }
-    }
+    // pub fn set_gc_status(&self, s: GcStatus) {
+    //     let mut gc_status = self.gc_status.lock().unwrap();
+    //     if *gc_status == GcStatus::NotInGC {
+    //         self.stacks_prepared.store(false, Ordering::SeqCst);
+    //         // FIXME stats
+    //         self.stats.start_gc();
+    //     }
+    //     *gc_status = s;
+    //     if *gc_status == GcStatus::NotInGC {
+    //         // FIXME stats
+    //         if self.stats.get_gathering_stats() {
+    //             self.stats.end_gc();
+    //         }
+    //     }
+    // }
 
-    /// Are the stacks scanned?
-    pub fn stacks_prepared(&self) -> bool {
-        self.stacks_prepared.load(Ordering::SeqCst)
-    }
+    // /// Are the stacks scanned?
+    // pub fn stacks_prepared(&self) -> bool {
+    //     self.stacks_prepared.load(Ordering::SeqCst)
+    // }
 
-    /// Prepare for stack scanning. This is usually used with `inform_stack_scanned()`.
-    /// This should be called before doing stack scanning.
-    pub fn prepare_for_stack_scanning(&self) {
-        self.scanned_stacks.store(0, Ordering::SeqCst);
-        self.stacks_prepared.store(false, Ordering::SeqCst);
-    }
+    // /// Prepare for stack scanning. This is usually used with `inform_stack_scanned()`.
+    // /// This should be called before doing stack scanning.
+    // pub fn prepare_for_stack_scanning(&self) {
+    //     self.scanned_stacks.store(0, Ordering::SeqCst);
+    //     self.stacks_prepared.store(false, Ordering::SeqCst);
+    // }
 
-    /// Inform that 1 stack has been scanned. The argument `n_mutators` indicates the
-    /// total stacks we should scan. This method returns true if the number of scanned
-    /// stacks equals the total mutator count. Otherwise it returns false. This method
-    /// is thread safe and we guarantee only one thread will return true.
-    pub fn inform_stack_scanned(&self, n_mutators: usize) -> bool {
-        let old = self.scanned_stacks.fetch_add(1, Ordering::SeqCst);
-        debug_assert!(
-            old < n_mutators,
-            "The number of scanned stacks ({}) is more than the number of mutators ({})",
-            old,
-            n_mutators
-        );
-        let scanning_done = old + 1 == n_mutators;
-        if scanning_done {
-            self.stacks_prepared.store(true, Ordering::SeqCst);
-        }
-        scanning_done
-    }
+    // /// Inform that 1 stack has been scanned. The argument `n_mutators` indicates the
+    // /// total stacks we should scan. This method returns true if the number of scanned
+    // /// stacks equals the total mutator count. Otherwise it returns false. This method
+    // /// is thread safe and we guarantee only one thread will return true.
+    // pub fn inform_stack_scanned(&self, n_mutators: usize) -> bool {
+    //     let old = self.scanned_stacks.fetch_add(1, Ordering::SeqCst);
+    //     debug_assert!(
+    //         old < n_mutators,
+    //         "The number of scanned stacks ({}) is more than the number of mutators ({})",
+    //         old,
+    //         n_mutators
+    //     );
+    //     let scanning_done = old + 1 == n_mutators;
+    //     if scanning_done {
+    //         self.stacks_prepared.store(true, Ordering::SeqCst);
+    //     }
+    //     scanning_done
+    // }
 
-    pub fn gc_in_progress(&self) -> bool {
-        *self.gc_status.lock().unwrap() != GcStatus::NotInGC
-    }
+    // pub fn gc_in_progress(&self) -> bool {
+    //     *self.gc_status.lock().unwrap() != GcStatus::NotInGC
+    // }
 
-    pub fn gc_in_progress_proper(&self) -> bool {
-        *self.gc_status.lock().unwrap() == GcStatus::GcProper
-    }
+    // pub fn gc_in_progress_proper(&self) -> bool {
+    //     *self.gc_status.lock().unwrap() == GcStatus::GcProper
+    // }
 
-    fn determine_collection_attempts(&self) -> usize {
-        if !self.allocation_success.load(Ordering::Relaxed) {
-            self.max_collection_attempts.fetch_add(1, Ordering::Relaxed);
-        } else {
-            self.allocation_success.store(false, Ordering::Relaxed);
-            self.max_collection_attempts.store(1, Ordering::Relaxed);
-        }
+    // fn determine_collection_attempts(&self) -> usize {
+    //     if !self.allocation_success.load(Ordering::Relaxed) {
+    //         self.max_collection_attempts.fetch_add(1, Ordering::Relaxed);
+    //     } else {
+    //         self.allocation_success.store(false, Ordering::Relaxed);
+    //         self.max_collection_attempts.store(1, Ordering::Relaxed);
+    //     }
 
-        self.max_collection_attempts.load(Ordering::Relaxed)
-    }
+    //     self.max_collection_attempts.load(Ordering::Relaxed)
+    // }
 
-    /// Return true if this collection was triggered by application code.
-    pub fn is_user_triggered_collection(&self) -> bool {
-        self.user_triggered_collection.load(Ordering::Relaxed)
-    }
+    // /// Return true if this collection was triggered internally.
+    // pub fn is_internal_triggered_collection(&self) -> bool {
+    //     let is_internal_triggered = self
+    //         .last_internal_triggered_collection
+    //         .load(Ordering::SeqCst);
+    //     // Remove this assertion when we have concurrent GC.
+    //     assert!(
+    //         !is_internal_triggered,
+    //         "We have no concurrent GC implemented. We should not have internally triggered GC"
+    //     );
+    //     is_internal_triggered
+    // }
 
-    /// Return true if this collection was triggered internally.
-    pub fn is_internal_triggered_collection(&self) -> bool {
-        let is_internal_triggered = self
-            .last_internal_triggered_collection
-            .load(Ordering::SeqCst);
-        // Remove this assertion when we have concurrent GC.
-        assert!(
-            !is_internal_triggered,
-            "We have no concurrent GC implemented. We should not have internally triggered GC"
-        );
-        is_internal_triggered
-    }
+    // /// Increase the allocation bytes and return the current allocation bytes after increasing
+    // pub fn increase_allocation_bytes_by(&self, size: usize) -> usize {
+    //     let old_allocation_bytes = self.allocation_bytes.fetch_add(size, Ordering::SeqCst);
+    //     trace!(
+    //         "Stress GC: old_allocation_bytes = {}, size = {}, allocation_bytes = {}",
+    //         old_allocation_bytes,
+    //         size,
+    //         self.allocation_bytes.load(Ordering::Relaxed),
+    //     );
+    //     old_allocation_bytes + size
+    // }
 
-    /// Increase the allocation bytes and return the current allocation bytes after increasing
-    pub fn increase_allocation_bytes_by(&self, size: usize) -> usize {
-        let old_allocation_bytes = self.allocation_bytes.fetch_add(size, Ordering::SeqCst);
-        trace!(
-            "Stress GC: old_allocation_bytes = {}, size = {}, allocation_bytes = {}",
-            old_allocation_bytes,
-            size,
-            self.allocation_bytes.load(Ordering::Relaxed),
-        );
-        old_allocation_bytes + size
-    }
+    // /// Check if the options are set for stress GC. If either stress_factor or analysis_factor is set,
+    // /// we should do stress GC.
+    // pub fn is_stress_test_gc_enabled(&self) -> bool {
+    //     use crate::util::constants::DEFAULT_STRESS_FACTOR;
+    //     *self.options.stress_factor != DEFAULT_STRESS_FACTOR
+    //         || *self.options.analysis_factor != DEFAULT_STRESS_FACTOR
+    // }
 
-    /// Check if the options are set for stress GC. If either stress_factor or analysis_factor is set,
-    /// we should do stress GC.
-    pub fn is_stress_test_gc_enabled(&self) -> bool {
-        use crate::util::constants::DEFAULT_STRESS_FACTOR;
-        *self.options.stress_factor != DEFAULT_STRESS_FACTOR
-            || *self.options.analysis_factor != DEFAULT_STRESS_FACTOR
-    }
+    // /// Check if we should do precise stress test. If so, we need to check for stress GCs for every allocation.
+    // /// Otherwise, we only check in the allocation slow path.
+    // pub fn is_precise_stress(&self) -> bool {
+    //     *self.options.precise_stress
+    // }
 
-    /// Check if we should do precise stress test. If so, we need to check for stress GCs for every allocation.
-    /// Otherwise, we only check in the allocation slow path.
-    pub fn is_precise_stress(&self) -> bool {
-        *self.options.precise_stress
-    }
+    // /// Check if we should do a stress GC now. If GC is initialized and the allocation bytes exceeds
+    // /// the stress factor, we should do a stress GC.
+    // pub fn should_do_stress_gc(&self) -> bool {
+    //     self.global_state.initialized.load(Ordering::SeqCst)
+    //         && (self.allocation_bytes.load(Ordering::SeqCst) > *self.options.stress_factor)
+    // }
 
-    /// Check if we should do a stress GC now. If GC is initialized and the allocation bytes exceeds
-    /// the stress factor, we should do a stress GC.
-    pub fn should_do_stress_gc(&self) -> bool {
-        self.initialized.load(Ordering::SeqCst)
-            && (self.allocation_bytes.load(Ordering::SeqCst) > *self.options.stress_factor)
-    }
+    // pub(super) fn collection_required<P: Plan>(&self, plan: &P, space_full: bool) -> bool {
+    //     let stress_force_gc = self.should_do_stress_gc();
+    //     if stress_force_gc {
+    //         debug!(
+    //             "Stress GC: allocation_bytes = {}, stress_factor = {}",
+    //             self.global_state.allocation_bytes.load(Ordering::Relaxed),
+    //             *self.options.stress_factor
+    //         );
+    //         debug!("Doing stress GC");
+    //         self.global_state.allocation_bytes.store(0, Ordering::SeqCst);
+    //     }
 
-    pub(super) fn collection_required<P: Plan>(&self, plan: &P, space_full: bool) -> bool {
-        let stress_force_gc = self.should_do_stress_gc();
-        if stress_force_gc {
-            debug!(
-                "Stress GC: allocation_bytes = {}, stress_factor = {}",
-                self.allocation_bytes.load(Ordering::Relaxed),
-                *self.options.stress_factor
-            );
-            debug!("Doing stress GC");
-            self.allocation_bytes.store(0, Ordering::SeqCst);
-        }
+    //     debug!(
+    //         "self.get_reserved_pages()={}, self.get_total_pages()={}",
+    //         plan.get_reserved_pages(),
+    //         plan.get_total_pages()
+    //     );
 
-        debug!(
-            "self.get_reserved_pages()={}, self.get_total_pages()={}",
-            plan.get_reserved_pages(),
-            plan.get_total_pages()
-        );
-        // Check if we reserved more pages (including the collection copy reserve)
-        // than the heap's total pages. In that case, we will have to do a GC.
-        let heap_full = plan.base().gc_trigger.is_heap_full();
+    //     space_full || stress_force_gc
+    // }
 
-        space_full || stress_force_gc || heap_full
-    }
-
-    #[cfg(feature = "malloc_counted_size")]
-    pub(crate) fn increase_malloc_bytes_by(&self, size: usize) {
-        self.malloc_bytes.fetch_add(size, Ordering::SeqCst);
-    }
-    #[cfg(feature = "malloc_counted_size")]
-    pub(crate) fn decrease_malloc_bytes_by(&self, size: usize) {
-        self.malloc_bytes.fetch_sub(size, Ordering::SeqCst);
-    }
-    #[cfg(feature = "malloc_counted_size")]
-    pub fn get_malloc_bytes(&self) -> usize {
-        self.malloc_bytes.load(Ordering::SeqCst)
-    }
+    // #[cfg(feature = "malloc_counted_size")]
+    // pub(crate) fn increase_malloc_bytes_by(&self, size: usize) {
+    //     self.malloc_bytes.fetch_add(size, Ordering::SeqCst);
+    // }
+    // #[cfg(feature = "malloc_counted_size")]
+    // pub(crate) fn decrease_malloc_bytes_by(&self, size: usize) {
+    //     self.malloc_bytes.fetch_sub(size, Ordering::SeqCst);
+    // }
+    // #[cfg(feature = "malloc_counted_size")]
+    // pub fn get_malloc_bytes(&self) -> usize {
+    //     self.malloc_bytes.load(Ordering::SeqCst)
+    // }
 }
 
 /**
@@ -949,9 +942,9 @@ impl<VM: VMBinding> CommonPlan<VM> {
         self.base.release(tls, full_heap)
     }
 
-    pub fn stacks_prepared(&self) -> bool {
-        self.base.stacks_prepared()
-    }
+    // pub fn stacks_prepared(&self) -> bool {
+    //     self.base.stacks_prepared()
+    // }
 
     pub fn get_immortal(&self) -> &ImmortalSpace<VM> {
         &self.immortal

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -46,6 +46,10 @@ pub const IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for Immix<VM> {
+    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+
     fn last_collection_was_exhaustive(&self) -> bool {
         ImmixSpace::<VM>::is_last_gc_exhaustive(self.last_gc_was_defrag.load(Ordering::Relaxed))
     }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -86,14 +86,14 @@ impl<VM: VMBinding> Plan for Immix<VM> {
         &ALLOCATOR_MAPPING
     }
 
-    fn prepare(&mut self, tls: VMWorkerThread) {
+    fn prepare(&self, tls: VMWorkerThread) {
         self.common.prepare(tls, true);
         let stats_for_defrag = crate::policy::immix::defrag::PlanStatsForDefrag::collect(self);
         let mut space = self.immix_space.write();
         space.prepare(true, stats_for_defrag);
     }
 
-    fn release(&mut self, tls: VMWorkerThread) {
+    fn release(&self, tls: VMWorkerThread) {
         self.common.release(tls, true);
         // release the collected region
         let mut space = self.immix_space.write();

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -84,7 +84,10 @@ impl<VM: VMBinding> Plan for Immix<VM> {
 
     fn prepare(&mut self, tls: VMWorkerThread) {
         self.common.prepare(tls, true);
-        self.immix_space.prepare(true);
+        self.immix_space.prepare(
+            true,
+            crate::policy::immix::defrag::PlanStatsForDefrag::collect(self),
+        );
     }
 
     fn release(&mut self, tls: VMWorkerThread) {

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -46,10 +46,6 @@ pub const IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for Immix<VM> {
-    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        false
-    }
-
     fn last_collection_was_exhaustive(&self) -> bool {
         ImmixSpace::<VM>::is_last_gc_exhaustive(self.last_gc_was_defrag.load(Ordering::Relaxed))
     }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -4,7 +4,6 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::global_state::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;
@@ -47,7 +46,7 @@ pub const IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
 };
 
 impl<VM: VMBinding> Plan for Immix<VM> {
-    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         false
     }
 
@@ -165,7 +164,10 @@ impl<VM: VMBinding> Immix<VM> {
         let in_defrag = immix_space.decide_whether_to_defrag(
             plan.base().global_state.is_emergency_collection(),
             true,
-            plan.base().global_state.cur_collection_attempts.load(Ordering::SeqCst),
+            plan.base()
+                .global_state
+                .cur_collection_attempts
+                .load(Ordering::SeqCst),
             plan.base().global_state.is_user_triggered_collection(),
             *plan.base().options.full_heap_system_gc,
         );

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -1,15 +1,14 @@
 use super::Immix;
-use crate::MMTK;
 use crate::plan::mutator_context::create_allocator_mapping;
 use crate::plan::mutator_context::create_space_mapping;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::AllocationSemantics;
-use crate::plan::Plan;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::ImmixAllocator;
 use crate::vm::VMBinding;
+use crate::MMTK;
 use crate::{
     plan::barriers::NoBarrier,
     util::opaque_pointer::{VMMutatorThread, VMWorkerThread},

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -59,7 +59,7 @@ pub fn create_immix_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, immix);
-            vec.push((AllocatorSelector::Immix(0), immix.immix_space.clone()));
+            vec.push((AllocatorSelector::Immix(0), immix.immix_space.clone().to_dyn_space()));
             vec
         }),
         prepare_func: &immix_mutator_prepare,

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -59,7 +59,10 @@ pub fn create_immix_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, immix);
-            vec.push((AllocatorSelector::Immix(0), immix.immix_space.clone().to_dyn_space()));
+            vec.push((
+                AllocatorSelector::Immix(0),
+                immix.immix_space.clone().into_dyn_space(),
+            ));
             vec
         }),
         prepare_func: &immix_mutator_prepare,

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -59,7 +59,7 @@ pub fn create_immix_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, immix);
-            vec.push((AllocatorSelector::Immix(0), &immix.immix_space));
+            vec.push((AllocatorSelector::Immix(0), immix.immix_space.clone()));
             vec
         }),
         prepare_func: &immix_mutator_prepare,

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -42,7 +42,7 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
         // The following needs to be done right before the second round of root scanning
         VM::VMScanning::prepare_for_roots_re_scanning();
-        mmtk.get_plan().base().prepare_for_stack_scanning();
+        mmtk.state.prepare_for_stack_scanning();
         // Prepare common and base spaces for the 2nd round of transitive closure
         let plan_mut = unsafe { &mut *(self.plan as *mut MarkCompact<VM>) };
         plan_mut.common.release(worker.tls, true);

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -4,7 +4,7 @@ use super::gc_work::{
     UpdateReferences,
 };
 use crate::plan::global::CommonPlan;
-use crate::plan::global::GcStatus;
+use crate::global_state::GcStatus;
 use crate::plan::global::{BasePlan, CreateGeneralPlanArgs, CreateSpecificPlanArgs};
 use crate::plan::markcompact::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
@@ -79,9 +79,6 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
-        self.base().set_collection_kind::<Self>(self);
-        self.base().set_gc_status(GcStatus::GcPrepare);
-
         // TODO use schedule_common once it can work with markcompact
         // self.common()
         //     .schedule_common::<Self, MarkingProcessEdges<VM>, NoCopy<VM>>(
@@ -165,7 +162,7 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        self.base().collection_required(self, space_full)
+        false
     }
 
     fn get_used_pages(&self) -> usize {

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -4,7 +4,6 @@ use super::gc_work::{
     UpdateReferences,
 };
 use crate::plan::global::CommonPlan;
-use crate::global_state::GcStatus;
 use crate::plan::global::{BasePlan, CreateGeneralPlanArgs, CreateSpecificPlanArgs};
 use crate::plan::markcompact::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
@@ -161,7 +160,7 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
             .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new(self));
     }
 
-    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         false
     }
 

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -160,6 +160,10 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
             .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new(self));
     }
 
+    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+
     fn get_used_pages(&self) -> usize {
         self.mc_space.reserved_pages() + self.common.get_used_pages()
     }

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -64,12 +64,12 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         &self.common
     }
 
-    fn prepare(&mut self, _tls: VMWorkerThread) {
+    fn prepare(&self, _tls: VMWorkerThread) {
         self.common.prepare(_tls, true);
         self.mc_space.read().prepare();
     }
 
-    fn release(&mut self, _tls: VMWorkerThread) {
+    fn release(&self, _tls: VMWorkerThread) {
         self.common.release(_tls, true);
         self.mc_space.read().release();
     }

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -160,10 +160,6 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
             .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new(self));
     }
 
-    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        false
-    }
-
     fn get_used_pages(&self) -> usize {
         self.mc_space.reserved_pages() + self.common.get_used_pages()
     }

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -1,4 +1,5 @@
-use super::MarkCompact; use crate::MMTK;
+use super::MarkCompact;
+use crate::MMTK;
 // Add
 use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::create_allocator_mapping;
@@ -11,7 +12,6 @@ use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::MarkCompactAllocator;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
-use crate::Plan;
 use enum_map::EnumMap;
 
 const RESERVED_ALLOCATORS: ReservedAllocators = ReservedAllocators {

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -36,7 +36,10 @@ pub fn create_markcompact_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, markcompact);
-            vec.push((AllocatorSelector::MarkCompact(0), markcompact.mc_space()));
+            vec.push((
+                AllocatorSelector::MarkCompact(0),
+                markcompact.mc_space().clone().into_dyn_space(),
+            ));
             vec
         }),
         prepare_func: &markcompact_mutator_prepare,

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -1,4 +1,5 @@
-use super::MarkCompact; // Add
+use super::MarkCompact; use crate::MMTK;
+// Add
 use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::create_allocator_mapping;
 use crate::plan::mutator_context::create_space_mapping;
@@ -28,13 +29,13 @@ lazy_static! {
 
 pub fn create_markcompact_mutator<VM: VMBinding>(
     mutator_tls: VMMutatorThread,
-    plan: &'static dyn Plan<VM = VM>,
+    mmtk: &'static MMTK<VM>,
 ) -> Mutator<VM> {
-    let markcompact = plan.downcast_ref::<MarkCompact<VM>>().unwrap();
+    let markcompact = mmtk.get_plan().downcast_ref::<MarkCompact<VM>>().unwrap();
     let config = MutatorConfig {
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
-            let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, plan);
+            let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, markcompact);
             vec.push((AllocatorSelector::MarkCompact(0), markcompact.mc_space()));
             vec
         }),
@@ -43,11 +44,11 @@ pub fn create_markcompact_mutator<VM: VMBinding>(
     };
 
     Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, plan, &config.space_mapping),
+        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         barrier: Box::new(NoBarrier),
         mutator_tls,
         config,
-        plan,
+        plan: markcompact,
     }
 }
 

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -2,7 +2,6 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::global_state::GcStatus;
 use crate::plan::marksweep::gc_work::MSGCWorkContext;
 use crate::plan::marksweep::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
@@ -65,7 +64,7 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.release(tls, true);
     }
 
-    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         false
     }
 

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -64,10 +64,6 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.release(tls, true);
     }
 
-    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        false
-    }
-
     fn get_used_pages(&self) -> usize {
         self.common.get_used_pages() + self.ms.reserved_pages()
     }

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -2,7 +2,7 @@ use crate::plan::global::BasePlan;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::plan::global::GcStatus;
+use crate::global_state::GcStatus;
 use crate::plan::marksweep::gc_work::MSGCWorkContext;
 use crate::plan::marksweep::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
@@ -48,8 +48,6 @@ pub const MS_CONSTRAINTS: PlanConstraints = PlanConstraints {
 
 impl<VM: VMBinding> Plan for MarkSweep<VM> {
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
-        self.base().set_collection_kind::<Self>(self);
-        self.base().set_gc_status(GcStatus::GcPrepare);
         scheduler.schedule_common_work::<MSGCWorkContext<VM>>(self);
     }
 
@@ -68,7 +66,7 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        self.base().collection_required(self, space_full)
+        false
     }
 
     fn get_used_pages(&self) -> usize {

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -64,6 +64,10 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.release(tls, true);
     }
 
+    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+
     fn get_used_pages(&self) -> usize {
         self.common.get_used_pages() + self.ms.reserved_pages()
     }

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -55,12 +55,12 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         &ALLOCATOR_MAPPING
     }
 
-    fn prepare(&mut self, tls: VMWorkerThread) {
+    fn prepare(&self, tls: VMWorkerThread) {
         self.common.prepare(tls, true);
         self.ms.write().prepare();
     }
 
-    fn release(&mut self, tls: VMWorkerThread) {
+    fn release(&self, tls: VMWorkerThread) {
         self.ms.write().release();
         self.common.release(tls, true);
     }

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -43,7 +43,10 @@ mod malloc_mark_sweep {
         Box::new({
             let mut vec =
                 crate::plan::mutator_context::create_space_mapping(RESERVED_ALLOCATORS, true, plan);
-            vec.push((AllocatorSelector::Malloc(0), ms.ms_space()));
+            vec.push((
+                AllocatorSelector::Malloc(0),
+                ms.ms_space().clone().into_dyn_space(),
+            ));
             vec
         })
     }
@@ -98,7 +101,10 @@ mod native_mark_sweep {
         Box::new({
             let mut vec =
                 crate::plan::mutator_context::create_space_mapping(RESERVED_ALLOCATORS, true, plan);
-            vec.push((AllocatorSelector::FreeList(0), ms.ms_space()));
+            vec.push((
+                AllocatorSelector::FreeList(0),
+                ms.ms_space().clone().into_dyn_space(),
+            ));
             vec
         })
     }

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -1,3 +1,4 @@
+use crate::MMTK;
 use crate::plan::barriers::NoBarrier;
 use crate::plan::marksweep::MarkSweep;
 use crate::plan::mutator_context::create_allocator_mapping;
@@ -111,20 +112,20 @@ pub use native_mark_sweep::*;
 
 pub fn create_ms_mutator<VM: VMBinding>(
     mutator_tls: VMMutatorThread,
-    plan: &'static dyn Plan<VM = VM>,
+    mmtk: &'static MMTK<VM>,
 ) -> Mutator<VM> {
     let config = MutatorConfig {
         allocator_mapping: &ALLOCATOR_MAPPING,
-        space_mapping: create_space_mapping(plan),
+        space_mapping: create_space_mapping(mmtk.get_plan()),
         prepare_func: &ms_mutator_prepare,
         release_func: &ms_mutator_release,
     };
 
     Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, plan, &config.space_mapping),
+        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         barrier: Box::new(NoBarrier),
         mutator_tls,
         config,
-        plan,
+        plan: mmtk.get_plan(),
     }
 }

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -1,4 +1,3 @@
-use crate::MMTK;
 use crate::plan::barriers::NoBarrier;
 use crate::plan::marksweep::MarkSweep;
 use crate::plan::mutator_context::create_allocator_mapping;
@@ -11,6 +10,7 @@ use crate::plan::Plan;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;
+use crate::MMTK;
 
 use enum_map::EnumMap;
 

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -39,17 +39,17 @@ pub use plan_constraints::DEFAULT_PLAN_CONSTRAINTS;
 mod tracing;
 pub use tracing::{ObjectQueue, ObjectsClosure, VectorObjectQueue, VectorQueue};
 
-// /// Generational plans (with a copying nursery)
+/// Generational plans (with a copying nursery)
 mod generational;
-// /// Sticky plans (using sticky marks for generational behaviors without a copying nursery)
-// mod sticky;
+/// Sticky plans (using sticky marks for generational behaviors without a copying nursery)
+mod sticky;
 
 mod immix;
-// mod markcompact;
-// mod marksweep;
-// mod nogc;
-// mod pageprotect;
-// mod semispace;
+mod markcompact;
+mod marksweep;
+mod nogc;
+mod pageprotect;
+mod semispace;
 
 pub(crate) use generational::global::is_nursery_gc;
 pub(crate) use generational::global::GenerationalPlan;
@@ -57,12 +57,12 @@ pub(crate) use generational::global::GenerationalPlan;
 // Expose plan constraints as public. Though a binding can get them from plan.constraints(),
 // it is possible for performance reasons that they want the constraints as constants.
 
-// pub use generational::copying::GENCOPY_CONSTRAINTS;
-// pub use generational::immix::GENIMMIX_CONSTRAINTS;
+pub use generational::copying::GENCOPY_CONSTRAINTS;
+pub use generational::immix::GENIMMIX_CONSTRAINTS;
 pub use immix::IMMIX_CONSTRAINTS;
-// pub use markcompact::MARKCOMPACT_CONSTRAINTS;
-// pub use marksweep::MS_CONSTRAINTS;
-// pub use nogc::NOGC_CONSTRAINTS;
-// pub use pageprotect::PP_CONSTRAINTS;
-// pub use semispace::SS_CONSTRAINTS;
-// pub use sticky::immix::STICKY_IMMIX_CONSTRAINTS;
+pub use markcompact::MARKCOMPACT_CONSTRAINTS;
+pub use marksweep::MS_CONSTRAINTS;
+pub use nogc::NOGC_CONSTRAINTS;
+pub use pageprotect::PP_CONSTRAINTS;
+pub use semispace::SS_CONSTRAINTS;
+pub use sticky::immix::STICKY_IMMIX_CONSTRAINTS;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -23,7 +23,6 @@ pub(crate) use global::create_gc_worker_context;
 pub(crate) use global::create_mutator;
 pub(crate) use global::create_plan;
 pub use global::AllocationSemantics;
-pub(crate) use global::GcStatus;
 pub(crate) use global::HasSpaces;
 pub use global::Plan;
 pub(crate) use global::PlanTraceObject;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -23,6 +23,7 @@ pub(crate) use global::create_gc_worker_context;
 pub(crate) use global::create_mutator;
 pub(crate) use global::create_plan;
 pub use global::AllocationSemantics;
+pub(crate) use global::CreateGeneralPlanArgs;
 pub(crate) use global::HasSpaces;
 pub use global::Plan;
 pub(crate) use global::PlanTraceObject;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -39,17 +39,17 @@ pub use plan_constraints::DEFAULT_PLAN_CONSTRAINTS;
 mod tracing;
 pub use tracing::{ObjectQueue, ObjectsClosure, VectorObjectQueue, VectorQueue};
 
-/// Generational plans (with a copying nursery)
+// /// Generational plans (with a copying nursery)
 mod generational;
-/// Sticky plans (using sticky marks for generational behaviors without a copying nursery)
-mod sticky;
+// /// Sticky plans (using sticky marks for generational behaviors without a copying nursery)
+// mod sticky;
 
 mod immix;
-mod markcompact;
-mod marksweep;
-mod nogc;
-mod pageprotect;
-mod semispace;
+// mod markcompact;
+// mod marksweep;
+// mod nogc;
+// mod pageprotect;
+// mod semispace;
 
 pub(crate) use generational::global::is_nursery_gc;
 pub(crate) use generational::global::GenerationalPlan;
@@ -57,12 +57,12 @@ pub(crate) use generational::global::GenerationalPlan;
 // Expose plan constraints as public. Though a binding can get them from plan.constraints(),
 // it is possible for performance reasons that they want the constraints as constants.
 
-pub use generational::copying::GENCOPY_CONSTRAINTS;
-pub use generational::immix::GENIMMIX_CONSTRAINTS;
+// pub use generational::copying::GENCOPY_CONSTRAINTS;
+// pub use generational::immix::GENIMMIX_CONSTRAINTS;
 pub use immix::IMMIX_CONSTRAINTS;
-pub use markcompact::MARKCOMPACT_CONSTRAINTS;
-pub use marksweep::MS_CONSTRAINTS;
-pub use nogc::NOGC_CONSTRAINTS;
-pub use pageprotect::PP_CONSTRAINTS;
-pub use semispace::SS_CONSTRAINTS;
-pub use sticky::immix::STICKY_IMMIX_CONSTRAINTS;
+// pub use markcompact::MARKCOMPACT_CONSTRAINTS;
+// pub use marksweep::MS_CONSTRAINTS;
+// pub use nogc::NOGC_CONSTRAINTS;
+// pub use pageprotect::PP_CONSTRAINTS;
+// pub use semispace::SS_CONSTRAINTS;
+// pub use sticky::immix::STICKY_IMMIX_CONSTRAINTS;

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -4,6 +4,7 @@ use crate::plan::barriers::Barrier;
 use crate::plan::global::Plan;
 use crate::plan::AllocationSemantics;
 use crate::policy::space::Space;
+use crate::policy::space_ref::SpaceRef;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::{Address, ObjectReference};
 use crate::util::{VMMutatorThread, VMWorkerThread};
@@ -11,7 +12,7 @@ use crate::vm::VMBinding;
 
 use enum_map::EnumMap;
 
-pub(crate) type SpaceMapping<VM> = Vec<(AllocatorSelector, &'static dyn Space<VM>)>;
+pub(crate) type SpaceMapping<VM> = Vec<(AllocatorSelector, SpaceRef<dyn Space<VM> + Send>)>;
 
 // This struct is part of the Mutator struct.
 // We are trying to make it fixed-sized so that VM bindings can easily define a Mutator type to have the exact same layout as our Mutator struct.
@@ -34,13 +35,13 @@ impl<VM: VMBinding> std::fmt::Debug for MutatorConfig<VM> {
         f.write_str("MutatorConfig:\n")?;
         f.write_str("Semantics mapping:\n")?;
         for (semantic, selector) in self.allocator_mapping.iter() {
-            let space_name: &str = match self
+            let space_name = match self
                 .space_mapping
                 .iter()
                 .find(|(selector_to_find, _)| selector_to_find == selector)
             {
-                Some((_, space)) => space.name(),
-                None => "!!!missing space here!!!",
+                Some((_, space)) => crate::space_ref_read!(&space).name().to_owned(),
+                None => "!!!missing space here!!!".to_string(),
             };
             f.write_fmt(format_args!(
                 "- {:?} = {:?} ({:?})\n",
@@ -49,7 +50,7 @@ impl<VM: VMBinding> std::fmt::Debug for MutatorConfig<VM> {
         }
         f.write_str("Space mapping:\n")?;
         for (selector, space) in self.space_mapping.iter() {
-            f.write_fmt(format_args!("- {:?} = {:?}\n", selector, space.name()))?;
+            f.write_fmt(format_args!("- {:?} = {:?}\n", selector, crate::space_ref_read!(&space).name()))?;
         }
         Ok(())
     }
@@ -103,12 +104,13 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
         _bytes: usize,
         allocator: AllocationSemantics,
     ) {
-        unsafe {
-            self.allocators
-                .get_allocator_mut(self.config.allocator_mapping[allocator])
-        }
-        .get_space()
-        .initialize_object_metadata(refer, true)
+        // unsafe {
+        //     self.allocators
+        //         .get_allocator_mut(self.config.allocator_mapping[allocator])
+        // }
+        // .get_space()
+        // .read().initialize_object_metadata(refer, true)
+        unsafe { crate::mmtk::SFT_MAP.get_unchecked(refer.to_address::<VM>()) }.initialize_object_metadata(refer, true)
     }
 
     fn get_tls(&self) -> VMMutatorThread {
@@ -301,12 +303,12 @@ pub(crate) fn create_space_mapping<VM: VMBinding>(
     mut reserved: ReservedAllocators,
     include_common_plan: bool,
     plan: &'static dyn Plan<VM = VM>,
-) -> Vec<(AllocatorSelector, &'static dyn Space<VM>)> {
+) -> Vec<(AllocatorSelector, SpaceRef<dyn Space<VM> + Send>)> {
     // If we need to add new allocators, or new spaces, we need to make sure the allocator we assign here matches the allocator
     // we used in create_space_mapping(). The easiest way is to add the space/allocator mapping in the same order. So for any modification to this
     // function, please check the other function.
 
-    let mut vec: Vec<(AllocatorSelector, &'static dyn Space<VM>)> = vec![];
+    let mut vec: Vec<(AllocatorSelector, SpaceRef<dyn Space<VM> + Send>)> = vec![];
 
     // spaces in BasePlan
 
@@ -314,12 +316,12 @@ pub(crate) fn create_space_mapping<VM: VMBinding>(
     {
         vec.push((
             AllocatorSelector::BumpPointer(reserved.n_bump_pointer),
-            &plan.base().code_space,
+            plan.base().code_space.clone(),
         ));
         reserved.n_bump_pointer += 1;
         vec.push((
             AllocatorSelector::BumpPointer(reserved.n_bump_pointer),
-            &plan.base().code_lo_space,
+            plan.base().code_lo_space.clone(),
         ));
         reserved.n_bump_pointer += 1;
     }
@@ -328,7 +330,7 @@ pub(crate) fn create_space_mapping<VM: VMBinding>(
     {
         vec.push((
             AllocatorSelector::BumpPointer(reserved.n_bump_pointer),
-            &plan.base().ro_space,
+            plan.base().ro_space.clone(),
         ));
         reserved.n_bump_pointer += 1;
     }
@@ -338,18 +340,18 @@ pub(crate) fn create_space_mapping<VM: VMBinding>(
     if include_common_plan {
         vec.push((
             AllocatorSelector::BumpPointer(reserved.n_bump_pointer),
-            plan.common().get_immortal(),
+            plan.common().immortal.clone(),
         ));
         reserved.n_bump_pointer += 1;
         vec.push((
             AllocatorSelector::LargeObject(reserved.n_large_object),
-            plan.common().get_los(),
+            plan.common().los.clone(),
         ));
         reserved.n_large_object += 1;
         // TODO: This should be freelist allocator once we use marksweep for nonmoving space.
         vec.push((
             AllocatorSelector::BumpPointer(reserved.n_bump_pointer),
-            plan.common().get_nonmoving(),
+            plan.common().nonmoving.clone(),
         ));
         reserved.n_bump_pointer += 1;
     }

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -41,7 +41,7 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &NOGC_CONSTRAINTS
     }
 
-    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         false
     }
 

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -42,7 +42,7 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        self.base().collection_required(self, space_full)
+        false
     }
 
     fn base(&self) -> &BasePlan<VM> {
@@ -76,14 +76,14 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
             + self.base.get_used_pages()
     }
 
-    fn handle_user_collection_request(
-        &self,
-        _tls: VMMutatorThread,
-        _force: bool,
-        _exhaustive: bool,
-    ) {
-        warn!("User attempted a collection request, but it is not supported in NoGC. The request is ignored.");
-    }
+    // fn handle_user_collection_request(
+    //     &self,
+    //     _tls: VMMutatorThread,
+    //     _force: bool,
+    //     _exhaustive: bool,
+    // ) {
+    //     warn!("User attempted a collection request, but it is not supported in NoGC. The request is ignored.");
+    // }
 }
 
 impl<VM: VMBinding> NoGC<VM> {

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -54,11 +54,11 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &mut self.base
     }
 
-    fn prepare(&mut self, _tls: VMWorkerThread) {
+    fn prepare(&self, _tls: VMWorkerThread) {
         unreachable!()
     }
 
-    fn release(&mut self, _tls: VMWorkerThread) {
+    fn release(&self, _tls: VMWorkerThread) {
         unreachable!()
     }
 

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -41,10 +41,6 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &NOGC_CONSTRAINTS
     }
 
-    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        false
-    }
-
     fn base(&self) -> &BasePlan<VM> {
         &self.base
     }

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -41,6 +41,10 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &NOGC_CONSTRAINTS
     }
 
+    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+
     fn base(&self) -> &BasePlan<VM> {
         &self.base
     }

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -71,15 +71,6 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
             + self.los.reserved_pages()
             + self.base.get_used_pages()
     }
-
-    // fn handle_user_collection_request(
-    //     &self,
-    //     _tls: VMMutatorThread,
-    //     _force: bool,
-    //     _exhaustive: bool,
-    // ) {
-    //     warn!("User attempted a collection request, but it is not supported in NoGC. The request is ignored.");
-    // }
 }
 
 impl<VM: VMBinding> NoGC<VM> {

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -1,4 +1,3 @@
-use crate::MMTK;
 use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
@@ -7,10 +6,10 @@ use crate::plan::mutator_context::{
 };
 use crate::plan::nogc::NoGC;
 use crate::plan::AllocationSemantics;
-use crate::plan::Plan;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;
+use crate::MMTK;
 use enum_map::{enum_map, EnumMap};
 
 /// We use three bump allocators when enabling nogc_multi_space.
@@ -50,18 +49,9 @@ pub fn create_nogc_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(MULTI_SPACE_RESERVED_ALLOCATORS, false, plan);
-            vec.push((
-                AllocatorSelector::BumpPointer(0),
-                &plan.nogc_space,
-            ));
-            vec.push((
-                AllocatorSelector::BumpPointer(1),
-                &plan.immortal,
-            ));
-            vec.push((
-                AllocatorSelector::BumpPointer(2),
-                &plan.los,
-            ));
+            vec.push((AllocatorSelector::BumpPointer(0), &plan.nogc_space));
+            vec.push((AllocatorSelector::BumpPointer(1), &plan.immortal));
+            vec.push((AllocatorSelector::BumpPointer(2), &plan.los));
             vec
         }),
         prepare_func: &nogc_mutator_noop,

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -49,9 +49,18 @@ pub fn create_nogc_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(MULTI_SPACE_RESERVED_ALLOCATORS, false, plan);
-            vec.push((AllocatorSelector::BumpPointer(0), &plan.nogc_space));
-            vec.push((AllocatorSelector::BumpPointer(1), &plan.immortal));
-            vec.push((AllocatorSelector::BumpPointer(2), &plan.los));
+            vec.push((
+                AllocatorSelector::BumpPointer(0),
+                plan.nogc_space.clone().into_dyn_space(),
+            ));
+            vec.push((
+                AllocatorSelector::BumpPointer(1),
+                plan.immortal.clone().into_dyn_space(),
+            ));
+            vec.push((
+                AllocatorSelector::BumpPointer(2),
+                plan.los.clone().into_dyn_space(),
+            ));
             vec
         }),
         prepare_func: &nogc_mutator_noop,

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -55,6 +55,10 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         self.space.release(true);
     }
 
+    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+
     fn get_used_pages(&self) -> usize {
         self.space.reserved_pages() + self.common.get_used_pages()
     }

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -2,7 +2,6 @@ use super::gc_work::PPGCWorkContext;
 use super::mutator::ALLOCATOR_MAPPING;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::global_state::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;
@@ -56,7 +55,7 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         self.space.release(true);
     }
 
-    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         false
     }
 

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -46,12 +46,12 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         &ALLOCATOR_MAPPING
     }
 
-    fn prepare(&mut self, tls: VMWorkerThread) {
+    fn prepare(&self, tls: VMWorkerThread) {
         self.common.prepare(tls, true);
         self.space.write().prepare(true);
     }
 
-    fn release(&mut self, tls: VMWorkerThread) {
+    fn release(&self, tls: VMWorkerThread) {
         self.common.release(tls, true);
         self.space.write().release(true);
     }

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -2,7 +2,7 @@ use super::gc_work::PPGCWorkContext;
 use super::mutator::ALLOCATOR_MAPPING;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::plan::global::GcStatus;
+use crate::global_state::GcStatus;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;
@@ -39,8 +39,6 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
-        self.base().set_collection_kind::<Self>(self);
-        self.base().set_gc_status(GcStatus::GcPrepare);
         scheduler.schedule_common_work::<PPGCWorkContext<VM>>(self);
     }
 
@@ -59,7 +57,7 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        self.base().collection_required(self, space_full)
+        false
     }
 
     fn get_used_pages(&self) -> usize {

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -55,10 +55,6 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         self.space.release(true);
     }
 
-    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        false
-    }
-
     fn get_used_pages(&self) -> usize {
         self.space.reserved_pages() + self.common.get_used_pages()
     }

--- a/src/plan/pageprotect/mutator.rs
+++ b/src/plan/pageprotect/mutator.rs
@@ -44,7 +44,10 @@ pub fn create_pp_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, page);
-            vec.push((AllocatorSelector::LargeObject(0), &page.space));
+            vec.push((
+                AllocatorSelector::LargeObject(0),
+                page.space.clone().into_dyn_space(),
+            ));
             vec
         }),
         prepare_func: &pp_mutator_prepare,

--- a/src/plan/pageprotect/mutator.rs
+++ b/src/plan/pageprotect/mutator.rs
@@ -1,14 +1,13 @@
 use super::PageProtect;
-use crate::MMTK;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::{
     create_allocator_mapping, create_space_mapping, ReservedAllocators,
 };
 use crate::plan::AllocationSemantics;
-use crate::plan::Plan;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::vm::VMBinding;
+use crate::MMTK;
 use crate::{
     plan::barriers::NoBarrier,
     util::opaque_pointer::{VMMutatorThread, VMWorkerThread},

--- a/src/plan/plan_constraints.rs
+++ b/src/plan/plan_constraints.rs
@@ -8,6 +8,8 @@ use crate::util::constants::*;
 /// and use the constant wherever possible. However, for plan-neutral implementations,
 /// these constraints are not constant.
 pub struct PlanConstraints {
+    /// Does the plan collect garbage? Obviously most plans do, but NoGC does not collect.
+    pub collects_garbage: bool,
     pub moves_objects: bool,
     pub gc_header_bits: usize,
     pub gc_header_words: usize,
@@ -38,6 +40,7 @@ pub struct PlanConstraints {
 impl PlanConstraints {
     pub const fn default() -> Self {
         PlanConstraints {
+            collects_garbage: true,
             moves_objects: false,
             gc_header_bits: 0,
             gc_header_words: 0,

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -96,6 +96,10 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         self.fromspace().release();
     }
 
+    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+
     fn get_collection_reserved_pages(&self) -> usize {
         self.tospace().reserved_pages()
     }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -76,7 +76,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         &ALLOCATOR_MAPPING
     }
 
-    fn prepare(&mut self, tls: VMWorkerThread) {
+    fn prepare(&self, tls: VMWorkerThread) {
         self.common.prepare(tls, true);
 
         self.hi
@@ -96,7 +96,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
             .rebind(self.tospace().clone());
     }
 
-    fn release(&mut self, tls: VMWorkerThread) {
+    fn release(&self, tls: VMWorkerThread) {
         self.common.release(tls, true);
         // release the collected region
         self.fromspace().read().release();

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -2,7 +2,6 @@ use super::gc_work::SSGCWorkContext;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::global_state::GcStatus;
 use crate::plan::semispace::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -97,7 +96,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         self.fromspace().release();
     }
 
-    fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
+    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
         false
     }
 

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -104,12 +104,12 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         self.tospace().reserved_pages() + self.common.get_used_pages()
     }
 
-    // fn get_available_pages(&self) -> usize {
-    //     (self
-    //         .get_total_pages()
-    //         .saturating_sub(self.get_reserved_pages()))
-    //         >> 1
-    // }
+    fn get_available_pages(&self) -> usize {
+        (self
+            .get_total_pages()
+            .saturating_sub(self.get_reserved_pages()))
+            >> 1
+    }
 
     fn base(&self) -> &BasePlan<VM> {
         &self.common.base

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -2,7 +2,7 @@ use super::gc_work::SSGCWorkContext;
 use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
-use crate::plan::global::GcStatus;
+use crate::global_state::GcStatus;
 use crate::plan::semispace::mutator::ALLOCATOR_MAPPING;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
@@ -66,8 +66,6 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
     }
 
     fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
-        self.base().set_collection_kind::<Self>(self);
-        self.base().set_gc_status(GcStatus::GcPrepare);
         scheduler.schedule_common_work::<SSGCWorkContext<VM>>(self);
     }
 
@@ -100,7 +98,7 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        self.base().collection_required(self, space_full)
+        false
     }
 
     fn get_collection_reserved_pages(&self) -> usize {
@@ -111,12 +109,12 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         self.tospace().reserved_pages() + self.common.get_used_pages()
     }
 
-    fn get_available_pages(&self) -> usize {
-        (self
-            .get_total_pages()
-            .saturating_sub(self.get_reserved_pages()))
-            >> 1
-    }
+    // fn get_available_pages(&self) -> usize {
+    //     (self
+    //         .get_total_pages()
+    //         .saturating_sub(self.get_reserved_pages()))
+    //         >> 1
+    // }
 
     fn base(&self) -> &BasePlan<VM> {
         &self.common.base

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -96,10 +96,6 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         self.fromspace().release();
     }
 
-    fn collection_required(&self, _space_full: bool, _space: Option<&dyn Space<Self::VM>>) -> bool {
-        false
-    }
-
     fn get_collection_reserved_pages(&self) -> usize {
         self.tospace().reserved_pages()
     }

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -31,7 +31,9 @@ pub fn ss_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, _tls: VMWork
             .plan
             .downcast_ref::<SemiSpace<VM>>()
             .unwrap()
-            .tospace(),
+            .tospace()
+            .clone()
+            .into_dyn_space(),
     );
 }
 
@@ -57,7 +59,10 @@ pub fn create_ss_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, ss);
-            vec.push((AllocatorSelector::BumpPointer(0), ss.tospace()));
+            vec.push((
+                AllocatorSelector::BumpPointer(0),
+                ss.tospace().clone().into_dyn_space(),
+            ));
             vec
         }),
         prepare_func: &ss_mutator_prepare,

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -1,5 +1,4 @@
 use super::SemiSpace;
-use crate::MMTK;
 use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorConfig;
@@ -7,11 +6,11 @@ use crate::plan::mutator_context::{
     create_allocator_mapping, create_space_mapping, ReservedAllocators,
 };
 use crate::plan::AllocationSemantics;
-use crate::plan::Plan;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::BumpAllocator;
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;
+use crate::MMTK;
 use enum_map::EnumMap;
 
 pub fn ss_mutator_prepare<VM: VMBinding>(_mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -108,7 +108,10 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
     fn prepare(&mut self, tls: crate::util::VMWorkerThread) {
         if self.is_current_gc_nursery() {
             // Prepare both large object space and immix space
-            self.immix.immix_space.prepare(false);
+            self.immix.immix_space.prepare(
+                false,
+                crate::policy::immix::defrag::PlanStatsForDefrag::collect(self),
+            );
             self.immix.common.los.prepare(false);
         } else {
             self.full_heap_gc_count.lock().unwrap().inc();

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -109,7 +109,7 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
         &super::mutator::ALLOCATOR_MAPPING
     }
 
-    fn prepare(&mut self, tls: crate::util::VMWorkerThread) {
+    fn prepare(&self, tls: crate::util::VMWorkerThread) {
         if self.is_current_gc_nursery() {
             // Prepare both large object space and immix space
             self.immix.immix_space.write().prepare(
@@ -123,7 +123,7 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
         }
     }
 
-    fn release(&mut self, tls: crate::util::VMWorkerThread) {
+    fn release(&self, tls: crate::util::VMWorkerThread) {
         if self.is_current_gc_nursery() {
             let was_defrag = self.immix.immix_space.write().release(false);
             self.immix
@@ -134,7 +134,7 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
         }
     }
 
-    fn end_of_gc(&mut self, _tls: crate::util::opaque_pointer::VMWorkerThread) {
+    fn end_of_gc(&self, _tls: crate::util::opaque_pointer::VMWorkerThread) {
         let next_gc_full_heap =
             crate::plan::generational::global::CommonGenPlan::should_next_gc_be_full_heap(self);
         self.next_gc_full_heap

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -3,7 +3,6 @@ use crate::plan::global::CommonPlan;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::immix;
-use crate::global_state::GcStatus;
 use crate::plan::PlanConstraints;
 use crate::policy::immix::ImmixSpace;
 use crate::policy::sft::SFT;
@@ -292,7 +291,7 @@ impl<VM: VMBinding> StickyImmix<VM> {
                 &crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
             ),
         };
-        
+
         let immix = immix::Immix::new_with_args(
             plan_args,
             crate::policy::immix::ImmixSpaceArgs {
@@ -322,7 +321,8 @@ impl<VM: VMBinding> StickyImmix<VM> {
             .immix
             .common
             .base
-            .global_state.user_triggered_collection
+            .global_state
+            .user_triggered_collection
             .load(Ordering::SeqCst)
             && *self.immix.common.base.options.full_heap_system_gc
         {
@@ -333,7 +333,8 @@ impl<VM: VMBinding> StickyImmix<VM> {
                 .immix
                 .common
                 .base
-                .global_state.cur_collection_attempts
+                .global_state
+                .cur_collection_attempts
                 .load(Ordering::SeqCst)
                 > 1
         {

--- a/src/plan/sticky/immix/mutator.rs
+++ b/src/plan/sticky/immix/mutator.rs
@@ -30,7 +30,10 @@ pub fn create_stickyimmix_mutator<VM: VMBinding>(
         space_mapping: Box::new({
             let mut vec =
                 create_space_mapping(immix::mutator::RESERVED_ALLOCATORS, true, mmtk.get_plan());
-            vec.push((AllocatorSelector::Immix(0), stickyimmix.get_immix_space()));
+            vec.push((
+                AllocatorSelector::Immix(0),
+                stickyimmix.get_immix_space().clone().into_dyn_space(),
+            ));
             vec
         }),
         prepare_func: &stickyimmix_mutator_prepare,

--- a/src/plan/sticky/immix/mutator.rs
+++ b/src/plan/sticky/immix/mutator.rs
@@ -38,7 +38,7 @@ pub fn create_stickyimmix_mutator<VM: VMBinding>(
     };
 
     Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk.get_plan(), &config.space_mapping),
+        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         barrier: Box::new(ObjectBarrier::new(GenObjectBarrierSemantics::new(
             mmtk,
             stickyimmix,

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -14,8 +14,8 @@ use crate::util::object_forwarding;
 use crate::util::{Address, ObjectReference};
 use crate::vm::*;
 use libc::{mprotect, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 /// This type implements a simple copying space.
 pub struct CopySpace<VM: VMBinding> {
@@ -290,7 +290,6 @@ impl<VM: VMBinding> CopySpace<VM> {
     }
 }
 
-use crate::plan::Plan;
 use crate::util::alloc::Allocator;
 use crate::util::alloc::BumpAllocator;
 use crate::util::opaque_pointer::VMWorkerThread;

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -301,7 +301,7 @@ use crate::util::alloc::Allocator;
 use crate::util::alloc::BumpAllocator;
 use crate::util::opaque_pointer::VMWorkerThread;
 
-use crate::policy::space_ref::SpaceRef;
+use crate::util::rust_util::shared_ref::SharedRef;
 
 /// Copy allocator for CopySpace
 pub struct CopySpaceCopyContext<VM: VMBinding> {
@@ -330,17 +330,17 @@ impl<VM: VMBinding> CopySpaceCopyContext<VM> {
     pub(crate) fn new(
         tls: VMWorkerThread,
         context: Arc<AllocatorContext<VM>>,
-        tospace: SpaceRef<CopySpace<VM>>,
+        tospace: SharedRef<CopySpace<VM>>,
     ) -> Self {
         CopySpaceCopyContext {
-            copy_allocator: BumpAllocator::new(tls.0, tospace, context),
+            copy_allocator: BumpAllocator::new(tls.0, tospace.to_dyn_space(), context),
         }
     }
 }
 
 impl<VM: VMBinding> CopySpaceCopyContext<VM> {
-    pub fn rebind(&mut self, space: SpaceRef<CopySpace<VM>>) {
+    pub fn rebind(&mut self, space: SharedRef<CopySpace<VM>>) {
         self.copy_allocator
-            .rebind(space);
+            .rebind(space.to_dyn_space());
     }
 }

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -301,7 +301,7 @@ use crate::util::alloc::Allocator;
 use crate::util::alloc::BumpAllocator;
 use crate::util::opaque_pointer::VMWorkerThread;
 
-use crate::util::rust_util::shared_ref::SharedRef;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 
 /// Copy allocator for CopySpace
 pub struct CopySpaceCopyContext<VM: VMBinding> {
@@ -330,17 +330,16 @@ impl<VM: VMBinding> CopySpaceCopyContext<VM> {
     pub(crate) fn new(
         tls: VMWorkerThread,
         context: Arc<AllocatorContext<VM>>,
-        tospace: SharedRef<CopySpace<VM>>,
+        tospace: ArcFlexMut<CopySpace<VM>>,
     ) -> Self {
         CopySpaceCopyContext {
-            copy_allocator: BumpAllocator::new(tls.0, tospace.to_dyn_space(), context),
+            copy_allocator: BumpAllocator::new(tls.0, tospace.into_dyn_space(), context),
         }
     }
 }
 
 impl<VM: VMBinding> CopySpaceCopyContext<VM> {
-    pub fn rebind(&mut self, space: SharedRef<CopySpace<VM>>) {
-        self.copy_allocator
-            .rebind(space.to_dyn_space());
+    pub fn rebind(&mut self, space: ArcFlexMut<CopySpace<VM>>) {
+        self.copy_allocator.rebind(space.into_dyn_space());
     }
 }

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -301,6 +301,8 @@ use crate::util::alloc::Allocator;
 use crate::util::alloc::BumpAllocator;
 use crate::util::opaque_pointer::VMWorkerThread;
 
+use crate::policy::space_ref::SpaceRef;
+
 /// Copy allocator for CopySpace
 pub struct CopySpaceCopyContext<VM: VMBinding> {
     copy_allocator: BumpAllocator<VM>,
@@ -328,7 +330,7 @@ impl<VM: VMBinding> CopySpaceCopyContext<VM> {
     pub(crate) fn new(
         tls: VMWorkerThread,
         context: Arc<AllocatorContext<VM>>,
-        tospace: &'static CopySpace<VM>,
+        tospace: SpaceRef<CopySpace<VM>>,
     ) -> Self {
         CopySpaceCopyContext {
             copy_allocator: BumpAllocator::new(tls.0, tospace, context),
@@ -337,8 +339,8 @@ impl<VM: VMBinding> CopySpaceCopyContext<VM> {
 }
 
 impl<VM: VMBinding> CopySpaceCopyContext<VM> {
-    pub fn rebind(&mut self, space: &CopySpace<VM>) {
+    pub fn rebind(&mut self, space: SpaceRef<CopySpace<VM>>) {
         self.copy_allocator
-            .rebind(unsafe { &*{ space as *const _ } });
+            .rebind(space);
     }
 }

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -4,6 +4,7 @@ use crate::policy::sft::GCWorkerMutRef;
 use crate::policy::sft::SFT;
 use crate::policy::space::{CommonSpace, Space};
 use crate::scheduler::GCWorker;
+use crate::util::alloc::allocator::AllocatorContext;
 use crate::util::copy::*;
 #[cfg(feature = "vo_bit")]
 use crate::util::heap::layout::vm_layout::BYTES_IN_CHUNK;
@@ -13,6 +14,7 @@ use crate::util::object_forwarding;
 use crate::util::{Address, ObjectReference};
 use crate::vm::*;
 use libc::{mprotect, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// This type implements a simple copying space.
@@ -317,13 +319,13 @@ impl<VM: VMBinding> PolicyCopyContext for CopySpaceCopyContext<VM> {
 }
 
 impl<VM: VMBinding> CopySpaceCopyContext<VM> {
-    pub fn new(
+    pub(crate) fn new(
         tls: VMWorkerThread,
-        plan: &'static dyn Plan<VM = VM>,
+        context: Arc<AllocatorContext<VM>>,
         tospace: &'static CopySpace<VM>,
     ) -> Self {
         CopySpaceCopyContext {
-            copy_allocator: BumpAllocator::new(tls.0, tospace, plan),
+            copy_allocator: BumpAllocator::new(tls.0, tospace, context),
         }
     }
 }

--- a/src/policy/immix/defrag.rs
+++ b/src/policy/immix/defrag.rs
@@ -3,8 +3,8 @@ use super::{
     line::Line,
     ImmixSpace,
 };
-use crate::policy::space::Space;
 use crate::util::linear_scan::Region;
+use crate::{policy::space::Space, Plan};
 use crate::{util::constants::LOG_BYTES_IN_PAGE, vm::*};
 use spin::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -23,6 +23,22 @@ pub struct Defrag {
     pub defrag_spill_threshold: AtomicUsize,
     /// The number of remaining clean pages in defrag space.
     available_clean_pages_for_defrag: AtomicUsize,
+}
+
+pub struct PlanStatsForDefrag {
+    total_pages: usize,
+    reserved_pages: usize,
+    collection_reserved_pages: usize,
+}
+
+impl PlanStatsForDefrag {
+    pub fn collect<VM: VMBinding>(plan: &dyn Plan<VM = VM>) -> Self {
+        Self {
+            total_pages: plan.get_total_pages(),
+            reserved_pages: plan.get_reserved_pages(),
+            collection_reserved_pages: plan.get_collection_reserved_pages(),
+        }
+    }
 }
 
 impl Defrag {
@@ -100,15 +116,14 @@ impl Defrag {
 
     /// Prepare work. Should be called in ImmixSpace::prepare.
     #[allow(clippy::assertions_on_constants)]
-    pub fn prepare<VM: VMBinding>(&self, space: &ImmixSpace<VM>) {
+    pub fn prepare<VM: VMBinding>(&self, space: &ImmixSpace<VM>, plan_stats: PlanStatsForDefrag) {
         debug_assert!(super::DEFRAG);
         self.defrag_space_exhausted.store(false, Ordering::Release);
 
         // Calculate available free space for defragmentation.
 
-        let mut available_clean_pages_for_defrag = VM::VMActivePlan::global().get_total_pages()
-            as isize
-            - VM::VMActivePlan::global().get_reserved_pages() as isize
+        let mut available_clean_pages_for_defrag = plan_stats.total_pages as isize
+            - plan_stats.reserved_pages as isize
             + self.defrag_headroom_pages(space) as isize;
         if available_clean_pages_for_defrag < 0 {
             available_clean_pages_for_defrag = 0
@@ -122,8 +137,7 @@ impl Defrag {
         }
 
         self.available_clean_pages_for_defrag.store(
-            available_clean_pages_for_defrag as usize
-                + VM::VMActivePlan::global().get_collection_reserved_pages(),
+            available_clean_pages_for_defrag as usize + plan_stats.collection_reserved_pages,
             Ordering::Release,
         );
     }

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -7,7 +7,6 @@ use crate::policy::sft::GCWorkerMutRef;
 use crate::policy::sft::SFT;
 use crate::policy::sft_map::SFTMap;
 use crate::policy::space::{CommonSpace, Space, SpaceAllocFail};
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::alloc::allocator::AllocatorContext;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::copy::*;
@@ -20,6 +19,7 @@ use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::metadata::vo_bit;
 use crate::util::metadata::{self, MetadataSpec};
 use crate::util::object_forwarding as ForwardingWord;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::{Address, ObjectReference};
 use crate::vm::*;
 use crate::{
@@ -989,7 +989,7 @@ impl<VM: VMBinding> ImmixCopyContext<VM> {
     pub(crate) fn new(
         tls: VMWorkerThread,
         context: Arc<AllocatorContext<VM>>,
-        space: SharedRef<ImmixSpace<VM>>,
+        space: ArcFlexMut<ImmixSpace<VM>>,
     ) -> Self {
         ImmixCopyContext {
             allocator: ImmixAllocator::new(tls.0, space, context, true),
@@ -1038,7 +1038,7 @@ impl<VM: VMBinding> ImmixHybridCopyContext<VM> {
     pub(crate) fn new(
         tls: VMWorkerThread,
         context: Arc<AllocatorContext<VM>>,
-        space: SharedRef<ImmixSpace<VM>>,
+        space: ArcFlexMut<ImmixSpace<VM>>,
     ) -> Self {
         ImmixHybridCopyContext {
             copy_allocator: ImmixAllocator::new(tls.0, space.clone(), context.clone(), false),
@@ -1046,7 +1046,7 @@ impl<VM: VMBinding> ImmixHybridCopyContext<VM> {
         }
     }
 
-    fn get_space(&self) -> &SharedRef<ImmixSpace<VM>> {
+    fn get_space(&self) -> &ArcFlexMut<ImmixSpace<VM>> {
         // Both copy allocators should point to the same space.
         debug_assert_eq!(
             self.defrag_allocator.space.read().common().descriptor,

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -6,6 +6,7 @@ use crate::policy::sft::GCWorkerMutRef;
 use crate::policy::sft::SFT;
 use crate::policy::sft_map::SFTMap;
 use crate::policy::space::{CommonSpace, Space};
+use crate::util::alloc::allocator::AllocatorContext;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::copy::*;
 use crate::util::heap::chunk_map::*;
@@ -988,13 +989,13 @@ impl<VM: VMBinding> PolicyCopyContext for ImmixCopyContext<VM> {
 }
 
 impl<VM: VMBinding> ImmixCopyContext<VM> {
-    pub fn new(
+    pub(crate) fn new(
         tls: VMWorkerThread,
-        plan: &'static dyn Plan<VM = VM>,
+        context: Arc<AllocatorContext<VM>>,
         space: &'static ImmixSpace<VM>,
     ) -> Self {
         ImmixCopyContext {
-            allocator: ImmixAllocator::new(tls.0, Some(space), plan, true),
+            allocator: ImmixAllocator::new(tls.0, Some(space), context, true),
         }
     }
 
@@ -1041,14 +1042,14 @@ impl<VM: VMBinding> PolicyCopyContext for ImmixHybridCopyContext<VM> {
 }
 
 impl<VM: VMBinding> ImmixHybridCopyContext<VM> {
-    pub fn new(
+    pub(crate) fn new(
         tls: VMWorkerThread,
-        plan: &'static dyn Plan<VM = VM>,
+        context: Arc<AllocatorContext<VM>>,
         space: &'static ImmixSpace<VM>,
     ) -> Self {
         ImmixHybridCopyContext {
-            copy_allocator: ImmixAllocator::new(tls.0, Some(space), plan, false),
-            defrag_allocator: ImmixAllocator::new(tls.0, Some(space), plan, true),
+            copy_allocator: ImmixAllocator::new(tls.0, Some(space), context.clone(), false),
+            defrag_allocator: ImmixAllocator::new(tls.0, Some(space), context, true),
         }
     }
 

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -954,7 +954,6 @@ impl<VM: VMBinding> FlushPageResource<VM> {
     }
 }
 
-use crate::plan::Plan;
 use crate::policy::copy_context::PolicyCopyContext;
 use crate::util::alloc::Allocator;
 use crate::util::alloc::ImmixAllocator;

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -1,3 +1,4 @@
+use super::defrag::PlanStatsForDefrag;
 use super::line::*;
 use super::{block::*, defrag::Defrag};
 use crate::plan::VectorObjectQueue;
@@ -366,7 +367,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         &self.scheduler
     }
 
-    pub fn prepare(&mut self, major_gc: bool) {
+    pub fn prepare(&mut self, major_gc: bool, plan_stats: PlanStatsForDefrag) {
         if major_gc {
             // Update mark_state
             if VM::VMObjectModel::LOCAL_MARK_BIT_SPEC.is_on_side() {
@@ -378,7 +379,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
 
             // Prepare defrag info
             if super::DEFRAG {
-                self.defrag.prepare(self);
+                self.defrag.prepare(self, plan_stats);
             }
 
             // Prepare each block for GC

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -123,6 +123,8 @@ impl<VM: VMBinding> Space<VM> for LargeObjectSpace<VM> {
 use crate::scheduler::GCWorker;
 use crate::util::copy::CopySemantics;
 
+use super::space::SpaceAllocFail;
+
 impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for LargeObjectSpace<VM> {
     fn trace_object<Q: ObjectQueue, const KIND: crate::policy::gc_work::TraceKind>(
         &self,
@@ -242,7 +244,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
     }
 
     /// Allocate an object
-    pub fn allocate_pages(&self, tls: VMThread, pages: usize) -> Address {
+    pub fn allocate_pages(&self, tls: VMThread, pages: usize) -> Result<Address, SpaceAllocFail> {
         self.acquire(tls, pages)
     }
 

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -114,7 +114,7 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
         data_pages + meta_pages
     }
 
-    fn acquire(&self, _tls: VMThread, pages: usize) -> Address {
+    fn acquire(&self, _tls: VMThread, pages: usize) -> Result<Address, SpaceAllocFail> {
         let bytes = conversions::pages_to_bytes(pages);
         let start = self
             .cursor
@@ -128,7 +128,7 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
         if self.slow_path_zeroing {
             crate::util::memory::zero(start, bytes);
         }
-        start
+        Ok(start)
     }
 
     /// Get the name of the space
@@ -150,6 +150,8 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
 use crate::plan::{ObjectQueue, VectorObjectQueue};
 use crate::scheduler::GCWorker;
 use crate::util::copy::CopySemantics;
+
+use super::space::SpaceAllocFail;
 
 impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for LockFreeImmortalSpace<VM> {
     fn trace_object<Q: ObjectQueue, const KIND: crate::policy::gc_work::TraceKind>(

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -21,7 +21,7 @@ use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::util::{conversions, metadata};
 use crate::vm::VMBinding;
-use crate::vm::{ActivePlan, Collection, ObjectModel};
+use crate::vm::{ActivePlan, ObjectModel};
 use crate::{policy::space::Space, util::heap::layout::vm_layout::BYTES_IN_CHUNK};
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
@@ -328,7 +328,13 @@ impl<VM: VMBinding> MallocSpace<VM> {
         }
     }
 
-    pub fn alloc(&self, tls: VMThread, size: usize, align: usize, offset: usize) -> Result<Address, SpaceAllocFail> {
+    pub fn alloc(
+        &self,
+        tls: VMThread,
+        size: usize,
+        align: usize,
+        offset: usize,
+    ) -> Result<Address, SpaceAllocFail> {
         // TODO: Should refactor this and Space.acquire()
         if self.get_gc_trigger().poll(false, Some(self)) {
             assert!(VM::VMActivePlan::is_mutator(tls), "Polling in GC worker");

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -6,6 +6,7 @@ use crate::plan::VectorObjectQueue;
 use crate::policy::sft::GCWorkerMutRef;
 use crate::policy::sft::SFT;
 use crate::policy::space::CommonSpace;
+use crate::policy::space::SpaceAllocFail;
 use crate::scheduler::GCWorkScheduler;
 use crate::util::heap::gc_trigger::GCTrigger;
 use crate::util::heap::PageResource;
@@ -327,12 +328,11 @@ impl<VM: VMBinding> MallocSpace<VM> {
         }
     }
 
-    pub fn alloc(&self, tls: VMThread, size: usize, align: usize, offset: usize) -> Address {
+    pub fn alloc(&self, tls: VMThread, size: usize, align: usize, offset: usize) -> Result<Address, SpaceAllocFail> {
         // TODO: Should refactor this and Space.acquire()
         if self.get_gc_trigger().poll(false, Some(self)) {
             assert!(VM::VMActivePlan::is_mutator(tls), "Polling in GC worker");
-            VM::VMCollection::block_for_gc(VMMutatorThread(tls));
-            return unsafe { Address::zero() };
+            return Err(SpaceAllocFail);
         }
 
         let (address, is_offset_malloc) = alloc::<VM>(size, align, offset);
@@ -363,7 +363,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
             }
         }
 
-        address
+        Ok(address)
     }
 
     pub fn free(&self, addr: Address) {

--- a/src/policy/marksweepspace/mod.rs
+++ b/src/policy/marksweepspace/mod.rs
@@ -9,7 +9,7 @@
 
 // TODO: we should extract the code about mark sweep, and make both implementation use the same mark sweep code.
 
-// We will only use one of the two depends on the enabled feature.
+// We will only use one of the two mark sweep implementations, depending on the enabled feature.
 #![allow(dead_code)]
 
 /// Malloc mark sweep. This uses `MallocSpace` and `MallocAllocator`.

--- a/src/policy/marksweepspace/mod.rs
+++ b/src/policy/marksweepspace/mod.rs
@@ -9,6 +9,9 @@
 
 // TODO: we should extract the code about mark sweep, and make both implementation use the same mark sweep code.
 
+// We will only use one of the two depends on the enabled feature.
+#![allow(dead_code)]
+
 /// Malloc mark sweep. This uses `MallocSpace` and `MallocAllocator`.
 pub(crate) mod malloc_ms;
 /// Native mark sweep. This uses `MarkSweepSpace` and `FreeListAllocator`.

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -333,12 +333,12 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
                 }
             }
         }
+        use crate::vm::Collection;
 
         let acquired = self.acquire(tls, Block::BYTES >> LOG_BYTES_IN_PAGE);
-        if acquired.is_zero() {
-            BlockAcquireResult::Exhausted
-        } else {
-            BlockAcquireResult::Fresh(Block::from_unaligned_address(acquired))
+        match acquired {
+            Err(_) => BlockAcquireResult::Exhausted,
+            Ok(addr) => BlockAcquireResult::Fresh(Block::from_unaligned_address(addr))
         }
     }
 

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -333,12 +333,11 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
                 }
             }
         }
-        use crate::vm::Collection;
 
         let acquired = self.acquire(tls, Block::BYTES >> LOG_BYTES_IN_PAGE);
         match acquired {
             Err(_) => BlockAcquireResult::Exhausted,
-            Ok(addr) => BlockAcquireResult::Fresh(Block::from_unaligned_address(addr))
+            Ok(addr) => BlockAcquireResult::Fresh(Block::from_unaligned_address(addr)),
         }
     }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -14,6 +14,8 @@
 /// memory).
 pub mod space;
 
+pub mod space_ref;
+
 /// Copy context defines the thread local copy allocator for copying policies.
 pub mod copy_context;
 /// Policy specific GC work

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -87,7 +87,10 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         // - If tls is collector, we cannot attempt a GC.
         // - If gc is disabled, we cannot attempt a GC.
         let should_poll = VM::VMActivePlan::is_mutator(tls)
-            && self.common().global_state.should_trigger_gc_when_heap_is_full();
+            && self
+                .common()
+                .global_state
+                .should_trigger_gc_when_heap_is_full();
         // Is a GC allowed here? If we should poll but are not allowed to poll, we will panic.
         // initialize_collection() has to be called so we know GC is initialized.
         let allow_gc = should_poll && self.common().global_state.is_initialized();

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -1,3 +1,4 @@
+use crate::global_state::GlobalState;
 use crate::plan::PlanConstraints;
 use crate::scheduler::GCWorkScheduler;
 use crate::util::conversions::*;
@@ -86,10 +87,10 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         // - If tls is collector, we cannot attempt a GC.
         // - If gc is disabled, we cannot attempt a GC.
         let should_poll = VM::VMActivePlan::is_mutator(tls)
-            && VM::VMActivePlan::global().should_trigger_gc_when_heap_is_full();
+            && self.common().global_state.should_trigger_gc_when_heap_is_full();
         // Is a GC allowed here? If we should poll but are not allowed to poll, we will panic.
         // initialize_collection() has to be called so we know GC is initialized.
-        let allow_gc = should_poll && VM::VMActivePlan::global().is_initialized();
+        let allow_gc = should_poll && self.common().global_state.is_initialized();
 
         trace!("Reserving pages");
         let pr = self.get_page_resource();
@@ -437,6 +438,7 @@ pub struct CommonSpace<VM: VMBinding> {
     pub acquire_lock: Mutex<()>,
 
     pub gc_trigger: Arc<GCTrigger<VM>>,
+    pub global_state: Arc<GlobalState>,
 
     p: PhantomData<VM>,
 }
@@ -462,6 +464,7 @@ pub struct PlanCreateSpaceArgs<'a, VM: VMBinding> {
     pub gc_trigger: Arc<GCTrigger<VM>>,
     pub scheduler: Arc<GCWorkScheduler<VM>>,
     pub options: &'a Options,
+    pub global_state: Arc<GlobalState>,
 }
 
 impl<'a, VM: VMBinding> PlanCreateSpaceArgs<'a, VM> {
@@ -503,6 +506,7 @@ impl<VM: VMBinding> CommonSpace<VM> {
                 local: args.local_side_metadata_specs,
             },
             acquire_lock: Mutex::new(()),
+            global_state: args.plan_args.global_state,
             p: PhantomData,
         };
 

--- a/src/policy/space_ref.rs
+++ b/src/policy/space_ref.rs
@@ -1,74 +1,74 @@
-use std::sync::Arc;
+// use std::sync::Arc;
 
-use crate::vm::VMBinding;
-use crate::policy::space::Space;
+// use crate::vm::VMBinding;
+// use crate::policy::space::Space;
 
-// pub use parking_lot_impl::SpaceRef;
-// pub use parking_lot_impl::downcast;
-// pub use parking_lot_impl::new;
-pub use peace_lock_impl::SpaceRef;
-pub use peace_lock_impl::downcast;
-pub use peace_lock_impl::new;
+// // pub use parking_lot_impl::SpaceRef;
+// // pub use parking_lot_impl::downcast;
+// // pub use parking_lot_impl::new;
+// pub use peace_lock_impl::SpaceRef;
+// pub use peace_lock_impl::downcast;
+// pub use peace_lock_impl::new;
 
-#[macro_export]
-macro_rules! space_ref_write {
-    ($r: expr) => {
-        {
-            trace!("{} acquire write lock on {}", std::panic::Location::caller(), stringify!($r));
-            $r.write()
-        }
-    }
-}
+// #[macro_export]
+// macro_rules! space_ref_write {
+//     ($r: expr) => {
+//         {
+//             trace!("{} acquire write lock on {}", std::panic::Location::caller(), stringify!($r));
+//             $r.write()
+//         }
+//     }
+// }
 
-#[macro_export]
-macro_rules! space_ref_read {
-    ($r: expr) => {
-        {
-            trace!("{} acquire read lock on {}", std::panic::Location::caller(), stringify!($r));
-            $r.read()
-        }
-    }
-}
+// #[macro_export]
+// macro_rules! space_ref_read {
+//     ($r: expr) => {
+//         {
+//             trace!("{} acquire read lock on {}", std::panic::Location::caller(), stringify!($r));
+//             $r.read()
+//         }
+//     }
+// }
 
-mod parking_lot_impl {
-    use super::*;
+// mod parking_lot_impl {
+//     use super::*;
 
-    pub type SpaceRef<T> = Arc<parking_lot::RwLock<T>>;
+//     pub type SpaceRef<T> = Arc<parking_lot::RwLock<T>>;
 
-    pub fn new<VM: VMBinding, S: Space<VM>>(s: S) -> SpaceRef<S> {
-        Arc::new(parking_lot::RwLock::new(s))
-    }
+//     pub fn new<VM: VMBinding, S: Space<VM>>(s: S) -> SpaceRef<S> {
+//         Arc::new(parking_lot::RwLock::new(s))
+//     }
 
-    pub fn downcast<VM: VMBinding, S: Space<VM>>(a: SpaceRef<dyn Space<VM>>) -> SpaceRef<S> {
-        let lock = a.read();
-        if lock.downcast_ref::<S>().is_some() {
-            drop(lock);
-            let raw = Arc::into_raw(a);
-            unsafe { Arc::from_raw(raw as *const parking_lot::RwLock<S>) }
-        } else {
-            panic!("Failed to downcast")
-        }
-    }
+//     pub fn downcast<VM: VMBinding, S: Space<VM>>(a: SpaceRef<dyn Space<VM>>) -> SpaceRef<S> {
+//         let lock = a.read();
+//         if lock.downcast_ref::<S>().is_some() {
+//             drop(lock);
+//             let raw = Arc::into_raw(a);
+//             unsafe { Arc::from_raw(raw as *const parking_lot::RwLock<S>) }
+//         } else {
+//             panic!("Failed to downcast")
+//         }
+//     }
 
-}
+// }
 
-mod peace_lock_impl {
-    use super::*;
+// mod peace_lock_impl {
+//     use super::*;
 
-    pub type SpaceRef<T> = Arc<peace_lock::RwLock<T>>;
+//     pub type SpaceRef<T> = Arc<peace_lock::RwLock<T>>;
 
-    pub fn new<VM: VMBinding, S: Space<VM>>(s: S) -> SpaceRef<S> {
-        Arc::new(peace_lock::RwLock::new(s))
-    }
+//     pub fn new<VM: VMBinding, S: Space<VM>>(s: S) -> SpaceRef<S> {
+//         Arc::new(peace_lock::RwLock::new(s))
+//     }
 
-    pub fn downcast<VM: VMBinding, S: Space<VM>>(a: SpaceRef<dyn Space<VM>>) -> SpaceRef<S> {
-        let lock = a.read();
-        if lock.downcast_ref::<S>().is_some() {
-            drop(lock);
-            let raw = Arc::into_raw(a);
-            unsafe { Arc::from_raw(raw as *const peace_lock::RwLock<S>) }
-        } else {
-            panic!("Failed to downcast")
-        }
-    }
-}
+//     pub fn downcast<VM: VMBinding, S: Space<VM>>(a: SpaceRef<dyn Space<VM>>) -> SpaceRef<S> {
+//         let lock = a.read();
+//         if lock.downcast_ref::<S>().is_some() {
+//             drop(lock);
+//             let raw = Arc::into_raw(a);
+//             unsafe { Arc::from_raw(raw as *const peace_lock::RwLock<S>) }
+//         } else {
+//             panic!("Failed to downcast")
+//         }
+//     }
+// }

--- a/src/policy/space_ref.rs
+++ b/src/policy/space_ref.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use crate::vm::VMBinding;
 use crate::policy::space::Space;
 
-pub use parking_lot_impl::SpaceRef;
-pub use parking_lot_impl::downcast;
-pub use parking_lot_impl::new;
-// pub use peace_lock_impl::SpaceRef;
-// pub use peace_lock_impl::downcast;
-// pub use peace_lock_impl::new;
+// pub use parking_lot_impl::SpaceRef;
+// pub use parking_lot_impl::downcast;
+// pub use parking_lot_impl::new;
+pub use peace_lock_impl::SpaceRef;
+pub use peace_lock_impl::downcast;
+pub use peace_lock_impl::new;
 
 #[macro_export]
 macro_rules! space_ref_write {

--- a/src/policy/space_ref.rs
+++ b/src/policy/space_ref.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use crate::vm::VMBinding;
+use crate::policy::space::Space;
+
+pub use parking_lot_impl::SpaceRef;
+pub use parking_lot_impl::downcast;
+pub use parking_lot_impl::new;
+// pub use peace_lock_impl::SpaceRef;
+// pub use peace_lock_impl::downcast;
+// pub use peace_lock_impl::new;
+
+#[macro_export]
+macro_rules! space_ref_write {
+    ($r: expr) => {
+        {
+            trace!("{} acquire write lock on {}", std::panic::Location::caller(), stringify!($r));
+            $r.write()
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! space_ref_read {
+    ($r: expr) => {
+        {
+            trace!("{} acquire read lock on {}", std::panic::Location::caller(), stringify!($r));
+            $r.read()
+        }
+    }
+}
+
+mod parking_lot_impl {
+    use super::*;
+
+    pub type SpaceRef<T> = Arc<parking_lot::RwLock<T>>;
+
+    pub fn new<VM: VMBinding, S: Space<VM>>(s: S) -> SpaceRef<S> {
+        Arc::new(parking_lot::RwLock::new(s))
+    }
+
+    pub fn downcast<VM: VMBinding, S: Space<VM>>(a: SpaceRef<dyn Space<VM>>) -> SpaceRef<S> {
+        let lock = a.read();
+        if lock.downcast_ref::<S>().is_some() {
+            drop(lock);
+            let raw = Arc::into_raw(a);
+            unsafe { Arc::from_raw(raw as *const parking_lot::RwLock<S>) }
+        } else {
+            panic!("Failed to downcast")
+        }
+    }
+
+}
+
+mod peace_lock_impl {
+    use super::*;
+
+    pub type SpaceRef<T> = Arc<peace_lock::RwLock<T>>;
+
+    pub fn new<VM: VMBinding, S: Space<VM>>(s: S) -> SpaceRef<S> {
+        Arc::new(peace_lock::RwLock::new(s))
+    }
+
+    pub fn downcast<VM: VMBinding, S: Space<VM>>(a: SpaceRef<dyn Space<VM>>) -> SpaceRef<S> {
+        let lock = a.read();
+        if lock.downcast_ref::<S>().is_some() {
+            drop(lock);
+            let raw = Arc::into_raw(a);
+            unsafe { Arc::from_raw(raw as *const peace_lock::RwLock<S>) }
+        } else {
+            panic!("Failed to downcast")
+        }
+    }
+}

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -2,6 +2,7 @@ use crate::mmtk::SFT_MAP;
 use crate::plan::{ObjectQueue, VectorObjectQueue};
 use crate::policy::sft::GCWorkerMutRef;
 use crate::policy::sft::SFT;
+use crate::policy::space::SpaceAllocFail;
 use crate::policy::space::{CommonSpace, Space};
 use crate::util::address::Address;
 use crate::util::constants::BYTES_IN_PAGE;
@@ -119,7 +120,7 @@ impl<VM: VMBinding> Space<VM> for VMSpace<VM> {
         unreachable!()
     }
 
-    fn acquire(&self, _tls: VMThread, _pages: usize) -> Address {
+    fn acquire(&self, _tls: VMThread, _pages: usize) -> Result<Address, SpaceAllocFail> {
         unreachable!()
     }
 

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -130,10 +130,7 @@ impl<VM: VMBinding> GCController<VM> {
         self.scheduler.deactivate_all();
 
         // Tell GC trigger that GC ended - this happens before EndOfGC where we resume mutators.
-        self.mmtk
-            .get_plan()
-            .base()
-            .gc_trigger
+        self.mmtk.gc_trigger
             .policy
             .on_gc_end(self.mmtk);
 

--- a/src/scheduler/controller.rs
+++ b/src/scheduler/controller.rs
@@ -130,9 +130,7 @@ impl<VM: VMBinding> GCController<VM> {
         self.scheduler.deactivate_all();
 
         // Tell GC trigger that GC ended - this happens before EndOfGC where we resume mutators.
-        self.mmtk.gc_trigger
-            .policy
-            .on_gc_end(self.mmtk);
+        self.mmtk.gc_trigger.policy.on_gc_end(self.mmtk);
 
         // Finalization: Resume mutators, reset gc states
         // Note: Resume-mutators must happen after all work buckets are closed.

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -19,7 +19,7 @@ impl<VM: VMBinding> GCWork<VM> for ScheduleCollection {
             mmtk.get_plan().notify_emergency_collection();
         }
 
-        mmtk.state.set_gc_status(GcStatus::GcPrepare);
+        mmtk.set_gc_status(GcStatus::GcPrepare);
 
         mmtk.get_plan().schedule_collection(worker.scheduler());
 
@@ -251,7 +251,7 @@ impl<VM: VMBinding> GCWork<VM> for EndOfGC {
             mmtk.edge_logger.reset();
         }
 
-        mmtk.state.set_gc_status(GcStatus::NotInGC);
+        mmtk.set_gc_status(GcStatus::NotInGC);
 
         // Reset the triggering information.
         mmtk.state.reset_collection_trigger();
@@ -463,7 +463,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanMutatorRoots<E> {
             <E::VM as VMBinding>::VMScanning::notify_initial_thread_scan_complete(
                 false, worker.tls,
             );
-            mmtk.state.set_gc_status(GcStatus::GcProper);
+            mmtk.set_gc_status(GcStatus::GcProper);
         }
     }
 }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -14,7 +14,10 @@ pub struct ScheduleCollection;
 
 impl<VM: VMBinding> GCWork<VM> for ScheduleCollection {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
-        let is_emergency = mmtk.state.set_collection_kind(mmtk.get_plan().last_collection_was_exhaustive(), mmtk.gc_trigger.policy.can_heap_size_grow());
+        let is_emergency = mmtk.state.set_collection_kind(
+            mmtk.get_plan().last_collection_was_exhaustive(),
+            mmtk.gc_trigger.policy.can_heap_size_grow(),
+        );
         if is_emergency {
             mmtk.get_plan().notify_emergency_collection();
         }
@@ -449,7 +452,6 @@ pub struct ScanMutatorRoots<Edges: ProcessEdgesWork>(pub &'static mut Mutator<Ed
 impl<E: ProcessEdgesWork> GCWork<E::VM> for ScanMutatorRoots<E> {
     fn do_work(&mut self, worker: &mut GCWorker<E::VM>, mmtk: &'static MMTK<E::VM>) {
         trace!("ScanMutatorRoots for mutator {:?}", self.0.get_tls());
-        let base = mmtk.get_plan().base();
         let mutators = <E::VM as VMBinding>::VMActivePlan::number_of_mutators();
         let factory = ProcessEdgesWorkRootsWorkFactory::<E>::new(mmtk);
         <E::VM as VMBinding>::VMScanning::scan_roots_in_mutator_thread(

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -254,11 +254,11 @@ impl<VM: VMBinding> GCWork<VM> for EndOfGC {
             mmtk.edge_logger.reset();
         }
 
-        mmtk.set_gc_status(GcStatus::NotInGC);
-
         // Reset the triggering information.
         mmtk.state.reset_collection_trigger();
 
+        // Set to NotInGC after everything, and right before resuming mutators.
+        mmtk.set_gc_status(GcStatus::NotInGC);
         <VM as VMBinding>::VMCollection::resume_mutators(worker.tls);
     }
 }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -245,8 +245,7 @@ impl<VM: VMBinding> GCWork<VM> for EndOfGC {
         }
 
         // We assume this is the only running work packet that accesses plan at the point of execution
-        let plan_mut: &mut dyn Plan<VM = VM> = unsafe { mmtk.get_plan_mut() };
-        plan_mut.end_of_gc(worker.tls);
+        mmtk.get_plan().end_of_gc(worker.tls);
 
         #[cfg(feature = "extreme_assertions")]
         if crate::util::edge_logger::should_check_duplicate_edges(mmtk.get_plan()) {

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -93,7 +93,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         );
         let gc_controller = GCController::new(
             mmtk,
-            mmtk.get_plan().base().gc_requester.clone(),
+            mmtk.gc_requester.clone(),
             self.clone(),
             coordinator_worker,
         );
@@ -399,7 +399,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
     }
 
     pub fn notify_mutators_paused(&self, mmtk: &'static MMTK<VM>) {
-        mmtk.get_plan().base().gc_requester.clear_request();
+        mmtk.gc_requester.clear_request();
         let first_stw_bucket = &self.work_buckets[WorkBucketStage::first_stw_stage()];
         debug_assert!(!first_stw_bucket.is_activated());
         // Note: This is the only place where a non-coordinator thread opens a bucket.

--- a/src/scheduler/work.rs
+++ b/src/scheduler/work.rs
@@ -15,7 +15,7 @@ pub trait GCWork<VM: VMBinding>: 'static + Send {
     /// If the feature "work_packet_stats" is not enabled, this call simply forwards the call
     /// to `do_work()`.
     fn do_work_with_stat(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
-        debug!("{}", std::any::type_name::<Self>());
+        debug!("{} start", std::any::type_name::<Self>());
         debug_assert!(!worker.tls.0.0.is_null(), "TLS must be set correctly for a GC worker before the worker does any work. GC Worker {} has no valid tls.", worker.ordinal);
 
         #[cfg(feature = "work_packet_stats")]
@@ -34,6 +34,7 @@ pub trait GCWork<VM: VMBinding>: 'static + Send {
             let mut worker_stat = worker.shared.borrow_stat_mut();
             stat.end_of_work(&mut worker_stat);
         }
+        debug!("{} end", std::any::type_name::<Self>());
     }
 
     /// Get the compile-time static type name for the work packet.

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -1,4 +1,13 @@
+use crate::MMTK;
+use crate::global_state::GlobalState;
 use crate::util::address::Address;
+#[cfg(feature = "analysis")]
+use crate::util::analysis::AnalysisManager;
+use crate::util::heap::gc_trigger::GCTrigger;
+use crate::util::options::Options;
+
+use std::marker::PhantomData;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use crate::plan::Plan;
@@ -122,6 +131,26 @@ pub fn get_maximum_aligned_size_inner<VM: VMBinding>(
     }
 }
 
+pub struct AllocatorContext<VM: VMBinding> {
+    pub state: Arc<GlobalState>,
+    pub options: Arc<Options>,
+    pub gc_trigger: Arc<GCTrigger<VM>>,
+    #[cfg(feature = "analysis")]
+    pub analysis_manager: Arc<AnalysisManager<VM>>,
+}
+
+impl<VM: VMBinding> AllocatorContext<VM> {
+    pub fn new(mmtk: &MMTK<VM>) -> Self {
+        Self {
+            state: mmtk.state.clone(),
+            options: mmtk.options.clone(),
+            gc_trigger: mmtk.gc_trigger.clone(),
+            #[cfg(feature = "analysis")]
+            analysis_manager: mmtk.analysis_manager.clone(),
+        }
+    }
+}
+
 /// A trait which implements allocation routines. Every allocator needs to implements this trait.
 pub trait Allocator<VM: VMBinding>: Downcast {
     /// Return the [`VMThread`] associated with this allocator instance.
@@ -130,8 +159,10 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     /// Return the [`Space`](src/policy/space/Space) instance associated with this allocator instance.
     fn get_space(&self) -> &'static dyn Space<VM>;
 
-    /// Return the [`Plan`] instance that this allocator instance is associated with.
-    fn get_plan(&self) -> &'static dyn Plan<VM = VM>;
+    // /// Return the [`Plan`] instance that this allocator instance is associated with.
+    // fn get_plan(&self) -> &'static dyn Plan<VM = VM>;
+
+    fn get_context(&self) -> &AllocatorContext<VM>;
 
     /// Return if this allocator can do thread local allocation. If an allocator does not do thread
     /// local allocation, each allocation will go to slowpath and will have a check for GC polls.
@@ -195,9 +226,8 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     /// * `offset` the required offset in bytes.
     fn alloc_slow_inline(&mut self, size: usize, align: usize, offset: usize) -> Address {
         let tls = self.get_tls();
-        let plan = self.get_plan().base();
         let is_mutator = VM::VMActivePlan::is_mutator(tls);
-        let stress_test = plan.options.is_stress_test_gc_enabled();
+        let stress_test = self.get_context().options.is_stress_test_gc_enabled();
 
         // Information about the previous collection.
         let mut emergency_collection = false;
@@ -205,7 +235,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
 
         loop {
             // Try to allocate using the slow path
-            let result = if is_mutator && stress_test && *plan.options.precise_stress {
+            let result = if is_mutator && stress_test && *self.get_context().options.precise_stress {
                 // If we are doing precise stress GC, we invoke the special allow_slow_once call.
                 // alloc_slow_once_precise_stress() should make sure that every allocation goes
                 // to the slowpath (here) so we can check the allocation bytes and decide
@@ -214,7 +244,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 // If we should do a stress GC now, we tell the alloc_slow_once_precise_stress()
                 // so they would avoid try any thread local allocation, and directly call
                 // global acquire and do a poll.
-                let need_poll = is_mutator && plan.gc_trigger.should_do_stress_gc();
+                let need_poll = is_mutator && self.get_context().gc_trigger.should_do_stress_gc();
                 self.alloc_slow_once_precise_stress(size, align, offset, need_poll)
             } else {
                 // If we are not doing precise stress GC, just call the normal alloc_slow_once().
@@ -229,14 +259,14 @@ pub trait Allocator<VM: VMBinding>: Downcast {
 
             if !result.is_zero() {
                 // Report allocation success to assist OutOfMemory handling.
-                if !plan.global_state.allocation_success.load(Ordering::Relaxed) {
-                    plan.global_state.allocation_success.store(true, Ordering::SeqCst);
+                if !self.get_context().state.allocation_success.load(Ordering::Relaxed) {
+                    self.get_context().state.allocation_success.store(true, Ordering::SeqCst);
                 }
 
                 // Only update the allocation bytes if we haven't failed a previous allocation in this loop
-                if stress_test && self.get_plan().is_initialized() && !previous_result_zero {
+                if stress_test && self.get_context().state.is_initialized() && !previous_result_zero {
                     let allocated_size =
-                        if *plan.options.precise_stress || !self.does_thread_local_allocation() {
+                        if *self.get_context().options.precise_stress || !self.does_thread_local_allocation() {
                             // For precise stress test, or for allocators that do not have thread local buffer,
                             // we know exactly how many bytes we allocate.
                             size
@@ -247,19 +277,19 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                                 self.get_thread_local_buffer_granularity(),
                             )
                         };
-                    let _allocation_bytes = plan.global_state.increase_allocation_bytes_by(allocated_size);
+                    let _allocation_bytes = self.get_context().state.increase_allocation_bytes_by(allocated_size);
 
                     // This is the allocation hook for the analysis trait. If you want to call
                     // an analysis counter specific allocation hook, then here is the place to do so
                     #[cfg(feature = "analysis")]
-                    if _allocation_bytes > *plan.options.analysis_factor {
+                    if _allocation_bytes > *self.get_context().options.analysis_factor {
                         trace!(
                             "Analysis: allocation_bytes = {} more than analysis_factor = {}",
                             _allocation_bytes,
-                            *plan.options.analysis_factor
+                            *self.get_context().options.analysis_factor
                         );
 
-                        plan.analysis_manager.alloc_hook(size, align, offset);
+                        self.get_context().analysis_manager.alloc_hook(size, align, offset);
                     }
                 }
 
@@ -273,17 +303,17 @@ pub trait Allocator<VM: VMBinding>: Downcast {
             // the second GC, which is not emergency. In such case, we will give a false OOM.
             // We cannot just rely on the local var. Instead, we get the emergency collection value again,
             // and check both.
-            if emergency_collection && plan.global_state.is_emergency_collection() {
+            if emergency_collection && self.get_context().state.is_emergency_collection() {
                 trace!("Emergency collection");
                 // Report allocation success to assist OutOfMemory handling.
                 // This seems odd, but we must allow each OOM to run its course (and maybe give us back memory)
-                let fail_with_oom = !plan.global_state.allocation_success.swap(true, Ordering::SeqCst);
+                let fail_with_oom = !self.get_context().state.allocation_success.swap(true, Ordering::SeqCst);
                 trace!("fail with oom={}", fail_with_oom);
                 if fail_with_oom {
                     // Note that we throw a `HeapOutOfMemory` error here and return a null ptr back to the VM
                     trace!("Throw HeapOutOfMemory!");
                     VM::VMCollection::out_of_memory(tls, AllocationError::HeapOutOfMemory);
-                    plan.global_state.allocation_success.swap(false, Ordering::SeqCst);
+                    self.get_context().state.allocation_success.swap(false, Ordering::SeqCst);
                     return result;
                 }
             }
@@ -300,7 +330,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
 
             // Record whether last collection was an Emergency collection. If so, we make one more
             // attempt to allocate before we signal an OOM.
-            emergency_collection = self.get_plan().base().global_state.is_emergency_collection();
+            emergency_collection = self.get_context().state.is_emergency_collection();
             trace!("Got emergency collection as {}", emergency_collection);
             previous_result_zero = true;
         }

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -1,4 +1,5 @@
 use crate::global_state::GlobalState;
+use crate::policy::space_ref::SpaceRef;
 use crate::util::address::Address;
 #[cfg(feature = "analysis")]
 use crate::util::analysis::AnalysisManager;
@@ -154,9 +155,6 @@ impl<VM: VMBinding> AllocatorContext<VM> {
 pub trait Allocator<VM: VMBinding>: Downcast {
     /// Return the [`VMThread`] associated with this allocator instance.
     fn get_tls(&self) -> VMThread;
-
-    /// Return the [`Space`](src/policy/space/Space) instance associated with this allocator instance.
-    fn get_space(&self) -> &'static dyn Space<VM>;
 
     // Return the context for the allocator.
     fn get_context(&self) -> &AllocatorContext<VM>;

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -1,5 +1,5 @@
 use crate::global_state::GlobalState;
-use crate::policy::space_ref::SpaceRef;
+use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::address::Address;
 #[cfg(feature = "analysis")]
 use crate::util::analysis::AnalysisManager;

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -129,6 +129,7 @@ pub fn get_maximum_aligned_size_inner<VM: VMBinding>(
     }
 }
 
+/// The context an allocator needs to access in order to perform allocation.
 pub struct AllocatorContext<VM: VMBinding> {
     pub state: Arc<GlobalState>,
     pub options: Arc<Options>,
@@ -157,9 +158,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
     /// Return the [`Space`](src/policy/space/Space) instance associated with this allocator instance.
     fn get_space(&self) -> &'static dyn Space<VM>;
 
-    // /// Return the [`Plan`] instance that this allocator instance is associated with.
-    // fn get_plan(&self) -> &'static dyn Plan<VM = VM>;
-
+    // Return the context for the allocator.
     fn get_context(&self) -> &AllocatorContext<VM>;
 
     /// Return if this allocator can do thread local allocation. If an allocator does not do thread

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -1,5 +1,4 @@
 use crate::global_state::GlobalState;
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::address::Address;
 #[cfg(feature = "analysis")]
 use crate::util::analysis::AnalysisManager;
@@ -10,7 +9,6 @@ use crate::MMTK;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use crate::policy::space::Space;
 use crate::util::constants::*;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -4,8 +4,6 @@ use std::sync::Arc;
 
 use memoffset::offset_of;
 
-use crate::MMTK;
-use crate::plan::Plan;
 use crate::policy::largeobjectspace::LargeObjectSpace;
 use crate::policy::marksweepspace::malloc_ms::MallocSpace;
 use crate::policy::marksweepspace::native_ms::MarkSweepSpace;
@@ -16,10 +14,11 @@ use crate::util::alloc::{Allocator, BumpAllocator, ImmixAllocator};
 use crate::util::VMMutatorThread;
 use crate::vm::VMBinding;
 use crate::Mutator;
+use crate::MMTK;
 
+use super::allocator::AllocatorContext;
 use super::FreeListAllocator;
 use super::MarkCompactAllocator;
-use super::allocator::AllocatorContext;
 
 pub(crate) const MAX_BUMP_ALLOCATORS: usize = 6;
 pub(crate) const MAX_LARGE_OBJECT_ALLOCATORS: usize = 2;

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -1,8 +1,10 @@
 use std::mem::size_of;
 use std::mem::MaybeUninit;
+use std::sync::Arc;
 
 use memoffset::offset_of;
 
+use crate::MMTK;
 use crate::plan::Plan;
 use crate::policy::largeobjectspace::LargeObjectSpace;
 use crate::policy::marksweepspace::malloc_ms::MallocSpace;
@@ -17,6 +19,7 @@ use crate::Mutator;
 
 use super::FreeListAllocator;
 use super::MarkCompactAllocator;
+use super::allocator::AllocatorContext;
 
 pub(crate) const MAX_BUMP_ALLOCATORS: usize = 6;
 pub(crate) const MAX_LARGE_OBJECT_ALLOCATORS: usize = 2;
@@ -85,7 +88,7 @@ impl<VM: VMBinding> Allocators<VM> {
 
     pub fn new(
         mutator_tls: VMMutatorThread,
-        plan: &'static dyn Plan<VM = VM>,
+        mmtk: &MMTK<VM>,
         space_mapping: &[(AllocatorSelector, &'static dyn Space<VM>)],
     ) -> Self {
         let mut ret = Allocators {
@@ -96,6 +99,7 @@ impl<VM: VMBinding> Allocators<VM> {
             free_list: unsafe { MaybeUninit::uninit().assume_init() },
             markcompact: unsafe { MaybeUninit::uninit().assume_init() },
         };
+        let context = Arc::new(AllocatorContext::new(mmtk));
 
         for &(selector, space) in space_mapping.iter() {
             match selector {
@@ -103,28 +107,28 @@ impl<VM: VMBinding> Allocators<VM> {
                     ret.bump_pointer[index as usize].write(BumpAllocator::new(
                         mutator_tls.0,
                         space,
-                        plan,
+                        context.clone(),
                     ));
                 }
                 AllocatorSelector::LargeObject(index) => {
                     ret.large_object[index as usize].write(LargeObjectAllocator::new(
                         mutator_tls.0,
                         space.downcast_ref::<LargeObjectSpace<VM>>().unwrap(),
-                        plan,
+                        context.clone(),
                     ));
                 }
                 AllocatorSelector::Malloc(index) => {
                     ret.malloc[index as usize].write(MallocAllocator::new(
                         mutator_tls.0,
                         space.downcast_ref::<MallocSpace<VM>>().unwrap(),
-                        plan,
+                        context.clone(),
                     ));
                 }
                 AllocatorSelector::Immix(index) => {
                     ret.immix[index as usize].write(ImmixAllocator::new(
                         mutator_tls.0,
                         Some(space),
-                        plan,
+                        context.clone(),
                         false,
                     ));
                 }
@@ -132,14 +136,14 @@ impl<VM: VMBinding> Allocators<VM> {
                     ret.free_list[index as usize].write(FreeListAllocator::new(
                         mutator_tls.0,
                         space.downcast_ref::<MarkSweepSpace<VM>>().unwrap(),
-                        plan,
+                        context.clone(),
                     ));
                 }
                 AllocatorSelector::MarkCompact(index) => {
                     ret.markcompact[index as usize].write(MarkCompactAllocator::new(
                         mutator_tls.0,
                         space,
-                        plan,
+                        context.clone(),
                     ));
                 }
                 AllocatorSelector::None => panic!("Allocator mapping is not initialized"),

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -4,15 +4,11 @@ use std::sync::Arc;
 
 use memoffset::offset_of;
 
-use crate::policy::immix::ImmixSpace;
-use crate::policy::largeobjectspace::LargeObjectSpace;
-use crate::policy::marksweepspace::malloc_ms::MallocSpace;
-use crate::policy::marksweepspace::native_ms::MarkSweepSpace;
 use crate::policy::space::Space;
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::alloc::LargeObjectAllocator;
 use crate::util::alloc::MallocAllocator;
 use crate::util::alloc::{Allocator, BumpAllocator, ImmixAllocator};
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::VMMutatorThread;
 use crate::vm::VMBinding;
 use crate::Mutator;
@@ -90,7 +86,7 @@ impl<VM: VMBinding> Allocators<VM> {
     pub fn new(
         mutator_tls: VMMutatorThread,
         mmtk: &MMTK<VM>,
-        space_mapping: &[(AllocatorSelector, SharedRef<dyn Space<VM>>)],
+        space_mapping: &[(AllocatorSelector, ArcFlexMut<dyn Space<VM>>)],
     ) -> Self {
         let mut ret = Allocators {
             bump_pointer: unsafe { MaybeUninit::uninit().assume_init() },

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -4,7 +4,6 @@ use crate::util::Address;
 
 use crate::util::alloc::Allocator;
 
-use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::util::conversions::bytes_to_pages;
 use crate::util::opaque_pointer::*;

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::util::Address;
 
 use crate::util::alloc::Allocator;
@@ -20,8 +22,8 @@ pub struct BumpAllocator<VM: VMBinding> {
     pub(in crate::util::alloc) bump_pointer: BumpPointer,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
     space: &'static dyn Space<VM>,
-    /// [`Plan`] instance that this allocator instance is associated with.
-    plan: &'static dyn Plan<VM = VM>,
+    pub(in crate::util::alloc) context: Arc<AllocatorContext<VM>>,
+    _pad: usize,
 }
 
 /// A common fast-path bump-pointer allocator shared across different allocator implementations
@@ -65,13 +67,15 @@ impl<VM: VMBinding> BumpAllocator<VM> {
 use crate::util::alloc::allocator::align_allocation_no_fill;
 use crate::util::alloc::fill_alignment_gap;
 
+use super::allocator::AllocatorContext;
+
 impl<VM: VMBinding> Allocator<VM> for BumpAllocator<VM> {
     fn get_space(&self) -> &'static dyn Space<VM> {
         self.space
     }
 
-    fn get_plan(&self) -> &'static dyn Plan<VM = VM> {
-        self.plan
+    fn get_context(&self) -> &AllocatorContext<VM> {
+        &self.context
     }
 
     fn does_thread_local_allocation(&self) -> bool {
@@ -158,16 +162,17 @@ impl<VM: VMBinding> Allocator<VM> for BumpAllocator<VM> {
 }
 
 impl<VM: VMBinding> BumpAllocator<VM> {
-    pub fn new(
+    pub(crate) fn new(
         tls: VMThread,
         space: &'static dyn Space<VM>,
-        plan: &'static dyn Plan<VM = VM>,
+        context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         BumpAllocator {
             tls,
             bump_pointer: unsafe { BumpPointer::new(Address::zero(), Address::zero()) },
             space,
-            plan,
+            context,
+            _pad: 0,
         }
     }
 

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -9,7 +9,6 @@ use crate::util::linear_scan::Region;
 use crate::util::Address;
 use crate::util::VMThread;
 use crate::vm::VMBinding;
-use crate::Plan;
 
 use super::allocator::AllocatorContext;
 
@@ -467,9 +466,10 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
 
             // Sweep consumed blocks, and also push the blocks back to the available list.
             self.consumed_blocks[bin].sweep_blocks(self.space);
-            if self.plan.base().is_precise_stress() && self.plan.base().is_stress_test_gc_enabled()
+            if *self.context.options.precise_stress
+                && self.context.options.is_stress_test_gc_enabled()
             {
-                debug_assert!(self.plan.base().is_precise_stress());
+                debug_assert!(*self.context.options.precise_stress);
                 self.available_blocks_stress[bin].append(&mut self.consumed_blocks[bin]);
             } else {
                 self.available_blocks[bin].append(&mut self.consumed_blocks[bin]);

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -58,7 +58,7 @@ impl<VM: VMBinding> Allocator<VM> for FreeListAllocator<VM> {
                 // We succeeded in fastpath alloc, this cannot be precise stress test
                 debug_assert!(
                     !(*self.plan.options().precise_stress
-                        && self.plan.base().is_stress_test_gc_enabled())
+                        && self.plan.options().is_stress_test_gc_enabled())
                 );
 
                 let res = allocator::align_allocation::<VM>(cell, align, offset);
@@ -238,7 +238,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
     /// method may add the block to available_blocks, or available_blocks_stress.
     fn add_to_available_blocks(&mut self, bin: usize, block: Block, stress: bool) {
         if stress {
-            debug_assert!(self.plan.base().is_precise_stress());
+            debug_assert!(*self.plan.options().precise_stress);
             self.available_blocks_stress[bin].push(block);
         } else {
             self.available_blocks[bin].push(block);
@@ -268,7 +268,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
                         self.add_to_available_blocks(
                             bin,
                             block,
-                            self.plan.base().is_stress_test_gc_enabled(),
+                            self.plan.options().is_stress_test_gc_enabled(),
                         );
                         return Some(block);
                     } else {

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use super::allocator::{align_allocation_no_fill, fill_alignment_gap, AllocatorContext};
 use super::BumpPointer;
-use crate::plan::Plan;
 use crate::policy::immix::line::*;
 use crate::policy::immix::ImmixSpace;
 use crate::policy::space::Space;
@@ -52,7 +51,6 @@ impl<VM: VMBinding> Allocator<VM> for ImmixAllocator<VM> {
     fn get_context(&self) -> &AllocatorContext<VM> {
         &self.context
     }
-
 
     fn does_thread_local_allocation(&self) -> bool {
         true

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -5,6 +5,7 @@ use super::BumpPointer;
 use crate::policy::immix::line::*;
 use crate::policy::immix::ImmixSpace;
 use crate::policy::space::Space;
+use crate::policy::space_ref::SpaceRef;
 use crate::util::alloc::allocator::get_maximum_aligned_size;
 use crate::util::alloc::Allocator;
 use crate::util::linear_scan::Region;
@@ -19,7 +20,7 @@ pub struct ImmixAllocator<VM: VMBinding> {
     pub tls: VMThread,
     pub(in crate::util::alloc) bump_pointer: BumpPointer,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
-    space: &'static ImmixSpace<VM>,
+    pub(crate) space: SpaceRef<ImmixSpace<VM>>,
     context: Arc<AllocatorContext<VM>>,
     _pad: usize,
     /// *unused*
@@ -44,10 +45,6 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
 }
 
 impl<VM: VMBinding> Allocator<VM> for ImmixAllocator<VM> {
-    fn get_space(&self) -> &'static dyn Space<VM> {
-        self.space as _
-    }
-
     fn get_context(&self) -> &AllocatorContext<VM> {
         &self.context
     }
@@ -167,13 +164,13 @@ impl<VM: VMBinding> Allocator<VM> for ImmixAllocator<VM> {
 impl<VM: VMBinding> ImmixAllocator<VM> {
     pub(crate) fn new(
         tls: VMThread,
-        space: Option<&'static dyn Space<VM>>,
+        space: SpaceRef<ImmixSpace<VM>>,
         context: Arc<AllocatorContext<VM>>,
         copy: bool,
     ) -> Self {
         ImmixAllocator {
             tls,
-            space: space.unwrap().downcast_ref::<ImmixSpace<VM>>().unwrap(),
+            space,
             context,
             _pad: 0,
             bump_pointer: BumpPointer::new(Address::ZERO, Address::ZERO),
@@ -183,10 +180,6 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
             request_for_large: false,
             line: None,
         }
-    }
-
-    pub fn immix_space(&self) -> &'static ImmixSpace<VM> {
-        self.space
     }
 
     /// Large-object (larger than a line) bump allocation.
@@ -236,7 +229,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
     fn acquire_recyclable_lines(&mut self, size: usize, align: usize, offset: usize) -> bool {
         while self.line.is_some() || self.acquire_recyclable_block() {
             let line = self.line.unwrap();
-            if let Some((start_line, end_line)) = self.immix_space().get_next_available_lines(line)
+            if let Some((start_line, end_line)) = crate::space_ref_read!(&self.space).get_next_available_lines(line)
             {
                 // Find recyclable lines. Update the bump allocation cursor and limit.
                 self.bump_pointer.cursor = start_line.start();
@@ -276,7 +269,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
 
     /// Get a recyclable block from ImmixSpace.
     fn acquire_recyclable_block(&mut self) -> bool {
-        match self.immix_space().get_reusable_block(self.copy) {
+        match crate::space_ref_read!(&self.space).get_reusable_block(self.copy) {
             Some(block) => {
                 trace!("{:?}: acquire_recyclable_block -> {:?}", self.tls, block);
                 // Set the hole-searching cursor to the start of this block.
@@ -289,9 +282,9 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
 
     // Get a clean block from ImmixSpace.
     fn acquire_clean_block(&mut self, size: usize, align: usize, offset: usize) -> Address {
-        match self.immix_space().get_clean_block(self.tls, self.copy) {
-            None => Address::ZERO,
-            Some(block) => {
+        let alloc_res = crate::space_ref_read!(&self.space).get_clean_block(self.tls, self.copy);
+        match alloc_res {
+            Ok(block) => {
                 trace!(
                     "{:?}: Acquired a new block {:?} -> {:?}",
                     self.tls,
@@ -306,6 +299,10 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     self.bump_pointer.limit = block.end();
                 }
                 self.alloc(size, align, offset)
+            }
+            Err(_) => {
+                VM::VMCollection::block_for_gc(crate::util::VMMutatorThread(self.tls));
+                Address::ZERO
             }
         }
     }

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -218,8 +218,8 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
             // recyclable line.  Hence, we bring the "if we're in stress test" check up a level and
             // directly call `alloc_slow_inline()` which will properly account for the allocation
             // request as well as allocate from the newly recycled line
-            let stress_test = self.plan.base().is_stress_test_gc_enabled();
-            let precise_stress = self.plan.base().is_precise_stress();
+            let stress_test = self.plan.base().options.is_stress_test_gc_enabled();
+            let precise_stress = *self.plan.base().options.precise_stress;
             if unlikely(stress_test && precise_stress) {
                 self.alloc_slow_inline(size, align, offset)
             } else {

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use crate::plan::Plan;
 use crate::policy::largeobjectspace::LargeObjectSpace;
 use crate::policy::space::Space;
 use crate::util::alloc::{allocator, Allocator};
@@ -65,6 +64,11 @@ impl<VM: VMBinding> LargeObjectAllocator<VM> {
         space: &'static LargeObjectSpace<VM>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
-        LargeObjectAllocator { tls, space, context, _pad: 0 }
+        LargeObjectAllocator {
+            tls,
+            space,
+            context,
+            _pad: 0,
+        }
     }
 }

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use crate::policy::largeobjectspace::LargeObjectSpace;
 use crate::policy::space::Space;
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::alloc::{allocator, Allocator};
 use crate::util::opaque_pointer::*;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::Address;
 use crate::vm::VMBinding;
 
@@ -15,7 +15,7 @@ pub struct LargeObjectAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
-    space: SharedRef<LargeObjectSpace<VM>>,
+    space: ArcFlexMut<LargeObjectSpace<VM>>,
     context: Arc<AllocatorContext<VM>>,
     _pad: usize,
 }
@@ -65,7 +65,7 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
 impl<VM: VMBinding> LargeObjectAllocator<VM> {
     pub(crate) fn new(
         tls: VMThread,
-        space: SharedRef<LargeObjectSpace<VM>>,
+        space: ArcFlexMut<LargeObjectSpace<VM>>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         LargeObjectAllocator {

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::plan::Plan;
 use crate::policy::largeobjectspace::LargeObjectSpace;
 use crate::policy::space::Space;
@@ -6,14 +8,16 @@ use crate::util::opaque_pointer::*;
 use crate::util::Address;
 use crate::vm::VMBinding;
 
+use super::allocator::AllocatorContext;
+
 #[repr(C)]
 pub struct LargeObjectAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
     space: &'static LargeObjectSpace<VM>,
-    /// [`Plan`] instance that this allocator instance is associated with.
-    plan: &'static dyn Plan<VM = VM>,
+    context: Arc<AllocatorContext<VM>>,
+    _pad: usize,
 }
 
 impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
@@ -21,8 +25,8 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
         self.tls
     }
 
-    fn get_plan(&self) -> &'static dyn Plan<VM = VM> {
-        self.plan
+    fn get_context(&self) -> &AllocatorContext<VM> {
+        &self.context
     }
 
     fn get_space(&self) -> &'static dyn Space<VM> {
@@ -56,11 +60,11 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
 }
 
 impl<VM: VMBinding> LargeObjectAllocator<VM> {
-    pub fn new(
+    pub(crate) fn new(
         tls: VMThread,
         space: &'static LargeObjectSpace<VM>,
-        plan: &'static dyn Plan<VM = VM>,
+        context: Arc<AllocatorContext<VM>>,
     ) -> Self {
-        LargeObjectAllocator { tls, space, plan }
+        LargeObjectAllocator { tls, space, context, _pad: 0 }
     }
 }

--- a/src/util/alloc/malloc_allocator.rs
+++ b/src/util/alloc/malloc_allocator.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::policy::marksweepspace::malloc_ms::MallocSpace;
 use crate::policy::space::Space;
 use crate::util::alloc::Allocator;
@@ -6,14 +8,16 @@ use crate::util::Address;
 use crate::vm::VMBinding;
 use crate::Plan;
 
+use super::allocator::AllocatorContext;
+
 #[repr(C)]
 pub struct MallocAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
     space: &'static MallocSpace<VM>,
-    /// [`Plan`] instance that this allocator instance is associated with.
-    plan: &'static dyn Plan<VM = VM>,
+    context: Arc<AllocatorContext<VM>>,
+    _pad: usize,
 }
 
 impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
@@ -21,8 +25,8 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
         self.space as &'static dyn Space<VM>
     }
 
-    fn get_plan(&self) -> &'static dyn Plan<VM = VM> {
-        self.plan
+    fn get_context(&self) -> &AllocatorContext<VM> {
+        &self.context
     }
 
     fn alloc(&mut self, size: usize, align: usize, offset: usize) -> Address {
@@ -43,11 +47,11 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
 }
 
 impl<VM: VMBinding> MallocAllocator<VM> {
-    pub fn new(
+    pub(crate) fn new(
         tls: VMThread,
         space: &'static MallocSpace<VM>,
-        plan: &'static dyn Plan<VM = VM>,
+        context: Arc<AllocatorContext<VM>>,
     ) -> Self {
-        MallocAllocator { tls, space, plan }
+        MallocAllocator { tls, space, context, _pad: 0 }
     }
 }

--- a/src/util/alloc/malloc_allocator.rs
+++ b/src/util/alloc/malloc_allocator.rs
@@ -6,7 +6,6 @@ use crate::util::alloc::Allocator;
 use crate::util::opaque_pointer::*;
 use crate::util::Address;
 use crate::vm::VMBinding;
-use crate::Plan;
 
 use super::allocator::AllocatorContext;
 
@@ -52,6 +51,11 @@ impl<VM: VMBinding> MallocAllocator<VM> {
         space: &'static MallocSpace<VM>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
-        MallocAllocator { tls, space, context, _pad: 0 }
+        MallocAllocator {
+            tls,
+            space,
+            context,
+            _pad: 0,
+        }
     }
 }

--- a/src/util/alloc/malloc_allocator.rs
+++ b/src/util/alloc/malloc_allocator.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::policy::marksweepspace::malloc_ms::MallocSpace;
 use crate::policy::space::Space;
+use crate::policy::space_ref::SpaceRef;
 use crate::util::alloc::Allocator;
 use crate::util::opaque_pointer::*;
 use crate::util::Address;
@@ -14,16 +15,12 @@ pub struct MallocAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
-    space: &'static MallocSpace<VM>,
+    space: SpaceRef<MallocSpace<VM>>,
     context: Arc<AllocatorContext<VM>>,
     _pad: usize,
 }
 
 impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
-    fn get_space(&self) -> &'static dyn Space<VM> {
-        self.space as &'static dyn Space<VM>
-    }
-
     fn get_context(&self) -> &AllocatorContext<VM> {
         &self.context
     }
@@ -41,14 +38,18 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
     }
 
     fn alloc_slow_once(&mut self, size: usize, align: usize, offset: usize) -> Address {
-        self.space.alloc(self.tls, size, align, offset)
+        crate::space_ref_read!(&self.space).alloc(self.tls, size, align, offset).unwrap_or_else(|_| {
+            use crate::vm::Collection;
+            VM::VMCollection::block_for_gc(VMMutatorThread(self.tls));
+            Address::ZERO
+        })
     }
 }
 
 impl<VM: VMBinding> MallocAllocator<VM> {
     pub(crate) fn new(
         tls: VMThread,
-        space: &'static MallocSpace<VM>,
+        space: SpaceRef<MallocSpace<VM>>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         MallocAllocator {

--- a/src/util/alloc/markcompact_allocator.rs
+++ b/src/util/alloc/markcompact_allocator.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use super::allocator::AllocatorContext;
 use super::BumpAllocator;
 use crate::policy::space::Space;
+use crate::policy::space_ref::SpaceRef;
 use crate::util::alloc::Allocator;
 use crate::util::opaque_pointer::*;
 use crate::util::Address;
@@ -24,16 +25,12 @@ impl<VM: VMBinding> MarkCompactAllocator<VM> {
         self.bump_allocator.reset();
     }
 
-    pub fn rebind(&mut self, space: &'static dyn Space<VM>) {
+    pub fn rebind(&mut self, space: SpaceRef<dyn Space<VM>>) {
         self.bump_allocator.rebind(space);
     }
 }
 
 impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
-    fn get_space(&self) -> &'static dyn Space<VM> {
-        self.bump_allocator.get_space()
-    }
-
     fn get_context(&self) -> &AllocatorContext<VM> {
         &self.bump_allocator.context
     }
@@ -93,7 +90,7 @@ impl<VM: VMBinding> MarkCompactAllocator<VM> {
         crate::policy::markcompactspace::MarkCompactSpace::<VM>::HEADER_RESERVED_IN_BYTES;
     pub(crate) fn new(
         tls: VMThread,
-        space: &'static dyn Space<VM>,
+        space: SpaceRef<dyn Space<VM>>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         MarkCompactAllocator {

--- a/src/util/alloc/markcompact_allocator.rs
+++ b/src/util/alloc/markcompact_allocator.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use super::allocator::AllocatorContext;
 use super::BumpAllocator;
 use crate::policy::space::Space;
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::alloc::Allocator;
 use crate::util::opaque_pointer::*;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::Address;
 use crate::vm::VMBinding;
 
@@ -25,7 +25,7 @@ impl<VM: VMBinding> MarkCompactAllocator<VM> {
         self.bump_allocator.reset();
     }
 
-    pub fn rebind(&mut self, space: SharedRef<dyn Space<VM>>) {
+    pub fn rebind(&mut self, space: ArcFlexMut<dyn Space<VM>>) {
         self.bump_allocator.rebind(space);
     }
 }
@@ -90,7 +90,7 @@ impl<VM: VMBinding> MarkCompactAllocator<VM> {
         crate::policy::markcompactspace::MarkCompactSpace::<VM>::HEADER_RESERVED_IN_BYTES;
     pub(crate) fn new(
         tls: VMThread,
-        space: SharedRef<dyn Space<VM>>,
+        space: ArcFlexMut<dyn Space<VM>>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         MarkCompactAllocator {

--- a/src/util/alloc/markcompact_allocator.rs
+++ b/src/util/alloc/markcompact_allocator.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use super::BumpAllocator;
 use super::allocator::AllocatorContext;
-use crate::plan::Plan;
+use super::BumpAllocator;
 use crate::policy::space::Space;
 use crate::util::alloc::Allocator;
 use crate::util::opaque_pointer::*;

--- a/src/util/alloc/markcompact_allocator.rs
+++ b/src/util/alloc/markcompact_allocator.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use super::BumpAllocator;
+use super::allocator::AllocatorContext;
 use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::util::alloc::Allocator;
@@ -32,8 +35,8 @@ impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
         self.bump_allocator.get_space()
     }
 
-    fn get_plan(&self) -> &'static dyn Plan<VM = VM> {
-        self.bump_allocator.get_plan()
+    fn get_context(&self) -> &AllocatorContext<VM> {
+        &self.bump_allocator.context
     }
 
     fn get_tls(&self) -> VMThread {
@@ -89,13 +92,13 @@ impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
 impl<VM: VMBinding> MarkCompactAllocator<VM> {
     pub const HEADER_RESERVED_IN_BYTES: usize =
         crate::policy::markcompactspace::MarkCompactSpace::<VM>::HEADER_RESERVED_IN_BYTES;
-    pub fn new(
+    pub(crate) fn new(
         tls: VMThread,
         space: &'static dyn Space<VM>,
-        plan: &'static dyn Plan<VM = VM>,
+        context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         MarkCompactAllocator {
-            bump_allocator: BumpAllocator::new(tls, space, plan),
+            bump_allocator: BumpAllocator::new(tls, space, context),
         }
     }
 }

--- a/src/util/alloc/markcompact_allocator.rs
+++ b/src/util/alloc/markcompact_allocator.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use super::allocator::AllocatorContext;
 use super::BumpAllocator;
 use crate::policy::space::Space;
-use crate::policy::space_ref::SpaceRef;
+use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::alloc::Allocator;
 use crate::util::opaque_pointer::*;
 use crate::util::Address;
@@ -25,7 +25,7 @@ impl<VM: VMBinding> MarkCompactAllocator<VM> {
         self.bump_allocator.reset();
     }
 
-    pub fn rebind(&mut self, space: SpaceRef<dyn Space<VM>>) {
+    pub fn rebind(&mut self, space: SharedRef<dyn Space<VM>>) {
         self.bump_allocator.rebind(space);
     }
 }
@@ -90,7 +90,7 @@ impl<VM: VMBinding> MarkCompactAllocator<VM> {
         crate::policy::markcompactspace::MarkCompactSpace::<VM>::HEADER_RESERVED_IN_BYTES;
     pub(crate) fn new(
         tls: VMThread,
-        space: SpaceRef<dyn Space<VM>>,
+        space: SharedRef<dyn Space<VM>>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         MarkCompactAllocator {

--- a/src/util/analysis/mod.rs
+++ b/src/util/analysis/mod.rs
@@ -34,7 +34,7 @@ pub struct GcHookWork;
 impl<VM: VMBinding> GCWork<VM> for GcHookWork {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
         let base = &mmtk.get_plan().base();
-        base.analysis_manager.gc_hook(mmtk);
+        mmtk.analysis_manager.gc_hook(mmtk);
     }
 }
 
@@ -46,7 +46,7 @@ pub struct AnalysisManager<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> AnalysisManager<VM> {
-    pub fn new(stats: &Stats) -> Self {
+    pub fn new(stats: Arc<Stats>) -> Self {
         let mut manager = AnalysisManager {
             routines: Mutex::new(vec![]),
         };
@@ -56,12 +56,12 @@ impl<VM: VMBinding> AnalysisManager<VM> {
 
     // Initializing all routines. If you want to add a new routine, here is the place
     // to do so
-    fn initialize_routines(&mut self, stats: &Stats) {
+    fn initialize_routines(&mut self, stats: Arc<Stats>) {
         let ctr = stats.new_event_counter("obj.num", true, true);
         let gc_ctr = stats.new_event_counter("gc.num", true, true);
         let obj_num = Arc::new(Mutex::new(ObjectCounter::new(true, ctr)));
         let gc_count = Arc::new(Mutex::new(GcCounter::new(true, gc_ctr)));
-        let obj_size = Arc::new(Mutex::new(PerSizeClassObjectCounter::new(true)));
+        let obj_size = Arc::new(Mutex::new(PerSizeClassObjectCounter::new(true, stats)));
         self.add_analysis_routine(obj_num);
         self.add_analysis_routine(gc_count);
         self.add_analysis_routine(obj_size);

--- a/src/util/analysis/mod.rs
+++ b/src/util/analysis/mod.rs
@@ -33,7 +33,6 @@ pub struct GcHookWork;
 
 impl<VM: VMBinding> GCWork<VM> for GcHookWork {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
-        let base = &mmtk.get_plan().base();
         mmtk.analysis_manager.gc_hook(mmtk);
     }
 }

--- a/src/util/analysis/obj_size.rs
+++ b/src/util/analysis/obj_size.rs
@@ -1,7 +1,7 @@
 use crate::util::analysis::RtAnalysis;
 use crate::util::statistics::counter::EventCounter;
-use crate::vm::{ActivePlan, VMBinding};
 use crate::util::statistics::stats::Stats;
+use crate::vm::VMBinding;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/src/util/analysis/obj_size.rs
+++ b/src/util/analysis/obj_size.rs
@@ -1,6 +1,8 @@
 use crate::util::analysis::RtAnalysis;
 use crate::util::statistics::counter::EventCounter;
 use crate::vm::{ActivePlan, VMBinding};
+use crate::util::statistics::stats::Stats;
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -13,10 +15,10 @@ use std::sync::{Arc, Mutex};
  * We keep track of the size classes using a HashMap with the key being the name of the
  * size class.
  */
-#[derive(Default)]
 pub struct PerSizeClassObjectCounter {
     running: bool,
     size_classes: Mutex<HashMap<String, Arc<Mutex<EventCounter>>>>,
+    stats: Arc<Stats>,
 }
 
 // Macro to simplify the creation of a new counter for a particular size class.
@@ -31,10 +33,11 @@ macro_rules! new_ctr {
 }
 
 impl PerSizeClassObjectCounter {
-    pub fn new(running: bool) -> Self {
+    pub fn new(running: bool, stats: Arc<Stats>) -> Self {
         Self {
             running,
             size_classes: Mutex::new(HashMap::new()),
+            stats,
         }
     }
 
@@ -51,14 +54,13 @@ impl<VM: VMBinding> RtAnalysis<VM> for PerSizeClassObjectCounter {
             return;
         }
 
-        let stats = &(VM::VMActivePlan::global().base()).stats;
         let size_class = format!("size{}", self.size_class(size));
         let mut size_classes = self.size_classes.lock().unwrap();
         let c = size_classes.get_mut(&size_class);
         match c {
             None => {
                 // Create (and increment) the counter associated with the size class if it doesn't exist
-                let ctr = new_ctr!(stats, size_classes, size_class);
+                let ctr = new_ctr!(self.stats, size_classes, size_class);
                 ctr.lock().unwrap().inc();
             }
             Some(ctr) => {

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -3,14 +3,12 @@ use std::sync::Arc;
 
 use crate::plan::PlanConstraints;
 use crate::policy::copy_context::PolicyCopyContext;
-use crate::policy::copyspace::CopySpace;
 use crate::policy::copyspace::CopySpaceCopyContext;
-use crate::policy::immix::ImmixSpace;
 use crate::policy::immix::{ImmixCopyContext, ImmixHybridCopyContext};
 use crate::policy::space::Space;
-use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::object_forwarding;
 use crate::util::opaque_pointer::VMWorkerThread;
+use crate::util::rust_util::flex_mut::ArcFlexMut;
 use crate::util::{Address, ObjectReference};
 use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
@@ -26,7 +24,7 @@ const MAX_COPYSPACE_COPY_ALLOCATORS: usize = 1;
 const MAX_IMMIX_COPY_ALLOCATORS: usize = 1;
 const MAX_IMMIX_HYBRID_COPY_ALLOCATORS: usize = 1;
 
-type CopySpaceMapping<VM> = Vec<(CopySelector, SharedRef<dyn Space<VM>>)>;
+type CopySpaceMapping<VM> = Vec<(CopySelector, ArcFlexMut<dyn Space<VM>>)>;
 
 /// A configuration for GCWorkerCopyContext.
 /// Similar to a `MutatorConfig`,

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -1,8 +1,6 @@
 use std::mem::MaybeUninit;
 use std::sync::Arc;
 
-use crate::MMTK;
-use crate::plan::Plan;
 use crate::plan::PlanConstraints;
 use crate::policy::copy_context::PolicyCopyContext;
 use crate::policy::copyspace::CopySpace;
@@ -15,6 +13,7 @@ use crate::util::opaque_pointer::VMWorkerThread;
 use crate::util::{Address, ObjectReference};
 use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
+use crate::MMTK;
 use std::sync::atomic::Ordering;
 
 use enum_map::Enum;
@@ -179,11 +178,7 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
     /// * `worker_tls`: The worker thread for this copy context.
     /// * `plan`: A reference to the current plan.
     /// * `config`: The configuration for the copy context.
-    pub fn new(
-        worker_tls: VMWorkerThread,
-        mmtk: &MMTK<VM>,
-        config: CopyConfig<VM>,
-    ) -> Self {
+    pub fn new(worker_tls: VMWorkerThread, mmtk: &MMTK<VM>, config: CopyConfig<VM>) -> Self {
         let mut ret = GCWorkerCopyContext {
             copy: unsafe { MaybeUninit::uninit().assume_init() },
             immix: unsafe { MaybeUninit::uninit().assume_init() },

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -8,7 +8,7 @@ use crate::policy::copyspace::CopySpaceCopyContext;
 use crate::policy::immix::ImmixSpace;
 use crate::policy::immix::{ImmixCopyContext, ImmixHybridCopyContext};
 use crate::policy::space::Space;
-use crate::policy::space_ref::SpaceRef;
+use crate::util::rust_util::shared_ref::SharedRef;
 use crate::util::object_forwarding;
 use crate::util::opaque_pointer::VMWorkerThread;
 use crate::util::{Address, ObjectReference};
@@ -26,7 +26,7 @@ const MAX_COPYSPACE_COPY_ALLOCATORS: usize = 1;
 const MAX_IMMIX_COPY_ALLOCATORS: usize = 1;
 const MAX_IMMIX_HYBRID_COPY_ALLOCATORS: usize = 1;
 
-type CopySpaceMapping<VM> = Vec<(CopySelector, SpaceRef<dyn Space<VM>>)>;
+type CopySpaceMapping<VM> = Vec<(CopySelector, SharedRef<dyn Space<VM>>)>;
 
 /// A configuration for GCWorkerCopyContext.
 /// Similar to a `MutatorConfig`,
@@ -196,21 +196,21 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
                     ret.copy[*index as usize].write(CopySpaceCopyContext::new(
                         worker_tls,
                         context.clone(),
-                        crate::policy::space_ref::downcast::<VM,CopySpace<VM>>(space),
+                        space.downcast(),
                     ));
                 }
                 CopySelector::Immix(index) => {
                     ret.immix[*index as usize].write(ImmixCopyContext::new(
                         worker_tls,
                         context.clone(),
-                        crate::policy::space_ref::downcast::<VM,ImmixSpace<VM>>(space),
+                        space.downcast(),
                     ));
                 }
                 CopySelector::ImmixHybrid(index) => {
                     ret.immix_hybrid[*index as usize].write(ImmixHybridCopyContext::new(
                         worker_tls,
                         context.clone(),
-                        crate::policy::space_ref::downcast::<VM,ImmixSpace<VM>>(space),
+                        space.downcast(),
                     ));
                 }
                 CopySelector::Unused => unreachable!(),

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -1,16 +1,16 @@
 use atomic::Ordering;
 
 use crate::global_state::GlobalState;
-use crate::plan::Plan;
 use crate::plan::gc_requester::GCRequester;
+use crate::plan::Plan;
 use crate::policy::space::Space;
 use crate::util::conversions;
 use crate::util::options::{GCTriggerSelector, Options};
 use crate::vm::VMBinding;
 use crate::MMTK;
 use std::mem::MaybeUninit;
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
 
 /// GCTrigger is responsible for triggering GCs based on the given policy.
 /// All the decisions about heap limit and GC triggering should be resolved here.
@@ -28,7 +28,11 @@ pub struct GCTrigger<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> GCTrigger<VM> {
-    pub fn new(options: Arc<Options>, gc_requester: Arc<GCRequester<VM>>, state: Arc<GlobalState>) -> Self {
+    pub fn new(
+        options: Arc<Options>,
+        gc_requester: Arc<GCRequester<VM>>,
+        state: Arc<GlobalState>,
+    ) -> Self {
         GCTrigger {
             plan: MaybeUninit::uninit(),
             policy: match *options.gc_trigger {
@@ -104,7 +108,7 @@ impl<VM: VMBinding> GCTrigger<VM> {
     pub fn should_do_stress_gc(&self) -> bool {
         self.state.initialized.load(Ordering::SeqCst)
             && (self.state.allocation_bytes.load(Ordering::SeqCst) > *self.options.stress_factor)
-    }    
+    }
 
     /// Check if the heap is full
     pub fn is_heap_full(&self) -> bool {

--- a/src/util/malloc/mod.rs
+++ b/src/util/malloc/mod.rs
@@ -27,7 +27,7 @@ pub fn malloc(size: usize) -> Address {
 pub fn counted_malloc<VM: VMBinding>(mmtk: &MMTK<VM>, size: usize) -> Address {
     let res = malloc(size);
     if !res.is_zero() {
-        mmtk.get_plan().base().increase_malloc_bytes_by(size);
+        mmtk.state.increase_malloc_bytes_by(size);
     }
     res
 }
@@ -40,7 +40,7 @@ pub fn calloc(num: usize, size: usize) -> Address {
 pub fn counted_calloc<VM: VMBinding>(mmtk: &MMTK<VM>, num: usize, size: usize) -> Address {
     let res = calloc(num, size);
     if !res.is_zero() {
-        mmtk.get_plan().base().increase_malloc_bytes_by(num * size);
+        mmtk.state.increase_malloc_bytes_by(num * size);
     }
     res
 }
@@ -59,10 +59,10 @@ pub fn realloc_with_old_size<VM: VMBinding>(
     let res = realloc(addr, size);
 
     if !addr.is_zero() {
-        mmtk.get_plan().base().decrease_malloc_bytes_by(old_size);
+        mmtk.state.decrease_malloc_bytes_by(old_size);
     }
     if size != 0 && !res.is_zero() {
-        mmtk.get_plan().base().increase_malloc_bytes_by(size);
+        mmtk.state.increase_malloc_bytes_by(size);
     }
 
     res
@@ -76,6 +76,6 @@ pub fn free(addr: Address) {
 pub fn free_with_size<VM: VMBinding>(mmtk: &MMTK<VM>, addr: Address, old_size: usize) {
     free(addr);
     if !addr.is_zero() {
-        mmtk.get_plan().base().decrease_malloc_bytes_by(old_size);
+        mmtk.state.decrease_malloc_bytes_by(old_size);
     }
 }

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -446,6 +446,13 @@ impl Options {
     pub fn get_min_nursery_pages(&self) -> usize {
         crate::util::conversions::bytes_to_pages_up(self.nursery.min)
     }
+
+    /// Check if the options are set for stress GC. If either stress_factor or analysis_factor is set,
+    /// we should do stress GC.
+    pub fn is_stress_test_gc_enabled(&self) -> bool {
+        *self.stress_factor != DEFAULT_STRESS_FACTOR
+            || *self.analysis_factor != DEFAULT_STRESS_FACTOR
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/util/reference_processor.rs
+++ b/src/util/reference_processor.rs
@@ -84,7 +84,7 @@ impl ReferenceProcessors {
     pub fn scan_soft_refs<E: ProcessEdgesWork>(&self, trace: &mut E, mmtk: &'static MMTK<E::VM>) {
         // For soft refs, it is up to the VM to decide when to reclaim this.
         // If this is not an emergency collection, we have no heap stress. We simply retain soft refs.
-        if !mmtk.get_plan().is_emergency_collection() {
+        if !mmtk.state.is_emergency_collection() {
             // This step only retains the referents (keep the referents alive), it does not update its addresses.
             // We will call soft.scan() again with retain=false to update its addresses based on liveness.
             self.soft.retain::<E>(trace, is_nursery_gc(mmtk.get_plan()));

--- a/src/util/rust_util/flex_mut.rs
+++ b/src/util/rust_util/flex_mut.rs
@@ -13,6 +13,17 @@ macro_rules! to_trait_object {
     }};
 }
 
+/// `ArcFlexMut` is a replacement for `UnsafeCell` for a shared reference in situations where 1.
+/// their mutability is managed by the programmer, 2. mutability is hard to reason about statically,
+/// 3. using locks or `RefCell`/`AtomicRefCell` is not plausible for the sake of performance, and
+/// 4. the shared reference could be both statically typed and a dyn ref to a trait object, depending
+/// on where it is used.
+/// `ArcFlexMut` does not guarantee thread safety, and it does not provide any actual locking.
+/// It provides methods for acquiring a read or write guard, and can optionally check if there is
+/// any possible data race. Without the checks, in a release build, `ArcFlexMut` should perform
+/// as efficient as `UnsafeCell`.
+/// We currently use this type for [`crate::policy::space::Space`]s.
+#[repr(transparent)]
 pub struct ArcFlexMut<T>
 where
     T: ?Sized,
@@ -21,6 +32,7 @@ where
 }
 
 impl<T> ArcFlexMut<T> {
+    /// Create a shared reference to the object.
     pub fn new(v: T) -> Self {
         Self {
             inner: Arc::new(peace_lock::RwLock::new(v)),
@@ -28,42 +40,20 @@ impl<T> ArcFlexMut<T> {
     }
 }
 
-impl<T> ArcFlexMut<T> {
-    pub fn into_dyn_space<VM: VMBinding>(self) -> ArcFlexMut<dyn Space<VM>>
-    where
-        T: 'static + Space<VM>,
-    {
-        to_trait_object!(self, dyn Space<VM>)
-    }
-}
-
 impl<T: ?Sized> ArcFlexMut<T> {
+    /// Acquire a read guard to get immutable access to the data. It is allowed to have a reader when there is no writer.
+    /// If the feature `check_flex_mut` is enabled, the method will panic if the rule is violated.
     pub fn read(&self) -> ArcFlexMutReadGuard<'_, T> {
         ArcFlexMutReadGuard {
             inner: self.inner.read(),
         }
     }
 
+    /// Acquire a write guard to get mutable access to the data. It is allowed to have a writer when there is no other writer or reader.
+    /// If the feature `check_flex_mut` is enabled, the method will panic if the rule is violated.
     pub fn write(&self) -> ArcFlexMutWriteGuard<'_, T> {
         ArcFlexMutWriteGuard {
             inner: self.inner.write(),
-        }
-    }
-}
-
-impl<T: 'static + Downcast + ?Sized> ArcFlexMut<T> {
-    fn can_downcast<S: 'static>(&self) -> bool {
-        let lock = self.inner.read();
-        (*lock).as_any().downcast_ref::<S>().is_some()
-    }
-
-    pub fn downcast<S: 'static>(self) -> ArcFlexMut<S> {
-        if self.can_downcast::<S>() {
-            let raw = Arc::into_raw(self.inner);
-            let new_inner = unsafe { Arc::from_raw(raw as *const peace_lock::RwLock<S>) };
-            ArcFlexMut { inner: new_inner }
-        } else {
-            panic!("Failed to downcast")
         }
     }
 }
@@ -79,6 +69,43 @@ where
     }
 }
 
+// For types that implements `Downcast`, we can turn the shared reference into a reference of a concrete type.
+
+impl<T: 'static + Downcast + ?Sized> ArcFlexMut<T> {
+    /// Is it allowed to downcast to the given type?
+    fn can_downcast<S: 'static>(&self) -> bool {
+        let lock = self.inner.read();
+        (*lock).as_any().downcast_ref::<S>().is_some()
+    }
+
+    /// Downcast the shared reference into a shared reference of a concrete type. The new reference share
+    /// the count and the lock with the old consumed reference.
+    pub fn downcast<S: 'static>(self) -> ArcFlexMut<S> {
+        if self.can_downcast::<S>() {
+            let raw = Arc::into_raw(self.inner);
+            let new_inner = unsafe { Arc::from_raw(raw as *const peace_lock::RwLock<S>) };
+            ArcFlexMut { inner: new_inner }
+        } else {
+            panic!("Failed to downcast")
+        }
+    }
+}
+
+// Methods to turn the shared reference into a shared reference of a trait object.
+// The references points to the same object with the same count.
+// This impl block is a workaround to implement the functionality specifically for
+// `dyn Space`, as I can't find a way to implement this using generics.
+
+impl<T> ArcFlexMut<T> {
+    pub fn into_dyn_space<VM: VMBinding>(self) -> ArcFlexMut<dyn Space<VM>>
+    where
+        T: 'static + Space<VM>,
+    {
+        to_trait_object!(self, dyn Space<VM>)
+    }
+}
+
+/// Read guard for ArcFlexMut
 pub struct ArcFlexMutReadGuard<'a, T>
 where
     T: ?Sized,
@@ -98,6 +125,7 @@ where
     }
 }
 
+/// Write guard for ArcFlexMut
 pub struct ArcFlexMutWriteGuard<'a, T>
 where
     T: ?Sized,

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod rev_group;
 pub mod zeroed_alloc;
+pub mod shared_ref;
 
 /// Const function for min value of two usize numbers.
 pub const fn min_of_usize(a: usize, b: usize) -> usize {

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -2,9 +2,9 @@
 //! functionalities that we may expect the Rust programming language and its standard libraries
 //! to provide.
 
+pub mod flex_mut;
 pub mod rev_group;
 pub mod zeroed_alloc;
-pub mod shared_ref;
 
 /// Const function for min value of two usize numbers.
 pub const fn min_of_usize(a: usize, b: usize) -> usize {

--- a/src/util/rust_util/shared_ref.rs
+++ b/src/util/rust_util/shared_ref.rs
@@ -1,0 +1,227 @@
+use crate::vm::VMBinding;
+use crate::policy::space::Space;
+
+use std::{sync::Arc, ops::Deref, ops::DerefMut};
+use downcast_rs::Downcast;
+
+macro_rules! to_trait_object {
+    ($self: expr, $trait: ty) => {
+        {
+            let inner = $self.inner;
+            let raw = Arc::into_raw(inner);
+            let new_inner = unsafe { Arc::from_raw(raw as *const peace_lock::RwLock<$trait>) };
+            SharedRef { inner: new_inner }
+        }
+    }
+}
+
+pub struct SharedRef<T> where T: ?Sized {
+    inner: Arc<peace_lock::RwLock<T>>,
+}
+
+impl<T> SharedRef<T> {
+    pub fn new(v: T) -> Self {
+        Self {
+            inner: Arc::new(peace_lock::RwLock::new(v)),
+        }
+    }
+}
+
+impl<T> SharedRef<T> {
+    pub fn to_dyn_space<VM: VMBinding>(self) -> SharedRef<dyn Space<VM>> where T: 'static + Space<VM> {
+        to_trait_object!(self, dyn Space<VM>)
+    }
+}
+
+impl<T: ?Sized> SharedRef<T> {
+    pub fn read<'a>(&'a self) -> SharedRefReadGuard<'a, T> {
+        SharedRefReadGuard { inner: self.inner.read() }
+    }
+
+    pub fn write<'a>(&'a self) -> SharedRefWriteGuard<'a, T> {
+        SharedRefWriteGuard { inner: self.inner.write() }
+    }
+}
+
+impl<T: 'static + Downcast + ?Sized> SharedRef<T> {
+    fn can_downcast<S: 'static>(&self) -> bool {
+        let lock = self.inner.read();
+        (&*lock).as_any().downcast_ref::<S>().is_some()
+    }
+
+    pub fn downcast<S: 'static>(self) -> SharedRef<S> {
+        if self.can_downcast::<S>() {
+            let raw = Arc::into_raw(self.inner);
+            let new_inner = unsafe { Arc::from_raw(raw as *const peace_lock::RwLock<S>) };
+            SharedRef {
+                inner: new_inner,
+            }
+        } else {
+            panic!("Failed to downcast")
+        }
+    }
+}
+
+impl<T> Clone for SharedRef<T> where T: ?Sized {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone()
+        }
+    }
+}
+
+pub struct SharedRefReadGuard<'a, T> where T: ?Sized {
+    inner: peace_lock::RwLockReadGuard<'a, T>,
+}
+
+impl<T> Deref for SharedRefReadGuard<'_, T> where T: ?Sized {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        self.inner.deref()
+    }
+}
+
+pub struct SharedRefWriteGuard<'a, T> where T: ?Sized {
+    inner: peace_lock::RwLockWriteGuard<'a, T>,
+}
+
+impl<T> Deref for SharedRefWriteGuard<'_, T> where T: ?Sized {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        self.inner.deref()
+    }
+}
+
+impl<T> DerefMut for SharedRefWriteGuard<'_, T> where T: ?Sized {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        self.inner.deref_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Foo(usize);
+    trait Bar: 'static + Downcast {
+        fn get(&self) -> usize;
+        fn set(&mut self, v: usize);
+    }
+    impl Bar for Foo {
+        fn get(&self) -> usize {
+            self.0
+        }
+        fn set(&mut self, v: usize) {
+            self.0 = v;
+        }
+    }
+
+    impl<T> SharedRef<T> {
+        fn to_dyn_bar(self) -> SharedRef<dyn Bar> where T: 'static + Bar {
+            to_trait_object!(self, dyn Bar)
+        }
+    }
+
+    #[test]
+    fn create_clone_drop() {
+        let r = SharedRef::new(Foo(42));
+        assert_eq!(Arc::strong_count(&r.inner), 1);
+
+        {
+            let r2 = r.clone();
+            assert_eq!(r2.inner.read().get(), 42);
+            assert_eq!(Arc::strong_count(&r2.inner), 2);
+        }
+        assert_eq!(Arc::strong_count(&r.inner), 1);
+    }
+
+    #[test]
+    fn to_trait_object() {
+        let r: SharedRef<Foo> = SharedRef::new(Foo(42));
+        assert_eq!(Arc::strong_count(&r.inner), 1);
+
+        let trait_obj: SharedRef<dyn Bar> = r.clone().to_dyn_bar();
+        assert_eq!(Arc::strong_count(&r.inner), 2);
+        assert_eq!(r.inner.read().get(), 42);
+        assert_eq!(Arc::strong_count(&trait_obj.inner), 2);
+        assert_eq!(trait_obj.inner.read().get(), 42);
+
+        drop(trait_obj);
+        assert_eq!(Arc::strong_count(&r.inner), 1);
+    }
+
+    #[test]
+    fn downcast() {
+        let r = SharedRef::new(Foo(42));
+        let trait_obj: SharedRef<dyn Bar> = r.to_dyn_bar();
+        assert_eq!(Arc::strong_count(&trait_obj.inner), 1);
+
+        let trait_obj_clone = trait_obj.clone();
+        assert_eq!(Arc::strong_count(&trait_obj.inner), 2);
+
+        let downcast: SharedRef<Foo> = trait_obj_clone.downcast::<Foo>();
+        assert_eq!(Arc::strong_count(&trait_obj.inner), 2);
+        assert_eq!(Arc::strong_count(&downcast.inner), 2);
+        assert_eq!(downcast.inner.read().get(), 42);
+    }
+
+    #[test]
+    fn read() {
+        let r = SharedRef::new(Foo(42));
+        assert_eq!(r.read().get(), 42);
+
+        let read1 = r.read();
+        let read2 = r.read();
+        assert_eq!(read1.get(), 42);
+        assert_eq!(read2.get(), 42);
+    }
+
+    #[test]
+    fn write() {
+        let r = SharedRef::new(Foo(42));
+        let r2 = r.clone();
+        let trait_obj = r.clone().to_dyn_bar();
+        let downcast = trait_obj.clone().downcast::<Foo>();
+        assert_eq!(Arc::strong_count(&r.inner), 4);
+
+        r.write().set(1);
+        assert_eq!(r.read().get(), 1);
+        assert_eq!(r2.read().get(), 1);
+        assert_eq!(trait_obj.read().get(), 1);
+        assert_eq!(downcast.read().get(), 1);
+    }
+
+    #[test]
+    fn multiple_readers() {
+        let r = SharedRef::new(Foo(42));
+        let read1 = r.read();
+        let read2 = r.read();
+        assert_eq!(read1.get(), 42);
+        assert_eq!(read2.get(), 42);
+    }
+
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic)]
+    fn multiple_writers() {
+        let r = SharedRef::new(Foo(42));
+        let write1 = r.write();
+        let write2 = r.write();
+        assert_eq!(write1.get(), 42);
+        assert_eq!(write2.get(), 42);
+    }
+
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic)]
+    fn mix_reader_writer() {
+        let r = SharedRef::new(Foo(42));
+        let read = r.read();
+        let write = r.write();
+        assert_eq!(read.get(), 42);
+        assert_eq!(write.get(), 42);
+    }
+}

--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -1,5 +1,4 @@
 use crate::plan::Mutator;
-use crate::plan::Plan;
 use crate::scheduler::GCWorker;
 use crate::util::opaque_pointer::*;
 use crate::util::ObjectReference;
@@ -8,12 +7,6 @@ use crate::ObjectQueue;
 
 /// VM-specific methods for the current plan.
 pub trait ActivePlan<VM: VMBinding> {
-    /// Return a reference to the current plan.
-    // TODO: I don't know how this can be implemented when we have multiple MMTk instances.
-    // This function is used by space and phase to refer to the current plan.
-    // Possibly we should remove the use of this function, and remove this function?
-    fn global() -> &'static dyn Plan<VM = VM>;
-
     /// Return whether there is a mutator created and associated with the thread.
     ///
     /// Arguments:

--- a/vmbindings/dummyvm/src/active_plan.rs
+++ b/vmbindings/dummyvm/src/active_plan.rs
@@ -1,17 +1,11 @@
 use crate::DummyVM;
-use crate::SINGLETON;
 use mmtk::util::opaque_pointer::*;
 use mmtk::vm::ActivePlan;
 use mmtk::Mutator;
-use mmtk::Plan;
 
 pub struct VMActivePlan {}
 
 impl ActivePlan<DummyVM> for VMActivePlan {
-    fn global() -> &'static dyn Plan<VM = DummyVM> {
-        SINGLETON.get_plan()
-    }
-
     fn number_of_mutators() -> usize {
         unimplemented!()
     }

--- a/vmbindings/dummyvm/src/api.rs
+++ b/vmbindings/dummyvm/src/api.rs
@@ -164,11 +164,6 @@ pub extern "C" fn mmtk_is_mapped_address(address: Address) -> bool {
 }
 
 #[no_mangle]
-pub extern "C" fn mmtk_modify_check(object: ObjectReference) {
-    memory_manager::modify_check(&SINGLETON, object)
-}
-
-#[no_mangle]
 pub extern "C" fn mmtk_handle_user_collection_request(tls: VMMutatorThread) {
     memory_manager::handle_user_collection_request::<DummyVM>(&SINGLETON, tls);
 }
@@ -262,4 +257,10 @@ pub extern "C" fn mmtk_free_with_size(addr: Address, old_size: usize) {
 #[no_mangle]
 pub extern "C" fn mmtk_free(addr: Address) {
     memory_manager::free(addr)
+}
+
+#[no_mangle]
+#[cfg(feature = "malloc_counted_size")]
+pub extern "C" fn mmtk_get_malloc_bytes() -> usize {
+    memory_manager::get_malloc_bytes(&SINGLETON)
 }

--- a/vmbindings/dummyvm/src/tests/malloc_counted.rs
+++ b/vmbindings/dummyvm/src/tests/malloc_counted.rs
@@ -9,76 +9,76 @@ lazy_static! {
 
 #[test]
 pub fn malloc_free() {
-    MMTK_SINGLETON.with_fixture(|fixture| {
-        let bytes_before = fixture.mmtk.get_plan().base().get_malloc_bytes();
+    MMTK_SINGLETON.with_fixture(|_| {
+        let bytes_before = mmtk_get_malloc_bytes();
 
         let res = mmtk_counted_malloc(8);
         assert!(!res.is_zero());
-        let bytes_after_alloc = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_alloc = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before + 8, bytes_after_alloc);
 
         mmtk_free_with_size(res, 8);
-        let bytes_after_free = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_free = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before, bytes_after_free);
     });
 }
 
 #[test]
 pub fn calloc_free() {
-    MMTK_SINGLETON.with_fixture(|fixture| {
-        let bytes_before = fixture.mmtk.get_plan().base().get_malloc_bytes();
+    MMTK_SINGLETON.with_fixture(|_| {
+        let bytes_before = mmtk_get_malloc_bytes();
 
         let res = mmtk_counted_calloc(1, 8);
         assert!(!res.is_zero());
-        let bytes_after_alloc = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_alloc = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before + 8, bytes_after_alloc);
 
         mmtk_free_with_size(res, 8);
-        let bytes_after_free = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_free = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before, bytes_after_free);
     });
 }
 
 #[test]
 pub fn realloc_grow() {
-    MMTK_SINGLETON.with_fixture(|fixture| {
-        let bytes_before = fixture.mmtk.get_plan().base().get_malloc_bytes();
+    MMTK_SINGLETON.with_fixture(|_| {
+        let bytes_before = mmtk_get_malloc_bytes();
 
         let res1 = mmtk_counted_malloc(8);
         assert!(!res1.is_zero());
-        let bytes_after_alloc = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_alloc = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before + 8, bytes_after_alloc);
 
         // grow to 16 bytes
         let res2 = mmtk_realloc_with_old_size(res1, 16, 8);
         assert!(!res2.is_zero());
-        let bytes_after_realloc = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_realloc = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before + 16, bytes_after_realloc);
 
         mmtk_free_with_size(res2, 16);
-        let bytes_after_free = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_free = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before, bytes_after_free);
     });
 }
 
 #[test]
 pub fn realloc_shrink() {
-    MMTK_SINGLETON.with_fixture(|fixture| {
-        let bytes_before = fixture.mmtk.get_plan().base().get_malloc_bytes();
+    MMTK_SINGLETON.with_fixture(|_| {
+        let bytes_before = mmtk_get_malloc_bytes();
 
         let res1 = mmtk_counted_malloc(16);
         assert!(!res1.is_zero());
-        let bytes_after_alloc = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_alloc = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before + 16, bytes_after_alloc);
 
         // shrink to 8 bytes
         let res2 = mmtk_realloc_with_old_size(res1, 8, 16);
         assert!(!res2.is_zero());
-        let bytes_after_realloc = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_realloc = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before + 8, bytes_after_realloc);
 
         mmtk_free_with_size(res2, 8);
-        let bytes_after_free = fixture.mmtk.get_plan().base().get_malloc_bytes();
+        let bytes_after_free = mmtk_get_malloc_bytes();
         assert_eq!(bytes_before, bytes_after_free);
     });
 }


### PR DESCRIPTION
This PR is based on https://github.com/mmtk/mmtk-core/pull/949. 

It introduces `ArcFlexMut` for some shared references where 1. their mutability is managed by the programmer, 2. mutability is hard to reason about statically, 3. using locks or `RefCell`/`AtomicRefCell` is not plausible for the sake of performance, and 4. the shared reference could be both statically typed and a dyn ref to a trait object, depending on where it is used. `ArcFlexMut` is a replacement for `UnsafeCell`. Basically `ArcFlexMut` can be used for both `Plan` and `Space`. This PR only uses `ArcFlexMut` for `Space`, as currently with the refactoring, we do not need to mutate on a plan.

In my preliminary evaluation, the PR should have no performance overhead over https://github.com/mmtk/mmtk-core/pull/949 on immix. I will rerun the benchmarks and provide results before we attempt to merge the PR.