### PR TITLE
Feature/four state forwarding bits

### DIFF
--- a/src/util/object_forwarding.rs
+++ b/src/util/object_forwarding.rs
@@ -1,6 +1,5 @@
 use crate::util::copy::*;
 use crate::util::metadata::MetadataSpec;
-/// https://github.com/JikesRVM/JikesRVM/blob/master/MMTk/src/org/mmtk/utility/ForwardingWord.java
 use crate::util::{constants, ObjectReference};
 use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
@@ -174,7 +173,7 @@ pub fn write_forwarding_pointer<VM: VMBinding>(
         get_forwarding_status::<VM>(object),
     );
 
-    trace!("GCForwardingWord::write({:#?}, {:x})\n", object, new_object);
+    trace!("write_forwarding_pointer({}, {})", object, new_object);
     VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC.store_atomic::<VM, usize>(
         object,
         new_object.to_raw_address().as_usize(),


### PR DESCRIPTION
**DRAFT: This PR depends on cyclic marking state if forwarding bits are in the header.**

Currently the forwarding bits is a 2-bits-per-object metadata, but it only has three states, namely "not triggered", "being forwarded" and "forwarded".  Marking is supported by a separate marking bit.  This PR uses the fourth state of the forwarding bits to represent the state that "the object is marked and should not move".  With this change, Immix (and other GCs that do not evacuate all objects in a GC) will no longer need to "set the state to 'being forwarded' and then revert it if the object is marked".  Instead, one CMPXCHG will be enough to atomically initiate forwarding as well as atomically mark an object, and fail if another thread is trying to mark or forward the same object.