### PR TITLE
Adding feature to query the fragmentation of immixspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,9 @@ malloc_counted_size = []
 # Count the size of all live objects in GC
 count_live_bytes_in_gc = []
 
+# Count the size of live objects in immixspace (the ones that can actually be opportunistically moved)
+count_live_bytes_immixspace = []
+
 # Workaround a problem where bpftrace scripts (see tools/tracing/timeline/capture.bt) cannot
 # capture the type names of work packets.
 bpftrace_workaround = []

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -43,6 +43,11 @@ pub struct GlobalState {
     /// This stores the size in bytes for all the live objects in last GC. This counter is only updated in the GC release phase.
     #[cfg(feature = "count_live_bytes_in_gc")]
     pub(crate) live_bytes_in_last_gc: AtomicUsize,
+    /// These keep track of the fragmentation rate in immixspace
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub(crate) live_bytes_in_immixspace: AtomicUsize,
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub(crate) fragmentation_rate_in_immixspace: AtomicUsize,
 }
 
 impl GlobalState {
@@ -188,6 +193,38 @@ impl GlobalState {
     pub fn set_live_bytes_in_last_gc(&self, size: usize) {
         self.live_bytes_in_last_gc.store(size, Ordering::SeqCst);
     }
+
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub fn get_live_bytes_in_last_gc(&self) -> usize {
+        self.live_bytes_in_immixspace.load(Ordering::SeqCst)
+    }
+
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub fn set_live_bytes_in_immixspace(&self, size: usize) {
+        self.live_bytes_in_immixspace.store(size, Ordering::SeqCst);
+    }
+
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub fn get_live_bytes_in_immixspace(&self) -> usize {
+        self.live_bytes_in_immixspace.load(Ordering::SeqCst)
+    }
+
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub fn increase_live_bytes_in_immixspace_by(&self, size: usize) {
+        self.live_bytes_in_immixspace
+            .fetch_add(size, Ordering::SeqCst);
+    }
+
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub fn get_fragmentation_rate_in_immixspace(&self) -> usize {
+        self.fragmentation_rate_in_immixspace.load(Ordering::SeqCst)
+    }
+
+    #[cfg(feature = "count_live_bytes_immixspace")]
+    pub fn set_fragmentation_rate_in_immixspace(&self, size: usize) {
+        self.fragmentation_rate_in_immixspace
+            .store(size, Ordering::SeqCst);
+    }
 }
 
 impl Default for GlobalState {
@@ -209,6 +246,10 @@ impl Default for GlobalState {
             malloc_bytes: AtomicUsize::new(0),
             #[cfg(feature = "count_live_bytes_in_gc")]
             live_bytes_in_last_gc: AtomicUsize::new(0),
+            #[cfg(feature = "count_live_bytes_immixspace")]
+            live_bytes_in_immixspace: AtomicUsize::new(0),
+            #[cfg(feature = "count_live_bytes_immixspace")]
+            fragmentation_rate_in_immixspace: AtomicUsize::new(0),
         }
     }
 }

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -557,6 +557,19 @@ pub fn live_bytes_in_last_gc<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
     mmtk.state.live_bytes_in_last_gc.load(Ordering::SeqCst)
 }
 
+/// Return the percentage of fragmentation of the immixspace (e.g. 42.98 percent). To do that we count the size of every live object
+/// in the immixspace. Since MMTk accounts for memory in pages, we return the ratio between this number and
+/// the number of used bytes (according to the used pages by the immixspace).
+/// The value returned by this method is only updated when we finish tracing in a GC. A recommended timing
+/// to call this method is at the end of a GC (e.g. when the runtime is about to resume threads).
+#[cfg(feature = "count_live_bytes_immixspace")]
+pub fn fragmentation_rate_in_immixspace<VM: VMBinding>(mmtk: &MMTK<VM>) -> f64 {
+    mmtk.state
+        .fragmentation_rate_in_immixspace
+        .load(Ordering::SeqCst) as f64
+        / 100.0
+}
+
 /// Return the starting address of the heap. *Note that currently MMTk uses
 /// a fixed address range as heap.*
 pub fn starting_heap_address() -> Address {


### PR DESCRIPTION
Currently we can use the `count_live_bytes_in_gc` feature to check the total fragmentation of the heap, by counting the bytes of all objects that are scanned and dividing that by the total number of pages used by MMTk. 
However, to provide an accurate idea about fragmentation in terms of how much of the heap could be (opportunistically) defragmented, this PR does the counting only for the immix space, enabling to print the fragmentation rate of immixspace as `live_bytes_in_immixspace / (live_pages_in_immixspace << log_bytes_on_page)`.