### PR TITLE
Upload perf build and log as artifacts (merge after #1005)

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.7-test"
+          ref: "branch-0.7.0"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "test-0.7.1"
+          ref: "0.7.1"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.6.8"
+          ref: "0.7-test"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.7.0"
+          ref: "test-0.7.1"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "branch-0.7.0"
+          ref: "0.7.0"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -9,13 +9,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'self-hosted'
+  RESULT_REPO_BRANCH: 'test'
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/build
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'self-hosted'
+  RESULT_REPO_BRANCH: 'test'
 
 jobs:
   jikesrvm-baseline:

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -63,13 +63,13 @@ jobs:
       - name: Upload build as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build
+          name: jikesrvm-baseline-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: logs
+          name: jikesrvm-baseline-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
           if-no-files-found: error
 
@@ -115,12 +115,12 @@ jobs:
       - name: Upload build as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build
+          name: openjdk-baseline-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: logs
+          name: openjdk-baseline-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
           if-no-files-found: error

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7-test"
+          ref: "branch-0.7.0"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -79,7 +79,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7-test"
+          ref: "branch-0.7.0"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -17,7 +17,7 @@ env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
   RESULT_REPO_BRANCH: 'test'
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
-  CI_PERF_KIT_BUILD: ci-perf-kit/build
+  CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
 
 jobs:

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -9,13 +9,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'test'
+  RESULT_REPO_BRANCH: 'self-hosted'
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -16,6 +16,9 @@ on:
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
   RESULT_REPO_BRANCH: 'self-hosted'
+  # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
+  CI_PERF_KIT_BUILD: ci-perf-kit/build
+  CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
 
 jobs:
   jikesrvm-baseline:
@@ -57,6 +60,18 @@ jobs:
           export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
           export FROM_DATE=2020-07-10
           JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-stock.sh ./mmtk-jikesrvm/repos/jikesrvm
+      - name: Upload build as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ env.CI_PERF_KIT_BUILD }}
+          if-no-files-found: error
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: ${{ env.CI_PERF_KIT_LOG }}
+          if-no-files-found: error
 
   openjdk-baseline:
     runs-on: [self-hosted, Linux, freq-scaling-off]
@@ -97,3 +112,15 @@ jobs:
           export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
           export FROM_DATE=2020-07-10
           ./ci-perf-kit/scripts/openjdk-stock.sh ./mmtk-openjdk/repos/openjdk
+      - name: Upload build as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ env.CI_PERF_KIT_BUILD }}
+          if-no-files-found: error
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: ${{ env.CI_PERF_KIT_LOG }}
+          if-no-files-found: error

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.6.10"
+          ref: "0.7-test"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -79,7 +79,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.6.10"
+          ref: "0.7-test"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "test-0.7.1"
+          ref: "0.7.1"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "test-0.7.1"
+          ref: "0.7.1"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -9,13 +9,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'test'
+  RESULT_REPO_BRANCH: 'self-hosted'
 
 jobs:
   jikesrvm-baseline:
@@ -39,7 +39,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.7.0"
+          ref: "0.7.0"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -79,7 +79,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.7.0"
+          ref: "0.7.0"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7.0"
+          ref: "test-0.7.1"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7.0"
+          ref: "test-0.7.1"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -9,9 +9,9 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -106,7 +106,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.6.8"
+              ref: "0.7-test"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -129,7 +129,7 @@ jobs:
           - name: Compare Performance
             id: run
             run: |
-              JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm-trunk/ mmtk-core-trunk/ mmtk-jikesrvm-branch/ mmtk-core-branch/ jikesrvm-compare-report.md
+              JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-compare.sh mmtk-jikesrvm-trunk/ mmtk-core-trunk/ mmtk-jikesrvm-branch/ mmtk-core-branch/ jikesrvm-compare-report.md
           # set report.md to output
           - uses: pCYSl5EDgo/cat@master
             id: cat
@@ -208,7 +208,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.6.8"
+                ref: "0.7-test"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -112,7 +112,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "test-0.7.1"
+              ref: "0.7.1"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -219,7 +219,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "test-0.7.1"
+                ref: "0.7.1"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -119,10 +119,6 @@ jobs:
           # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)
           - name: Setup Rust Toolchain
             run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
-          - name: Setup
-            run: |
-              mkdir -p ci-perf-kit/running/benchmarks/dacapo
-              cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo/
           # run compare
           - uses: hasura/comment-progress@v2.1.0
             with:
@@ -230,10 +226,6 @@ jobs:
             # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)
             - name: Setup Rust Toolchain
               run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
-            - name: Setup
-              run: |
-                mkdir -p ci-perf-kit/running/benchmarks/dacapo
-                cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo/
             # run compare
             - uses: hasura/comment-progress@v2.1.0
               with:

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -63,6 +63,7 @@ jobs:
     jikesrvm-perf-compare:
         runs-on: [self-hosted, Linux, freq-scaling-off]
         needs: [binding-refs, mmtk-refs]
+        timeout-minutes: 1440
         steps:
           # Trunk - we always use master from the mmtk org
           # - binding
