### PR TITLE
Add an action that labels new issues for triage

### DIFF
--- a/.github/workflows/auto-label-new-issues.yml
+++ b/.github/workflows/auto-label-new-issues.yml
@@ -1,0 +1,16 @@
+name: Auto Label New Issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add F-triage for new issues if there is no priority label assigned.
+        uses: matthamil/labeler@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          required-label-prefixes: 'P-'
+          default-labels: 'F-triage'


### PR DESCRIPTION
This PR adds an action which is triggered when an issue is created or is edited. If there is no `P-*` labels on the issue, it automatically adds a `F-triage` label (https://github.com/mmtk/mmtk-core/labels/F-triage).

This action will not add `F-triage` for current issues. However, we could manually go through the list of issues that have no priority assigned by filtering with `is:issue is:open -label:P-low -label:P-normal -label:P-high -label:P-critical` (https://github.com/mmtk/mmtk-core/issues?q=is%3Aissue+is%3Aopen+-label%3AP-low+-label%3AP-normal+-label%3AP-high+-label%3AP-critical), and add `F-triage` for them.

This PR is not tested. But it simply uses a third-party action and it should work fine.