### PR TITLE
Create separate work packet types for object tracing from mod buf

### DIFF
--- a/src/plan/generational/barrier.rs
+++ b/src/plan/generational/barrier.rs
@@ -10,9 +10,7 @@ use crate::vm::edge_shape::MemorySlice;
 use crate::vm::VMBinding;
 use crate::MMTK;
 
-use super::gc_work::GenNurseryProcessEdges;
-use super::gc_work::ProcessModBuf;
-use super::gc_work::ProcessRegionModBuf;
+use super::gc_work::*;
 use super::global::GenerationalPlanExt;
 
 pub struct GenObjectBarrierSemantics<
@@ -45,7 +43,7 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>>
         let buf = self.modbuf.take();
         if !buf.is_empty() {
             self.mmtk.scheduler.work_buckets[WorkBucketStage::Closure]
-                .add(ProcessModBuf::<GenNurseryProcessEdges<VM, P>>::new(buf));
+                .add(ProcessModBuf::<GenNurseryProcessEdgesFromModBuf<VM, P>>::new(buf));
         }
     }
 
@@ -54,7 +52,7 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>>
         if !buf.is_empty() {
             debug_assert!(!buf.is_empty());
             self.mmtk.scheduler.work_buckets[WorkBucketStage::Closure].add(ProcessRegionModBuf::<
-                GenNurseryProcessEdges<VM, P>,
+                GenNurseryProcessEdgesFromRegionModBuf<VM, P>,
             >::new(buf));
         }
     }


### PR DESCRIPTION
Currently all the tracing in a nursery GC is done in `GenNurseryProcessEdges`, including objects reachable from root, and objects reachable from mod buf. This PR uses seperate work packet types for objects that are from mod buf. This helps us understand the nursery GC time better.