@@ -165,6 +166,7 @@ jobs:
     openjdk-perf-compare:
         runs-on: [self-hosted, Linux, freq-scaling-off]
         needs: [binding-refs, mmtk-refs]
+        timeout-minutes: 1440
         steps:
             # Trunk - we always use master from the mmtk org
             # - binding

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -16,6 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
+  CI_PERF_KIT_BUILD: ci-perf-kit/build
+  CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
+
 jobs:
     # Figure out binding PRs.
     binding-refs:
@@ -137,10 +142,18 @@ jobs:
             with:
               path: jikesrvm-compare-report.md
           # upload run results
-          - uses: actions/upload-artifact@v2
+          - name: Upload build as artifacts
+            uses: actions/upload-artifact@v3
             with:
-              name: jikesrvm-log
-              path: ci-perf-kit/running/results/log
+              name: build
+              path: ${{ env.CI_PERF_KIT_BUILD }}
+              if-no-files-found: error
+          - name: Upload logs as artifacts
+            uses: actions/upload-artifact@v3
+            with:
+              name: logs
+              path: ${{ env.CI_PERF_KIT_LOG }}
+              if-no-files-found: error
           - uses: actions/upload-artifact@v2
             with:
               name: jikesrvm-compare-report.md
@@ -160,7 +173,7 @@ jobs:
           - name: Clean up logs and reports
             if: always()
             run: |
