### PR TITLE
Fix un-cleared VO bits for contiguous monotone PR

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -7,8 +7,6 @@ use crate::policy::space::{CommonSpace, Space};
 use crate::scheduler::GCWorker;
 use crate::util::alloc::allocator::AllocatorContext;
 use crate::util::copy::*;
-#[cfg(feature = "vo_bit")]
-use crate::util::heap::layout::vm_layout::BYTES_IN_CHUNK;
 use crate::util::heap::{MonotonePageResource, PageResource};
 use crate::util::metadata::{extract_side_metadata, MetadataSpec};
 use crate::util::object_forwarding;
@@ -189,19 +187,8 @@ impl<VM: VMBinding> CopySpace<VM> {
 
     #[cfg(feature = "vo_bit")]
     unsafe fn reset_vo_bit(&self) {
-        let current_chunk = self.pr.get_current_chunk();
-        if self.common.contiguous {
-            // If we have allocated something into this space, we need to clear its VO bit.
-            if current_chunk != self.common.start {
-                crate::util::metadata::vo_bit::bzero_vo_bit(
-                    self.common.start,
-                    current_chunk + BYTES_IN_CHUNK - self.common.start,
-                );
-            }
-        } else {
-            for (start, size) in self.pr.iterate_allocated_regions() {
-                crate::util::metadata::vo_bit::bzero_vo_bit(start, size);
-            }
+        for (start, size) in self.pr.iterate_allocated_regions() {
+            crate::util::metadata::vo_bit::bzero_vo_bit(start, size);
         }
     }
 


### PR DESCRIPTION
Fixed a bug that when using a generational plan, if mutators allocated less than one chunk of memory into the nursery between GCs, some VO bits will not be cleared.

This PR also ensures the field `MonotonePageResourceSync::current_chunk` grows monotonically during GC when the space is contiguous.

Fixes: https://github.com/mmtk/mmtk-core/issues/1070