### PR TITLE
Properly get PR number for merge group

### DIFF
--- a/.github/workflows/minimal-tests-bindings.yml
+++ b/.github/workflows/minimal-tests-bindings.yml
@@ -19,6 +19,14 @@ jobs:
   grace-period:
     runs-on: ubuntu-latest
     steps:
+      # This workflow runs for both merge_group and pull_request
+      # We need a way to get the pull request number that works for both cases.
+      # The action can do that.
+      - id: get-pr-number
+        uses: mgaitan/gha-get-pr-number@main
+      # This job also outputs the PR number
+      - run: echo "pr-number=${{ steps.get-pr-number.outputs.number }}"
+      # Sleep for 2 mins
       - run: sleep 120
 
   # Figure out binding PRs.
@@ -26,7 +34,7 @@ jobs:
     needs: grace-period
     uses: ./.github/workflows/pr-binding-refs.yml
     with:
-      pull_request: ${{ github.event.pull_request.number }}
+      pull_request: ${{ needs.grace-period.outputs.pr-number }}
 
   minimal-tests-openjdk:
     needs: binding-refs

--- a/.github/workflows/minimal-tests-bindings.yml
+++ b/.github/workflows/minimal-tests-bindings.yml
@@ -18,6 +18,8 @@ jobs:
   # This step allows 2mins before we check comments for binding repos/refs.
   grace-period:
     runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.set-output.outputs.pr-number }}
     steps:
       # This workflow runs for both merge_group and pull_request
       # We need a way to get the pull request number that works for both cases.
@@ -25,7 +27,8 @@ jobs:
       - id: get-pr-number
         uses: mgaitan/gha-get-pr-number@main
       # This job also outputs the PR number
-      - run: echo "pr-number=${{ steps.get-pr-number.outputs.number }}"
+      - id: set-output
+        run: echo "pr-number=${{ steps.get-pr-number.outputs.number }}" >> $GITHUB_OUTPUT
       # Sleep for 2 mins
       - run: sleep 120
 


### PR DESCRIPTION
Run https://github.com/mmtk/mmtk-core/actions/runs/7649653943/job/20844445119 failed, as we use `${{ github.event.pull_request.number }}` to get the pull request number and it does not work for the `merge_group` trigger. This PR gets pull request number using a third-party action which properly deals with both `pull_request` and `merge_group`.