### PR TITLE
Fix issues in sanity GC

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -25,3 +25,9 @@ jobs:
           checkInterval: 600
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Check result
+        if: ${{ steps.waitforstatuschecks.outputs.status != 'success' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Status checks failed')

--- a/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
@@ -78,8 +78,8 @@ impl<VM: VMBinding> ProcessEdgesWork for MyGCProcessEdges<VM> {
         }
     }
 
-    fn create_scan_work(&self, nodes: Vec<ObjectReference>, roots: bool) -> ScanObjects<Self> {
-        ScanObjects::<Self>::new(nodes, false, roots, self.bucket)
+    fn create_scan_work(&self, nodes: Vec<ObjectReference>) -> ScanObjects<Self> {
+        ScanObjects::<Self>::new(nodes, false, self.bucket)
     }
 }
 // ANCHOR_END: mygc_process_edges_impl

--- a/src/plan/generational/gc_work.rs
+++ b/src/plan/generational/gc_work.rs
@@ -57,12 +57,8 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>> ProcessEdg
         }
     }
 
-    fn create_scan_work(
-        &self,
-        nodes: Vec<ObjectReference>,
-        roots: bool,
-    ) -> Self::ScanObjectsWorkType {
-        PlanScanObjects::new(self.plan, nodes, false, roots, self.bucket)
+    fn create_scan_work(&self, nodes: Vec<ObjectReference>) -> Self::ScanObjectsWorkType {
+        PlanScanObjects::new(self.plan, nodes, false, self.bucket)
     }
 }
 
@@ -122,7 +118,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for ProcessModBuf<E> {
             // Scan objects in the modbuf and forward pointers
             let modbuf = std::mem::take(&mut self.modbuf);
             GCWork::do_work(
-                &mut ScanObjects::<E>::new(modbuf, false, false, WorkBucketStage::Closure),
+                &mut ScanObjects::<E>::new(modbuf, false, WorkBucketStage::Closure),
                 worker,
                 mmtk,
             )

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -1101,7 +1101,11 @@ impl<E: ProcessEdgesWork, P: Plan<VM = E::VM> + PlanTraceObject<E::VM>> GCWork<E
 /// but creates the work to scan these objects using E. This is necessary to guarantee that these objects do not move
 /// (`I` should trace them without moving) as we do not have the information about the edges pointing to them.
 
-struct ProcessRootNode<VM: VMBinding, I: ProcessEdgesWork<VM = VM>, E: ProcessEdgesWork<VM = VM>> {
+pub(crate) struct ProcessRootNode<
+    VM: VMBinding,
+    I: ProcessEdgesWork<VM = VM>,
+    E: ProcessEdgesWork<VM = VM>,
+> {
     phantom: PhantomData<(VM, I, E)>,
     roots: Vec<ObjectReference>,
     bucket: WorkBucketStage,

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -227,11 +227,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SanityGCProcessEdges<VM> {
         object
     }
 
-    fn create_scan_work(
-        &self,
-        nodes: Vec<ObjectReference>,
-        roots: bool,
-    ) -> Self::ScanObjectsWorkType {
-        ScanObjects::<Self>::new(nodes, false, roots, WorkBucketStage::Closure)
+    fn create_scan_work(&self, nodes: Vec<ObjectReference>) -> Self::ScanObjectsWorkType {
+        ScanObjects::<Self>::new(nodes, false, WorkBucketStage::Closure)
     }
 }


### PR DESCRIPTION
This PR fixes two issues in sanity GC.
* It fixes https://github.com/mmtk/mmtk-core/issues/1078 by removing the code to prepare/release mutator/collector, which seems unnecessary.
* It replaces the use of `ScanObjects` for cached root nodes with `ProcessRootNode`. Otherwise, the assertion `assert!(!self.roots())` will fail in `ScanObjectsWork::do_work_common`.