### PR TITLE
Let the VM customize object forwarding implementation

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -16,7 +16,7 @@ use crate::util::metadata::side_metadata::SideMetadataSpec;
 #[cfg(feature = "vo_bit")]
 use crate::util::metadata::vo_bit;
 use crate::util::metadata::{self, MetadataSpec};
-use crate::util::object_forwarding as ForwardingWord;
+use crate::util::object_forwarding;
 use crate::util::{Address, ObjectReference};
 use crate::vm::*;
 use crate::{
@@ -90,8 +90,8 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
             return None;
         }
 
-        if ForwardingWord::is_forwarded::<VM>(object) {
-            Some(ForwardingWord::read_forwarding_pointer::<VM>(object))
+        if object_forwarding::is_forwarded::<VM>(object) {
+            Some(object_forwarding::read_forwarding_pointer::<VM>(object))
         } else {
             None
         }
@@ -120,7 +120,7 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
         }
 
         // If the object is forwarded, it is live, too.
-        ForwardingWord::is_forwarded::<VM>(object)
+        object_forwarding::is_forwarded::<VM>(object)
     }
     #[cfg(feature = "object_pinning")]
     fn pin_object(&self, object: ObjectReference) -> bool {
@@ -591,75 +591,78 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         #[cfg(feature = "vo_bit")]
         vo_bit::helper::on_trace_object::<VM>(object);
 
-        let forwarding_status = ForwardingWord::attempt_to_forward::<VM>(object);
-        if ForwardingWord::state_is_forwarded_or_being_forwarded(forwarding_status) {
-            // We lost the forwarding race as some other thread has set the forwarding word; wait
-            // until the object has been forwarded by the winner. Note that the object may not
-            // necessarily get forwarded since Immix opportunistically moves objects.
-            #[allow(clippy::let_and_return)]
-            let new_object =
-                ForwardingWord::spin_and_get_forwarded_object::<VM>(object, forwarding_status);
-            #[cfg(debug_assertions)]
-            {
-                if new_object == object {
-                    debug_assert!(
+        match object_forwarding::ForwardingAttempt::<VM>::attempt(object) {
+            object_forwarding::ForwardingAttempt::Lost(lost) => {
+                // We lost the forwarding race as some other thread has set the forwarding word; wait
+                // until the object has been forwarded by the winner. Note that the object may not
+                // necessarily get forwarded since Immix opportunistically moves objects.
+                #[allow(clippy::let_and_return)]
+                let new_object = lost.spin_and_get_forwarded_object();
+
+                #[cfg(debug_assertions)]
+                {
+                    if new_object == object {
+                        debug_assert!(
                         self.is_marked(object) || self.defrag.space_exhausted() || self.is_pinned(object),
                         "Forwarded object is the same as original object {} even though it should have been copied",
                         object,
                     );
-                } else {
-                    // new_object != object
-                    debug_assert!(
+                    } else {
+                        // new_object != object
+                        debug_assert!(
                         !Block::containing::<VM>(new_object).is_defrag_source(),
                         "Block {:?} containing forwarded object {} should not be a defragmentation source",
                         Block::containing::<VM>(new_object),
                         new_object,
                     );
+                    }
+                }
+                new_object
+            }
+            object_forwarding::ForwardingAttempt::Won(won) => {
+                if self.is_marked(object) {
+                    // We won the forwarding race but the object is already marked so we clear the
+                    // forwarding status and return the unmoved object
+                    won.revert();
+                    object
+                } else {
+                    // We won the forwarding race; actually forward and copy the object if it is not pinned
+                    // and we have sufficient space in our copy allocator
+                    let new_object = if self.is_pinned(object)
+                        || (!nursery_collection && self.defrag.space_exhausted())
+                    {
+                        self.attempt_mark(object, self.mark_state);
+                        won.revert();
+                        Block::containing::<VM>(object).set_state(BlockState::Marked);
+
+                        #[cfg(feature = "vo_bit")]
+                        vo_bit::helper::on_object_marked::<VM>(object);
+
+                        object
+                    } else {
+                        // We are forwarding objects. When the copy allocator allocates the block, it should
+                        // mark the block. So we do not need to explicitly mark it here.
+
+                        // Clippy complains if the "vo_bit" feature is not enabled.
+                        #[allow(clippy::let_and_return)]
+                        let new_object = won.forward_object(semantics, copy_context);
+
+                        #[cfg(feature = "vo_bit")]
+                        vo_bit::helper::on_object_forwarded::<VM>(new_object);
+
+                        new_object
+                    };
+                    debug_assert_eq!(
+                        Block::containing::<VM>(new_object).get_state(),
+                        BlockState::Marked
+                    );
+
+                    queue.enqueue(new_object);
+                    debug_assert!(new_object.is_live());
+                    self.unlog_object_if_needed(new_object);
+                    new_object
                 }
             }
-            new_object
-        } else if self.is_marked(object) {
-            // We won the forwarding race but the object is already marked so we clear the
-            // forwarding status and return the unmoved object
-            ForwardingWord::clear_forwarding_bits::<VM>(object);
-            object
-        } else {
-            // We won the forwarding race; actually forward and copy the object if it is not pinned
-            // and we have sufficient space in our copy allocator
-            let new_object = if self.is_pinned(object)
-                || (!nursery_collection && self.defrag.space_exhausted())
-            {
-                self.attempt_mark(object, self.mark_state);
-                ForwardingWord::clear_forwarding_bits::<VM>(object);
-                Block::containing::<VM>(object).set_state(BlockState::Marked);
-
-                #[cfg(feature = "vo_bit")]
-                vo_bit::helper::on_object_marked::<VM>(object);
-
-                object
-            } else {
-                // We are forwarding objects. When the copy allocator allocates the block, it should
-                // mark the block. So we do not need to explicitly mark it here.
-
-                // Clippy complains if the "vo_bit" feature is not enabled.
-                #[allow(clippy::let_and_return)]
-                let new_object =
-                    ForwardingWord::forward_object::<VM>(object, semantics, copy_context);
-
-                #[cfg(feature = "vo_bit")]
-                vo_bit::helper::on_object_forwarded::<VM>(new_object);
-
-                new_object
-            };
-            debug_assert_eq!(
-                Block::containing::<VM>(new_object).get_state(),
-                BlockState::Marked
-            );
-
-            queue.enqueue(new_object);
-            debug_assert!(new_object.is_live());
-            self.unlog_object_if_needed(new_object);
-            new_object
         }
     }
 

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -117,6 +117,12 @@ pub trait ObjectModel<VM: VMBinding> {
     #[cfg(feature = "vo_bit")]
     const NEED_VO_BITS_DURING_TRACING: bool = false;
 
+    /// When true, mmtk-core will use the metadata `LOCAL_FORWARDING_BITS_SPEC` and
+    /// `LOCAL_FORWARDING_POINTER_SPEC` defined above to implement object forwarding.
+    ///
+    /// When false, 
+    const VM_IMPLEMENTED_FORWARDING: bool = false;
+
     /// A function to non-atomically load the specified per-object metadata's content.
     /// The default implementation assumes the bits defined by the spec are always avilable for MMTk to use. If that is not the case, a binding should override this method, and provide their implementation.
     /// Returns the metadata value.


### PR DESCRIPTION
**DRAFT: This is still a work in progress.**

Some VMs, such as Ruby, do not have sufficient amount of bits in the header for forwarding bits.  However, they can use the type tag to indicate the object is "condemned" and is forwarded to a different place.  This requires the VM to implement some object forwarding primitives for mmtk-core, as the representation of forwarding states (i.e. "not forwarded", "being forwarded", and "forwarded") is VM-specific.