### PR TITLE
# of objects traced / moved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,8 @@ immix_non_moving = []
 # if `immix_non_moving` is in use.
 sticky_immix_non_moving_nursery = []
 
+# Statistics about how many objects get moved in defrag GCs for Immix
+objects_moved_stats = []
 
 # Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.
 immix_smaller_block = []

--- a/src/policy/immix/mod.rs
+++ b/src/policy/immix/mod.rs
@@ -7,6 +7,8 @@ pub use immixspace::*;
 
 use crate::policy::immix::block::Block;
 use crate::util::linear_scan::Region;
+#[cfg(feature = "objects_moved_stats")]
+use std::sync::atomic::AtomicUsize;
 
 /// The max object size for immix: half of a block
 pub const MAX_IMMIX_OBJECT_SIZE: usize = Block::BYTES >> 1;
@@ -37,6 +39,13 @@ pub const NEVER_MOVE_OBJECTS: bool = !DEFRAG && !PREFER_COPY_ON_NURSERY_GC;
 /// Mark lines when scanning objects.
 /// Otherwise, do it at mark time.
 pub const MARK_LINE_AT_SCAN_TIME: bool = true;
+
+/// Keep track of stats about # of objects traced / moved
+#[cfg(feature = "objects_moved_stats")]
+pub static mut OBJECTS_TRACED_AND_COPIED: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(feature = "objects_moved_stats")]
+pub static mut OBJECTS_TRACED: AtomicUsize = AtomicUsize::new(0);
 
 macro_rules! validate {
     ($x: expr) => { assert!($x, stringify!($x)) };


### PR DESCRIPTION
This PR adds the option to count the number of objects traced and moved in Immix GCs. In combination with `STRESS_DEFRAG` and `DEFRAG_EVERY_BLOCK` it can give an indication of how many objects are being (transitively) pinned and therefore cannot be copied.