### PR TITLE
Add missing docs for the vm module

### DIFF
--- a/src/util/metadata/header_metadata.rs
+++ b/src/util/metadata/header_metadata.rs
@@ -22,7 +22,20 @@ const BITS_IN_U64: usize = 1 << LOG_BITS_IN_U64;
 /// For performance reasons, objects of this struct should be constants.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HeaderMetadataSpec {
+    /// `bit_offset` is the index of the starting bit from which the data should be read or written.
+    /// It is counted from the right (least significant bit) of the byte.
+    /// Positive values refer to the bit positions within the current byte, starting with 0 for the
+    /// least significant bit (rightmost) up to 7 for the most significant bit (leftmost).
+    /// Negative values are used to refer to bit positions in the previous bytes, where -1 indicates
+    /// the most significant bit (leftmost) of the byte immediately before the current one.
     pub bit_offset: isize,
+    /// `num_of_bits` specifies the number of consecutive bits to be read or written starting from the `bit_offset`.
+    /// This value is used to define the size of the data field in bits. For instance, if `num_of_bits` is set to 1,
+    /// only a single bit is considered, whereas a value of 8 would indicate a full byte.
+    /// This field must be a positive integer and typically should not exceed the size of the data type that
+    /// will hold the extracted value (for example, 8 bits for a `u8`, 16 bits for a `u16`, etc.).
+    /// The `num_of_bits` together with the `bit_offset` enables the extraction of bit fields of arbitrary
+    /// length and position, facilitating bit-level data manipulation.
     pub num_of_bits: usize,
 }
 
@@ -501,6 +514,59 @@ mod tests {
     }
 
     #[test]
