### PR TITLE
Bump version to v0.22.1

### DIFF
--- a/.github/scripts/ci-style.sh
+++ b/.github/scripts/ci-style.sh
@@ -42,9 +42,3 @@ style_check_auxiliary_crate() {
 }
 
 style_check_auxiliary_crate macros
-
-# --- cargo publish dry run ---
-# Main crate
-cargo publish --dry-run
-# Macros
-cargo publish --dry-run --manifest-path=macros/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.22.1 (2024-01-11)
+===
+
+## What's Changed
+
+* Revert a mistake in v0.22 that prevents cargo publish by @qinsoon in https://github.com/mmtk/mmtk-core/pull/1065
+
+**Full Changelog**: https://github.com/mmtk/mmtk-core/compare/v0.22.0...v0.22.1
+
 0.22.0 (2023-12-21)
 ===
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmtk"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The MMTk Developers <>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -38,7 +38,7 @@ log = { version = "0.4", features = ["max_level_trace", "release_max_level_off"]
 memoffset = "0.9"
 mimalloc-sys = { version = "0.1.6", optional = true }
 # MMTk macros - we have to specify a version here in order to publish the crate, even though we use the dependency from a local path.
-mmtk-macros = { version="0.22.0", path = "macros/" }
+mmtk-macros = { version="0.22.1", path = "macros/" }
 num_cpus = "1.8"
 num-traits = "0.2"
 pfm = { version = "0.1.1", optional = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mmtk-macros"
 # the macro crate uses the same version as mmtk-core
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MMTk macros provides procedural macros used by mmtk-core."


### PR DESCRIPTION
Bumps the version to v0.22.1 for https://github.com/mmtk/mmtk-core/pull/1065.