### PR TITLE
Use ci-perf-kit 0.7.4: ignore runs with unmatched key/value in the logs.

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.7.3"
+          ref: "0.7.4"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7.3"
+          ref: "0.7.4"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.7.3"
+          ref: "0.7.4"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -112,7 +112,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.7.3"
+              ref: "0.7.4"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -219,7 +219,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.7.3"
+                ref: "0.7.4"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.3"
+          ref: "0.7.4"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.3"
+          ref: "0.7.4"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -191,7 +191,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.7.3"
+          ref: "0.7.4"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true


### PR DESCRIPTION
The perf CI run for mutator performance recently failed for the following error:
```console
++ python3 scripts/mutator_report.py /home/gitlab-runner/actions-runner/_work/mmtk-core/mmtk-core/ci-perf-kit/result_repo/mutator /home/gitlab-runner/actions-runner/_work/mmtk-core/mmtk-core/reports/master
Traceback (most recent call last):
  File "/home/gitlab-runner/actions-runner/_work/mmtk-core/mmtk-core/ci-perf-kit/scripts/mutator_report.py", line 43, in <module>
    run_id, results = parse.parse_run(os.path.join(result_repo_mutator_root, l))
  File "/home/gitlab-runner/actions-runner/_work/mmtk-core/mmtk-core/ci-perf-kit/scripts/parse.py", line 82, in parse_run
    results.append(parse_log(os.path.join(log_folder, l), n_invocations))
  File "/home/gitlab-runner/actions-runner/_work/mmtk-core/mmtk-core/ci-perf-kit/scripts/parse.py", line 48, in parse_log
    assert len(mmtk_keys) == len(mmtk_values), "Error when reading MMTk statistics: num of keys does not match num of values"
AssertionError: Error when reading MMTk statistics: num of keys does not match num of values
```

One of the runs recently has an incomplete `MMTk Statistics` printing. The process quit for some reason before it prints the values. This seems to be a random issue, as the other runs in the same log file look fine.
```console
============================ MMTk Statistics Totals ============================
GC time.other time.stw time.jitc time.ygc collections.young time.ogc collections.old
```
The unmatched key/value pairs caused an assertion failure in the `ci-perf-kit` script.`ci-perf-kit 0.7.4` (https://github.com/mmtk/ci-perf-kit/releases/tag/0.7.4) fixes this. Runs that do not have valid key/value pairs will be ignored, and the script will not quit.