### PR TITLE
Use BumpPointer::default()

### DIFF
--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -34,13 +34,6 @@ pub struct BumpPointer {
 }
 
 impl BumpPointer {
-    pub const fn new(start: Address, end: Address) -> Self {
-        BumpPointer {
-            cursor: start,
-            limit: end,
-        }
-    }
-
     pub fn reset(&mut self, start: Address, end: Address) {
         self.cursor = start;
         self.limit = end;
@@ -178,7 +171,7 @@ impl<VM: VMBinding> BumpAllocator<VM> {
     ) -> Self {
         BumpAllocator {
             tls,
-            bump_pointer: unsafe { BumpPointer::new(Address::zero(), Address::zero()) },
+            bump_pointer: BumpPointer::default(),
             space,
             plan,
         }

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -26,6 +26,9 @@ pub struct BumpAllocator<VM: VMBinding> {
 
 /// A common fast-path bump-pointer allocator shared across different allocator implementations
 /// that use bump-pointer allocation.
+/// A `BumpPointer` is always initialized with cursor = 0, limit = 0, so the first allocation
+/// always fails the check of `cursor + size < limit` and goes to the slowpath. A binding
+/// can also take advantage of this design to zero-initialize the a bump pointer.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct BumpPointer {
@@ -41,10 +44,10 @@ impl BumpPointer {
 }
 
 impl std::default::Default for BumpPointer {
+    /// Defaults to 0,0. In this case, the first
+    /// allocation would naturally fail the check
+    /// `cursor + size < limit`, and go to the slowpath.    
     fn default() -> Self {
-        // Defaults to 0,0. In this case, the first
-        // allocation would naturally fail the check
-        // `cursor + size < limit`, and go to the slowpath.
         BumpPointer {
             cursor: Address::ZERO,
             limit: Address::ZERO,

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -174,10 +174,10 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
             tls,
             space: space.unwrap().downcast_ref::<ImmixSpace<VM>>().unwrap(),
             plan,
-            bump_pointer: BumpPointer::new(Address::ZERO, Address::ZERO),
+            bump_pointer: BumpPointer::default(),
             hot: false,
             copy,
-            large_bump_pointer: BumpPointer::new(Address::ZERO, Address::ZERO),
+            large_bump_pointer: BumpPointer::default(),
             request_for_large: false,
             line: None,
         }


### PR DESCRIPTION
This PR changes the code snippet in our doc to use `BumpPointer::default()` to create a new zero-initialized bump pointer struct. It also changes our internal implementation to use `BumpPointer::default()` instead of `BumpPointer::new(zero, zero)`.