### PR TITLE
Immix: disable is_defrag_source check in get_forwarded_object

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -86,10 +86,6 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
     }
 
     fn get_forwarded_object(&self, object: ObjectReference) -> Option<ObjectReference> {
-        if !Block::containing::<VM>(object).is_defrag_source() {
-            return None;
-        }
-
         if ForwardingWord::is_forwarded::<VM>(object) {
             Some(ForwardingWord::read_forwarding_pointer::<VM>(object))
         } else {


### PR DESCRIPTION
This PR removes an incorrect check in `ImmixSpace::get_forwarded_object()`. The problem for this check is that defrag is not the only reason that an Immix object may gets moved. For example, in sticky immix, a nursery object may be moved in a nursery GC. In such cases, the block is not a defrag source and this check would return `None` suggesting there is no forwarded object. But the object may be actually moved.