### PR TITLE
Fix CI for OpenJDK nogc config

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.7.2"
+          ref: "0.7.3"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7.2"
+          ref: "0.7.3"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7.2"
+          ref: "0.7.3"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -112,7 +112,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.7.2"
+              ref: "0.7.3"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -219,7 +219,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.7.2"
+                ref: "0.7.3"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.2"
+          ref: "0.7.3"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.2"
+          ref: "0.7.3"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -191,7 +191,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.2"
+          ref: "0.7.3"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true


### PR DESCRIPTION
Current perf CI failed to run OpenJDK NoGC, as there is a typo in the config file in the run. It is fixed in `ci-perf-kit` 0.7.3 (https://github.com/mmtk/ci-perf-kit/releases/tag/0.7.3). This PR updates `ci-perf-kit` to 0.7.3.

The failed run was here: https://github.com/mmtk/mmtk-core/actions/runs/6765511244/job/18385256502. The NoGC failed to run, and has no result. This caused the plotting to fail.