### PR TITLE
Stop using the deprecated set-output in our CI configs

### DIFF
--- a/.github/workflows/auto-merge-inner.yml
+++ b/.github/workflows/auto-merge-inner.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           if [[ "${{ inputs.repo }}" == ${{ inputs.base_repo }} ]] && [[ "${{ inputs.ref }}" == "master" ]]; then
             echo "Conditions not met"
-            echo "::set-output name=skip::true"
+            echo "skip=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=skip::false"
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
         shell: bash
 
@@ -63,7 +63,7 @@ jobs:
         id: get-pr
         run: |
           PR_NUMBER=$(gh pr list --head ${{ inputs.ref }} --repo ${{ inputs.base_repo }} --json number --jq '.[0].number')
-          echo "::set-output name=pr_number::$PR_NUMBER"
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -61,8 +61,8 @@ jobs:
               return res.data.head.sha
         - id: print
           run: |
-            echo "::set-output name=mmtk_repo::${{ steps.core-repo.outputs.result }}"
-            echo "::set-output name=mmtk_ref::${{ steps.core-ref.outputs.result }}"
+            echo "mmtk_repo=${{ steps.core-repo.outputs.result }}" >> $GITHUB_OUTPUT
+            echo "mmtk_ref=${{ steps.core-ref.outputs.result }}" >> $GITHUB_OUTPUT
 
     # Run perf compare for JikesRVM
     jikesrvm-perf-compare:

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -61,7 +61,7 @@ jobs:
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-jikesrvm/mmtk/Cargo.toml
       - id: branch
         # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
       # run
       - name: Performance Run
         run: |
@@ -137,7 +137,7 @@ jobs:
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
       - id: branch
         # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
       # run
       - name: Performance Run
         run: |
@@ -207,7 +207,7 @@ jobs:
           rm -rf mmtk-openjdk/repos/openjdk/build
       - id: branch
         # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
       - name: Setup
         run: |
           ./ci-perf-kit/scripts/history-run-setup.sh

--- a/.github/workflows/pr-binding-refs.yml
+++ b/.github/workflows/pr-binding-refs.yml
@@ -89,13 +89,13 @@ jobs:
             default_env: 'OPENJDK_BINDING_REPO=mmtk/mmtk-openjdk,OPENJDK_BINDING_REF=master,JIKESRVM_BINDING_REPO=mmtk/mmtk-jikesrvm,JIKESRVM_BINDING_REF=master,V8_BINDING_REPO=mmtk/mmtk-v8,V8_BINDING_REF=master,JULIA_BINDING_REPO=mmtk/mmtk-julia,JULIA_BINDING_REF=master,RUBY_BINDING_REPO=mmtk/mmtk-ruby,RUBY_BINDING_REF=master'
         - id: print
           run: |
-            echo "::set-output name=openjdk_binding_repo::${{ env.OPENJDK_BINDING_REPO }}"
-            echo "::set-output name=openjdk_binding_ref::${{ env.OPENJDK_BINDING_REF }}"
-            echo "::set-output name=jikesrvm_binding_repo::${{ env.JIKESRVM_BINDING_REPO }}"
-            echo "::set-output name=jikesrvm_binding_ref::${{ env.JIKESRVM_BINDING_REF }}"
-            echo "::set-output name=v8_binding_repo::${{ env.V8_BINDING_REPO }}"
-            echo "::set-output name=v8_binding_ref::${{ env.V8_BINDING_REF }}"
-            echo "::set-output name=julia_binding_repo::${{ env.JULIA_BINDING_REPO }}"
-            echo "::set-output name=julia_binding_ref::${{ env.JULIA_BINDING_REF }}"
-            echo "::set-output name=ruby_binding_repo::${{ env.RUBY_BINDING_REPO }}"
-            echo "::set-output name=ruby_binding_ref::${{ env.RUBY_BINDING_REF }}"
+            echo "openjdk_binding_repo=${{ env.OPENJDK_BINDING_REPO }}" >> $GITHUB_OUTPUT
+            echo "openjdk_binding_ref=${{ env.OPENJDK_BINDING_REF }}" >> $GITHUB_OUTPUT
+            echo "jikesrvm_binding_repo=${{ env.JIKESRVM_BINDING_REPO }}" >> $GITHUB_OUTPUT
+            echo "jikesrvm_binding_ref=${{ env.JIKESRVM_BINDING_REF }}" >> $GITHUB_OUTPUT
+            echo "v8_binding_repo=${{ env.V8_BINDING_REPO }}" >> $GITHUB_OUTPUT
+            echo "v8_binding_ref=${{ env.V8_BINDING_REF }}" >> $GITHUB_OUTPUT
+            echo "julia_binding_repo=${{ env.JULIA_BINDING_REPO }}" >> $GITHUB_OUTPUT
+            echo "julia_binding_ref=${{ env.JULIA_BINDING_REF }}" >> $GITHUB_OUTPUT
+            echo "ruby_binding_repo=${{ env.RUBY_BINDING_REPO }}" >> $GITHUB_OUTPUT
+            echo "ruby_binding_ref=${{ env.RUBY_BINDING_REF }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pre-review-ci.yml
+++ b/.github/workflows/pre-review-ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           export MSRV=`cargo read-manifest | python -c 'import json,sys; print(json.load(sys.stdin)["rust_version"])'`
           export TEST=`cat rust-toolchain`
-          echo "::set-output name=array::[\"$MSRV\", \"$TEST\", \"stable\"]"
+          echo "array=[\"$MSRV\", \"$TEST\", \"stable\"]" >> $GITHUB_OUTPUT
 
   pre-code-review-checks:
     needs: setup-test-matrix

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -12,7 +12,7 @@ pub fn get_field_attribute<'f>(field: &'f Field, attr_name: &str) -> Option<&'f 
         abort! { second_attr.path().span(), "Duplicated attribute: #[{}]", attr_name }
     };
 
-    attrs.get(0).cloned()
+    attrs.first().cloned()
 }
 
 pub fn get_fields_with_attribute<'f>(fields: &'f FieldsNamed, attr_name: &str) -> Vec<&'f Field> {

--- a/src/policy/marksweepspace/malloc_ms/mod.rs
+++ b/src/policy/marksweepspace/malloc_ms/mod.rs
@@ -2,4 +2,3 @@ mod global;
 mod metadata;
 
 pub use global::*;
-pub use metadata::*;

--- a/src/util/statistics/mod.rs
+++ b/src/util/statistics/mod.rs
@@ -1,4 +1,3 @@
-pub use self::counter::Counter;
 pub use self::counter::Timer;
 
 pub mod counter;


### PR DESCRIPTION
This closes https://github.com/mmtk/mmtk-core/issues/927. This PR also includes a few changes to make style check pass for the stable Rust 1.75.