### PR TITLE
Use `cargo generate-lockfile` to update JikesRVM's Cargo.lock

### DIFF
--- a/.github/workflows/auto-merge-inner.yml
+++ b/.github/workflows/auto-merge-inner.yml
@@ -68,6 +68,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup
+        if: steps.check-input.outputs.skip == 'false'
+        working-directory: ${{ env.BINDING_WORK_DIR }}
+        run: |
+          .github/scripts/ci-setup.sh
       - name: Update mmtk dependency
         if: steps.check-input.outputs.skip == 'false'
         working-directory: ${{ env.MMTK_CORE_WORK_DIR }}

--- a/.github/workflows/auto-merge-inner.yml
+++ b/.github/workflows/auto-merge-inner.yml
@@ -68,11 +68,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup
-        if: steps.check-input.outputs.skip == 'false'
-        working-directory: ${{ env.BINDING_WORK_DIR }}
-        run: |
-          .github/scripts/ci-setup.sh
       - name: Update mmtk dependency
         if: steps.check-input.outputs.skip == 'false'
         working-directory: ${{ env.MMTK_CORE_WORK_DIR }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,7 +3,9 @@ name: Auto Merge Binding PRs
 # Only trigger on push to master. The workflow needs to use repo secrets.
 # Triggering on master can make sure we have secrets.
 on:
-  push
+  push:
+    branches:
+    - master
 
 jobs:
   # Figure out the PR that is merged.
@@ -17,7 +19,7 @@ jobs:
         run: echo "commit=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
       - id: get-pr
         run: |
-          PR_NUMBER=$(gh pr list --search "${GITHUB_SHA}" --repo mmtk/mmtk-core --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --search "${GITHUB_SHA}" --state merged --repo mmtk/mmtk-core --json number --jq '.[0].number')
           echo "pr=$PR_NUMBER" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -48,6 +48,10 @@ jobs:
       base_repo: mmtk/mmtk-jikesrvm
       ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
       core_commit: ${{ needs.get-merged-pr.outputs.commit }}
+      # `cargo generate-lockfile` will update other dependencies. We avoid using it for the bindings.
+      # But we do not have a good option for JikesRVM. The Rust project in JikesRVM needs some source files
+      # that are generated during its build process. Unless we want to do a full build for JikesRVM, we cannot
+      # use `cargo build`. So use `cargo generate-lockfile` instead.
       update_lockfile: cargo generate-lockfile
     secrets: inherit
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,9 +3,7 @@ name: Auto Merge Binding PRs
 # Only trigger on push to master. The workflow needs to use repo secrets.
 # Triggering on master can make sure we have secrets.
 on:
-  push:
-    branches:
-    - master
+  push
 
 jobs:
   # Figure out the PR that is merged.
@@ -19,7 +17,7 @@ jobs:
         run: echo "commit=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
       - id: get-pr
         run: |
-          PR_NUMBER=$(gh pr list --search "${GITHUB_SHA}" --state merged --repo mmtk/mmtk-core --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --search "${GITHUB_SHA}" --repo mmtk/mmtk-core --json number --jq '.[0].number')
           echo "pr=$PR_NUMBER" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -48,7 +48,7 @@ jobs:
       base_repo: mmtk/mmtk-jikesrvm
       ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
       core_commit: ${{ needs.get-merged-pr.outputs.commit }}
-      update_lockfile: cargo build --features nogc --target i686-unknown-linux-gnu
+      update_lockfile: cargo generate-lockfile
     secrets: inherit
 
   check-merge-v8-pr:


### PR DESCRIPTION
`auto-merge.yml` uses `cargo build` to generate lockfile for most bindings. But this does not work for JikesRVM:
1. JikesRVM uses `--target i686-unknown-linux-gnu` which is not installed automatically when running `cargo build`.
2. JikesRVM's cargo project uses some Rust source files that are generated during building JikesRVM. So we cannot build the cargo project alone from a fresh repo clone. We have to do a full build.

As a workaround, we use `cargo generate-lockfile` for JikesRVM. `cargo generate-lockfile` will update the version of dependencies. But we do not have a better option for JikesRVM