+    fn test_negative_bit_offset() {
+        let spec = HeaderMetadataSpec {
+            bit_offset: -1,
+            num_of_bits: 1,
+        };
+        spec.assert_spec::<u8>();
+        assert_eq!(spec.get_shift_and_mask_for_bits(), (7, 0b1000_0000));
+        assert_eq!(spec.byte_offset(), -1);
+        assert_eq!(spec.get_bits_from_u8(0b1000_0000), 1);
+        assert_eq!(spec.get_bits_from_u8(0b0111_1111), 0);
+
+        let spec = HeaderMetadataSpec {
+            bit_offset: -2,
+            num_of_bits: 1,
+        };
+        spec.assert_spec::<u8>();
+        assert_eq!(spec.get_shift_and_mask_for_bits(), (6, 0b0100_0000));
+        assert_eq!(spec.byte_offset(), -1);
+        assert_eq!(spec.get_bits_from_u8(0b0100_0000), 1);
+        assert_eq!(spec.get_bits_from_u8(0b1011_1111), 0);
+
+        let spec = HeaderMetadataSpec {
+            bit_offset: -7,
+            num_of_bits: 1,
+        };
+        spec.assert_spec::<u8>();
+        assert_eq!(spec.get_shift_and_mask_for_bits(), (1, 0b0000_0010));
+        assert_eq!(spec.byte_offset(), -1);
+        assert_eq!(spec.get_bits_from_u8(0b0000_0010), 1);
+        assert_eq!(spec.get_bits_from_u8(0b1111_1101), 0);
+
+        let spec = HeaderMetadataSpec {
+            bit_offset: -8,
+            num_of_bits: 1,
+        };
+        spec.assert_spec::<u8>();
+        assert_eq!(spec.get_shift_and_mask_for_bits(), (0, 0b0000_0001));
+        assert_eq!(spec.byte_offset(), -1);
+        assert_eq!(spec.get_bits_from_u8(0b0000_0001), 1);
+        assert_eq!(spec.get_bits_from_u8(0b1111_1110), 0);
+
+        let spec = HeaderMetadataSpec {
+            bit_offset: -9,
+            num_of_bits: 1,
+        };
+        spec.assert_spec::<u8>();
+        assert_eq!(spec.get_shift_and_mask_for_bits(), (7, 0b1000_0000));
+        assert_eq!(spec.byte_offset(), -2);
+        assert_eq!(spec.get_bits_from_u8(0b1000_0000), 1);
+        assert_eq!(spec.get_bits_from_u8(0b0111_1111), 0);
+    }
+
+    #[test]
     fn test_get_bits_from_u8() {
         // 1 bit
         let spec = HeaderMetadataSpec {
@@ -508,6 +574,7 @@ mod tests {
             num_of_bits: 1,
         };
         assert_eq!(spec.get_shift_and_mask_for_bits(), (0, 0b1));
+        assert_eq!(spec.byte_offset(), 0);
         assert_eq!(spec.get_bits_from_u8(0b0000_0001), 1);
         assert_eq!(spec.get_bits_from_u8(0b1111_1110), 0);
 

--- a/src/vm/collection.rs
+++ b/src/vm/collection.rs
@@ -5,7 +5,9 @@ use crate::{scheduler::*, Mutator};
 
 /// Thread context for the spawned GC thread.  It is used by spawn_gc_thread.
 pub enum GCThreadContext<VM: VMBinding> {
+    /// The GC thread to spawn is a controller thread. There is only one controller thread.
     Controller(Box<GCController<VM>>),
+    /// The GC thread to spawn is a worker thread. There can be multiple worker threads.
     Worker(Box<GCWorker<VM>>),
 }
 

--- a/src/vm/edge_shape.rs
+++ b/src/vm/edge_shape.rs
@@ -126,7 +126,9 @@ fn a_simple_edge_should_have_the_same_size_as_a_pointer() {
 
 /// A abstract memory slice represents a piece of **heap** memory.
 pub trait MemorySlice: Send + Debug + PartialEq + Eq + Clone + Hash {
+    /// The associate type to define how to access edges from a memory slice.
     type Edge: Edge;
+    /// The associate type to define how to iterate edges in a memory slice.
     type EdgeIterator: Iterator<Item = Self::Edge>;
     /// Iterate object edges within the slice. If there are non-reference values in the slice, the iterator should skip them.
     fn iter_edges(&self) -> Self::EdgeIterator;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19,6 +19,7 @@ use crate::util::constants::*;
 
 mod active_plan;
 mod collection;
+/// Allows MMTk to access edges in a VM defined way.
 pub mod edge_shape;
 pub(crate) mod object_model;
 mod reference_glue;
@@ -44,10 +45,15 @@ pub trait VMBinding
 where
     Self: Sized + 'static + Send + Sync + Default,
 {
+    /// The binding's implementation of [`crate::vm::ObjectModel`].
     type VMObjectModel: ObjectModel<Self>;
+    /// The binding's implementation of [`crate::vm::Scanning`].
     type VMScanning: Scanning<Self>;
+    /// The binding's implementation of [`crate::vm::Collection`].
     type VMCollection: Collection<Self>;
+    /// The binding's implementation of [`crate::vm::ActivePlan`].
     type VMActivePlan: ActivePlan<Self>;
+    /// The binding's implementation of [`crate::vm::ReferenceGlue`].
     type VMReferenceGlue: ReferenceGlue<Self>;
 
     /// The type of edges in this VM.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19,7 +19,7 @@ use crate::util::constants::*;
 
 mod active_plan;
 mod collection;
-/// Allows MMTk to access edges in a VM defined way.
+/// Allows MMTk to access edges in a VM-defined way.
 pub mod edge_shape;
 pub(crate) mod object_model;
 mod reference_glue;

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -495,14 +495,16 @@ pub mod specs {
                 /// The number of bits (in log2) that are needed for the spec.
                 pub const LOG_NUM_BITS: usize = $log_num_bits;
 
-                /// Whether this spec is global or local. The binding needs to make sure
-                /// global specs are laid out after a global spec, and local specs are laid
-                /// out after a local spec. Otherwise, there will be an assertion failure.
+                /// Whether this spec is global or local. For side metadata, the binding needs to make sure
+                /// global specs are laid out after another global spec, and local specs are laid
+                /// out after another local spec. Otherwise, there will be an assertion failure.
                 pub const IS_GLOBAL: bool = $is_global;
 
                 /// Declare that the VM uses in-header metadata for this metadata type.
                 /// For the specification of the `bit_offset` argument, please refer to
                 /// the document of `[crate::util::metadata::header_metadata::HeaderMetadataSpec.bit_offset]`.
+                /// The binding needs to make sure that the bits used for a spec in the header do not conflict with
+                /// the bits of another spec (unless it is specified that some bits may be reused).
                 pub const fn in_header(bit_offset: isize) -> Self {
                     Self(MetadataSpec::InHeader(HeaderMetadataSpec {
                         bit_offset,

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -492,29 +492,30 @@ pub mod specs {
             $(#[$outer])*
             pub struct $spec_name(MetadataSpec);
             impl $spec_name {
-                #[doc="The number of bits (in log2) that are needed for the spec."]
+                /// The number of bits (in log2) that are needed for the spec.
                 pub const LOG_NUM_BITS: usize = $log_num_bits;
 
-                #[doc="Whether this spec is global or local. The binding needs to make sure"]
-                #[doc="global specs are laid out after a global spec, and local specs are laid"]
-                #[doc="out after a local spec. Otherwise, there will be an assertion failure."]
+                /// Whether this spec is global or local. The binding needs to make sure
+                /// global specs are laid out after a global spec, and local specs are laid
+                /// out after a local spec. Otherwise, there will be an assertion failure.
                 pub const IS_GLOBAL: bool = $is_global;
 
-                #[doc="Declare that the VM uses in-header metadata for this metadata type."]
-                #[doc="For the specification of the `bit_offset` argument, please refer to"]
-                #[doc="the document of `[crate::util::metadata::header_metadata::HeaderMetadataSpec.bit_offset]`."]
+                /// Declare that the VM uses in-header metadata for this metadata type.
+                /// For the specification of the `bit_offset` argument, please refer to
+                /// the document of `[crate::util::metadata::header_metadata::HeaderMetadataSpec.bit_offset]`.
                 pub const fn in_header(bit_offset: isize) -> Self {
                     Self(MetadataSpec::InHeader(HeaderMetadataSpec {
                         bit_offset,
                         num_of_bits: 1 << Self::LOG_NUM_BITS,
                     }))
                 }
-                #[doc="Declare that the VM uses side metadata for this metadata type,"]
-                #[doc="and the side metadata is the first of its kind (global or local)."]
-                #[doc="The first global or local side metadata should be declared with `side_first()`,"]
-                #[doc="and the rest side metadata should be declared with `side_after()` after a defined"]
-                #[doc="side metadata of the same kind (global or local). Logically, all the declarations"]
-                #[doc="create two list of side metadata, one for global, and one for local."]
+
+                /// Declare that the VM uses side metadata for this metadata type,
+                /// and the side metadata is the first of its kind (global or local).
+                /// The first global or local side metadata should be declared with `side_first()`,
+                /// and the rest side metadata should be declared with `side_after()` after a defined
+                /// side metadata of the same kind (global or local). Logically, all the declarations
+                /// create two list of side metadata, one for global, and one for local.
                 pub const fn side_first() -> Self {
                     if Self::IS_GLOBAL {
                         Self(MetadataSpec::OnSide(SideMetadataSpec {
@@ -534,12 +535,13 @@ pub mod specs {
                         }))
                     }
                 }
-                #[doc="Declare that the VM uses side metadata for this metadata type,"]
-                #[doc="and the side metadata should be laid out after the given side metadata spec."]
-                #[doc="The first global or local side metadata should be declared with `side_first()`,"]
-                #[doc="and the rest side metadata should be declared with `side_after()` after a defined"]
-                #[doc="side metadata of the same kind (global or local). Logically, all the declarations"]
-                #[doc="create two list of side metadata, one for global, and one for local."]
+
+                /// Declare that the VM uses side metadata for this metadata type,
+                /// and the side metadata should be laid out after the given side metadata spec.
+                /// The first global or local side metadata should be declared with `side_first()`,
+                /// and the rest side metadata should be declared with `side_after()` after a defined
+                /// side metadata of the same kind (global or local). Logically, all the declarations
+                /// create two list of side metadata, one for global, and one for local.
                 pub const fn side_after(spec: &MetadataSpec) -> Self {
                     assert!(spec.is_on_side());
                     let side_spec = spec.extract_side_spec();
@@ -552,11 +554,13 @@ pub mod specs {
                         log_bytes_in_region: $side_min_obj_size as usize,
                     }))
                 }
-                #[doc="Return the inner `[crate::util::metadata::MetadataSpec]` for the metadata type."]
+
+                /// Return the inner `[crate::util::metadata::MetadataSpec]` for the metadata type.
                 pub const fn as_spec(&self) -> &MetadataSpec {
                     &self.0
                 }
-                #[doc="Return the number of bits for the metadata type."]
+
+                /// Return the number of bits for the metadata type.
                 pub const fn num_bits(&self) -> usize {
                     1 << $log_num_bits
                 }

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -242,6 +242,14 @@ pub trait Scanning<VM: VMBinding> {
     /// Return whether the VM supports return barriers. This is unused at the moment.
     fn supports_return_barrier() -> bool;
 
+    /// Prepare for another round of root scanning in the same GC. Some GC algorithms
+    /// need multiple transitive closures, and each transitive closure starts from
+    /// root scanning. We expect the binding to provide the same root set for every
+    /// round of root scanning in the same GC. Bindings can use this call to get
+    /// ready for another round of root scanning to make sure that the same root
+    /// set will be returned in the upcoming calls of root scannig methods,
+    /// such as [`crate::vm::Scanning::scan_roots_in_mutator_thread`] and
+    /// [`crate::vm::Scanning::scan_vm_specific_roots`].
     fn prepare_for_roots_re_scanning();
 
     /// Process weak references.

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -247,7 +247,7 @@ pub trait Scanning<VM: VMBinding> {
     /// root scanning. We expect the binding to provide the same root set for every
     /// round of root scanning in the same GC. Bindings can use this call to get
     /// ready for another round of root scanning to make sure that the same root
-    /// set will be returned in the upcoming calls of root scannig methods,
+    /// set will be returned in the upcoming calls of root scanning methods,
     /// such as [`crate::vm::Scanning::scan_roots_in_mutator_thread`] and
     /// [`crate::vm::Scanning::scan_vm_specific_roots`].
     fn prepare_for_roots_re_scanning();


### PR DESCRIPTION
This PR is a step towards https://github.com/mmtk/mmtk-core/issues/309.
* Add some tests and documents to clarify `HeaderMetadata.bit_offset` (related discussion: https://mmtk.zulipchat.com/#narrow/stream/315620-Porting/topic/ScalaNative.2FMMTK/near/398587245).
* Modify the macro `define_vm_metadata_spec!` to allow adding docs for the generated types.
* Add missing docs for public items in the `vm` module.

Please feel free to make edits to the PR if there is any issue.