-              rm -rf ci-perf-kit/running/results/log/*
+              rm -rf ${{ env.CI_PERF_KIT_LOG }}
               rm jikesrvm-compare-report.md
 
     openjdk-perf-compare:
@@ -240,10 +253,18 @@ jobs:
               with:
                 path: openjdk-compare-report.md
             # upload run results
-            - uses: actions/upload-artifact@v2
+            - name: Upload build as artifacts
+              uses: actions/upload-artifact@v3
               with:
-                name: openjdk-log
-                path: ci-perf-kit/running/results/log
+                name: build
+                path: ${{ env.CI_PERF_KIT_BUILD }}
+                if-no-files-found: error
+            - name: Upload logs as artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                name: logs
+                path: ${{ env.CI_PERF_KIT_LOG }}
+                if-no-files-found: error
             - uses: actions/upload-artifact@v2
               with:
                 name: openjdk-compare-report.md
@@ -262,5 +283,5 @@ jobs:
             - name: Clean up logs and reports
               if: always()
               run: |
-                rm -rf ci-perf-kit/running/results/log/*
+                rm -rf ${{ env.CI_PERF_KIT_LOG }}
                 rm openjdk-compare-report.md

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -106,7 +106,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.7-test"
+              ref: "branch-0.7.0"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -208,7 +208,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.7-test"
+                ref: "branch-0.7.0"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
-  CI_PERF_KIT_BUILD: ci-perf-kit/build
+  CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
 
 jobs:

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -112,7 +112,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.7.0"
+              ref: "test-0.7.1"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -219,7 +219,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.7.0"
+                ref: "test-0.7.1"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -107,7 +107,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "branch-0.7.0"
+              ref: "0.7.0"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -210,7 +210,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "branch-0.7.0"
+                ref: "0.7.0"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -141,13 +141,13 @@ jobs:
           - name: Upload build as artifacts
             uses: actions/upload-artifact@v3
             with:
-              name: build
+              name: jikesrvm-compare-build
               path: ${{ env.CI_PERF_KIT_BUILD }}
               if-no-files-found: error
           - name: Upload logs as artifacts
             uses: actions/upload-artifact@v3
             with:
-              name: logs
+              name: jikesrvm-compare-logs
               path: ${{ env.CI_PERF_KIT_LOG }}
               if-no-files-found: error
           - uses: actions/upload-artifact@v2
@@ -248,13 +248,13 @@ jobs:
             - name: Upload build as artifacts
               uses: actions/upload-artifact@v3
               with:
-                name: build
+                name: openjdk-compare-build
                 path: ${{ env.CI_PERF_KIT_BUILD }}
                 if-no-files-found: error
             - name: Upload logs as artifacts
               uses: actions/upload-artifact@v3
               with:
-                name: logs
+                name: openjdk-compare-logs
                 path: ${{ env.CI_PERF_KIT_LOG }}
                 if-no-files-found: error
             - uses: actions/upload-artifact@v2

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -83,13 +83,13 @@ jobs:
       - name: Upload build as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build
+          name: jikesrvm-regression-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: logs
+          name: jikesrvm-regression-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
           if-no-files-found: error
 
@@ -159,13 +159,13 @@ jobs:
       - name: Upload build as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build
+          name: openjdk-regression-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: logs
+          name: openjdk-regression-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
           if-no-files-found: error
 
@@ -235,12 +235,12 @@ jobs:
       - name: Upload build as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build
+          name: mutator-regression-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: logs
+          name: mutator-regression-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
           if-no-files-found: error

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -8,13 +8,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'self-hosted'
+  RESULT_REPO_BRANCH: 'test'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
 

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -57,8 +57,6 @@ jobs:
       - name: Setup
         run: |
           ./ci-perf-kit/scripts/history-run-setup.sh
-          mkdir -p ci-perf-kit/running/benchmarks/dacapo
-          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-jikesrvm/mmtk/Cargo.toml
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-jikesrvm/mmtk/Cargo.toml
       - id: branch
@@ -135,8 +133,6 @@ jobs:
       - name: Setup
         run: |
           ./ci-perf-kit/scripts/history-run-setup.sh
-          mkdir -p ci-perf-kit/running/benchmarks/dacapo
-          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
       - id: branch
@@ -215,8 +211,6 @@ jobs:
       - name: Setup
         run: |
           ./ci-perf-kit/scripts/history-run-setup.sh
-          mkdir -p ci-perf-kit/running/benchmarks/dacapo
-          cp /usr/share/benchmarks/dacapo/dacapo-2006-10-MR2.jar ci-perf-kit/running/benchmarks/dacapo
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
       # run

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -8,13 +8,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'test'
+  RESULT_REPO_BRANCH: 'self-hosted'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
 
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.7.0"
+          ref: "0.7.0"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.7.0"
+          ref: "0.7.0"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "branch-0.7.0"
+          ref: "0.7.0"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -8,13 +8,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'self-hosted'
+  RESULT_REPO_BRANCH: 'test'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.0"
+          ref: "test-0.7.1"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.0"
+          ref: "test-0.7.1"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -191,7 +191,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.0"
+          ref: "test-0.7.1"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -18,7 +18,7 @@ env:
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
-  CI_PERF_KIT_BUILD: ci-perf-kit/build
+  CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
 
 jobs:

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.10"
+          ref: "0.7-test"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.10"
+          ref: "0.7-test"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.6.10"
+          ref: "0.7-test"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -8,13 +8,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'test'
+  RESULT_REPO_BRANCH: 'self-hosted'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
 

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7-test"
+          ref: "branch-0.7.0"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7-test"
+          ref: "branch-0.7.0"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7-test"
+          ref: "branch-0.7.0"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -17,6 +17,9 @@ env:
   RESULT_REPO_BRANCH: 'self-hosted'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
+  # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
+  CI_PERF_KIT_BUILD: ci-perf-kit/build
+  CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
 
 jobs:
   # JikesRVM
@@ -79,6 +82,18 @@ jobs:
           publish_dir: ./reports
           publish_branch: gh-pages
           keep_files: true
+      - name: Upload build as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ env.CI_PERF_KIT_BUILD }}
+          if-no-files-found: error
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: ${{ env.CI_PERF_KIT_LOG }}
+          if-no-files-found: error
 
   # OpenJDK
   openjdk-perf-regression:
@@ -145,6 +160,18 @@ jobs:
           publish_dir: ./reports
           publish_branch: gh-pages
           keep_files: true
+      - name: Upload build as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ env.CI_PERF_KIT_BUILD }}
+          if-no-files-found: error
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: ${{ env.CI_PERF_KIT_LOG }}
+          if-no-files-found: error
 
   openjdk-mutator-perf:
     runs-on: [self-hosted, Linux, freq-scaling-off]
@@ -211,3 +238,15 @@ jobs:
           publish_dir: ./reports
           publish_branch: gh-pages
           keep_files: true
+      - name: Upload build as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ env.CI_PERF_KIT_BUILD }}
+          if-no-files-found: error
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: ${{ env.CI_PERF_KIT_LOG }}
+          if-no-files-found: error

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -22,6 +22,7 @@ jobs:
   # JikesRVM
   jikesrvm-perf-regression:
     runs-on: [self-hosted, Linux, freq-scaling-off]
+    timeout-minutes: 1440
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2
@@ -82,6 +83,7 @@ jobs:
   # OpenJDK
   openjdk-perf-regression:
     runs-on: [self-hosted, Linux, freq-scaling-off]
+    timeout-minutes: 1440
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2
@@ -146,6 +148,7 @@ jobs:
 
   openjdk-mutator-perf:
     runs-on: [self-hosted, Linux, freq-scaling-off]
+    timeout-minutes: 1440
     steps:
       - name: Checkout MMTk Core
         uses: actions/checkout@v2

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "test-0.7.1"
+          ref: "0.7.1"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "test-0.7.1"
+          ref: "0.7.1"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -191,7 +191,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "test-0.7.1"
+          ref: "0.7.1"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -8,13 +8,13 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'test'
+  RESULT_REPO_BRANCH: 'self-hosted'
   # Whether we deploy the generated page. Set to true for master.
   DEPLOY: true
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh


### PR DESCRIPTION
This PR moves to ci-perf-kit 0.7.1 (https://github.com/mmtk/ci-perf-kit/releases/tag/0.7.1), and adds a step to upload the build used in the perf run as artifacts. This PR closes https://github.com/mmtk/mmtk-core/issues/982.

This is an example of the testing runs: https://github.com/mmtk/mmtk-core/actions/runs/6742562731. The builds and the logs are uploaded as artifacts.