### PR TITLE
Bump dependencies after version 0.24

### DIFF
--- a/.github/scripts/ci-style.sh
+++ b/.github/scripts/ci-style.sh
@@ -2,6 +2,15 @@
 
 export RUSTFLAGS="-D warnings -A unknown-lints"
 
+# --- Check format ---
+cargo fmt -- --check
+cargo fmt --manifest-path=macros/Cargo.toml -- --check
+
+# All versions of Clippy randomly crash on Darwin.  We disable Clippy tests for Darwin for now.
+if [[ $(uname) == "Darwin" ]]; then
+    exit 0
+fi
+
 # Workaround the clippy issue on Rust 1.72: https://github.com/mmtk/mmtk-core/issues/929.
 # If we are not testing with Rust 1.72, or there is no problem running the following clippy checks, we can remove this export.
 CLIPPY_VERSION=$(cargo clippy --version)

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Install nightly Rust toolchain
         run: rustup toolchain install nightly
 
+      # Show the Rust toolchain we are actually using
+      - run: rustup show
       - run: cargo --version
       - run: cargo +nightly --version
 

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout mmtk-core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history needed
           fetch-depth: 0

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -24,22 +24,10 @@ jobs:
           # Full git history needed
           fetch-depth: 0
 
-      # cargo-public-api can be built with the latest stable toolchain.
-      - name: Install stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          # make it the active toolchain
-          override: true
-
       # cargo-public-api needs a nightly toolchain installed in order to work.
       # It does not have to be the active toolchain.
       - name: Install nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
+        run: rustup toolchain install nightly
 
       - run: cargo --version
       - run: cargo +nightly --version

--- a/.github/workflows/auto-merge-inner.yml
+++ b/.github/workflows/auto-merge-inner.yml
@@ -44,13 +44,13 @@ jobs:
         shell: bash
 
       - name: Checkout MMTk Core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: steps.check-input.outputs.skip == 'false'
         with:
           path: ${{ env.MMTK_CORE_WORK_DIR }}
       - name: Checkout repository
         if: steps.check-input.outputs.skip == 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo }}
           path: ${{ env.BINDING_WORK_DIR }}

--- a/.github/workflows/binding-tests-openjdk.yml
+++ b/.github/workflows/binding-tests-openjdk.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
         - name: Checkout MMTk Core
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
           with:
             path: mmtk-core
         - name: Checkout OpenJDK Binding
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
           with:
             repository: ${{ inputs.repo }}
             path: mmtk-openjdk

--- a/.github/workflows/cargo-msrv.yml
+++ b/.github/workflows/cargo-msrv.yml
@@ -18,11 +18,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
       - name: Install cargo-msrv
         run: cargo install cargo-msrv
       # Verify the MSRV defined in Cargo.toml

--- a/.github/workflows/cargo-msrv.yml
+++ b/.github/workflows/cargo-msrv.yml
@@ -17,7 +17,7 @@ jobs:
   msrv:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cargo-msrv.yml
+++ b/.github/workflows/cargo-msrv.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      # Show the Rust toolchain we are actually using
+      - run: rustup show
+      - run: cargo --version
+
       - name: Install cargo-msrv
         run: cargo install cargo-msrv
       # Verify the MSRV defined in Cargo.toml

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -14,7 +14,7 @@ jobs:
   cargo-publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      # Show the Rust toolchain we are actually using
+      - run: rustup show
+      - run: cargo --version
+
       - name: Cargo login
         run: cargo login ${{ secrets.CI_CARGO_LOGIN }}
       - name: Publish sub crates

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -15,13 +15,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          components: rustfmt, clippy
-          target: i686-unknown-linux-gnu
-          # This overwrites the default toolchain with the toolchain specified above.
-          override: true
       - name: Cargo login
         run: cargo login ${{ secrets.CI_CARGO_LOGIN }}
       - name: Publish sub crates

--- a/.github/workflows/extended-tests-bindings.yml
+++ b/.github/workflows/extended-tests-bindings.yml
@@ -25,11 +25,11 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout V8 Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ needs.binding-refs.outputs.v8_binding_repo }}
           path: mmtk-v8
@@ -71,11 +71,11 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout JikesRVM Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo }}
           path: mmtk-jikesrvm
@@ -106,11 +106,11 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout Julia Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ needs.binding-refs.outputs.julia_binding_repo }}
           path: mmtk-julia
@@ -154,12 +154,12 @@ jobs:
       DEBUG_LEVEL: ${{ matrix.debug-level }}
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
 
       - name: Checkout MMTk Ruby binding
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ needs.binding-refs.outputs.ruby_binding_repo }}
           path: mmtk-ruby
@@ -175,7 +175,7 @@ jobs:
         working-directory: mmtk-ruby
 
       - name: Checkout Ruby
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ steps.extract-ruby-revision.outputs.ruby_repo }}
           ref: ${{ steps.extract-ruby-revision.outputs.ruby_rev }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,7 +9,7 @@ jobs:
   check-broken-links-in-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore lychee cache
         uses: actions/cache@v3
         with:
@@ -17,13 +17,13 @@ jobs:
             key: cache-lychee-${{ github.sha }}
             restore-keys: cache-lychee-
       - name: Check links in docs/*.md
-        uses: lycheeverse/lychee-action@v1.9.0
+        uses: lycheeverse/lychee-action@v1.9.3
         with:
           fail: true
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --base docs --accept '200,201,202,203,204,429,500' --no-progress --cache --max-cache-age 1d './docs/**/*.md' --exclude https://users.cecs.anu.edu.au/~steveb/pubs/papers/**
       - name: Save lychee cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
             path: .lycheecache

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -14,7 +14,7 @@ jobs:
       - name: 'Wait for status checks'
         id: waitforstatuschecks
         timeout-minutes: 120
-        uses: "WyriHaximus/github-action-wait-for-status@v1.7.0"
+        uses: "WyriHaximus/github-action-wait-for-status@v1.8.0"
         with:
           # Ignore some actions (based on what merge_group triggers):
           # - this action
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Check result
         if: ${{ steps.waitforstatuschecks.outputs.status != 'success' }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           script: |
             core.setFailed('Status checks failed')

--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -24,14 +24,14 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'PR-benchmarking')
     steps:
       - name: Check Revisions
-        uses: qinsoon/comment-env-vars@1.0.3
+        uses: qinsoon/comment-env-vars@1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default_env: 'OPENJDK_BINDING_TRUNK_REF=master,MMTK_CORE_TRUNK_REF=master,OPENJDK_BINDING_BRANCH_REF=master,MMTK_CORE_BRANCH_REF=${{ github.event.pull_request.head.sha }}'
       # Trunk
       # - binding
       - name: Checkout OpenJDK Binding Trunk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,14 +40,14 @@ jobs:
           ref: ${{ env.OPENJDK_BINDING_TRUNK_REF }}
       # -core
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.MMTK_CORE_TRUNK_REF }}
           path: mmtk-core-trunk
       # Branch
       # - binding
       - name: Checkout OpenJDK Binding Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,13 +56,13 @@ jobs:
           ref: ${{ env.OPENJDK_BINDING_BRANCH_REF }}
       # - core
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.MMTK_CORE_BRANCH_REF }}
           path: mmtk-core-branch
       # checkout perf-kit
       - name: Checkout Perf Kit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,11 +83,11 @@ jobs:
         with:
           path: openjdk-rebench-report.md
       # upload run results
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: openjdk-rebench-data
           path: ci-perf-kit/microbm/ci.data
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: openjdk-rebench-report.md
           path: openjdk-rebench-report.md

--- a/.github/workflows/minimal-tests-core.yml
+++ b/.github/workflows/minimal-tests-core.yml
@@ -45,12 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}-${{ matrix.target.triple }}
-          components: rustfmt, clippy
-          # This overwrites the default toolchain with the toolchain specified above.
-          override: true
+        run: |
+          rustup toolchain install ${{ matrix.rust }}-${{ matrix.target.triple }}
+          rustup override set ${{ matrix.rust }}-${{ matrix.target.triple }}
+          rustup component add rustfmt clippy
 
       # Setup Environments
       - name: Setup Environments

--- a/.github/workflows/minimal-tests-core.yml
+++ b/.github/workflows/minimal-tests-core.yml
@@ -50,6 +50,10 @@ jobs:
           rustup override set ${{ matrix.rust }}-${{ matrix.target.triple }}
           rustup component add rustfmt clippy
 
+      # Show the Rust toolchain we are actually using
+      - run: rustup show
+      - run: cargo --version
+
       # Setup Environments
       - name: Setup Environments
         run: ./.github/scripts/ci-setup-${{ matrix.target.triple }}.sh

--- a/.github/workflows/minimal-tests-core.yml
+++ b/.github/workflows/minimal-tests-core.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       rust: ${{ steps.rust.outputs.array }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Get rust version
       - id: rust
         run: |
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.target.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/mmtk-dev-env.yml
+++ b/.github/workflows/mmtk-dev-env.yml
@@ -16,7 +16,7 @@ jobs:
   check-mmtk-dev-env:
     runs-on: ubuntu-22.04
     steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.3.0
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: mmtk
           repo: mmtk-dev-env
@@ -24,7 +24,7 @@ jobs:
           workflow_file_name: ci.yml
           ref: main
           wait_interval: 30
-          inputs: '{}'
+          client_payload: '{}'
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 1440
     steps:
       - name: Checkout JikesRVM Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-jikesrvm
           path: mmtk-jikesrvm
@@ -38,7 +38,7 @@ jobs:
           ./.github/scripts/ci-checkout.sh
       # checkout perf-kit
       - name: Checkout Perf Kit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
@@ -61,13 +61,13 @@ jobs:
           export FROM_DATE=2020-07-10
           JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-stock.sh ./mmtk-jikesrvm/repos/jikesrvm
       - name: Upload build as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jikesrvm-baseline-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jikesrvm-baseline-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 2880
     steps:
       - name: Checkout OpenJDK Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
           path: mmtk-openjdk
@@ -90,7 +90,7 @@ jobs:
           ./.github/scripts/ci-checkout.sh
       # checkout perf-kit
       - name: Checkout Perf Kit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
@@ -113,13 +113,13 @@ jobs:
           export FROM_DATE=2020-07-10
           ./ci-perf-kit/scripts/openjdk-stock.sh ./mmtk-openjdk/repos/openjdk
       - name: Upload build as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openjdk-baseline-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openjdk-baseline-logs
           path: ${{ env.CI_PERF_KIT_LOG }}

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -36,7 +36,7 @@ jobs:
         mmtk-ref: ${{ steps.print.outputs.mmtk_ref }}
       steps:
         - name: Get mmtk-core repo from pull_request
-          uses: actions/github-script@v6
+          uses: actions/github-script@v7
           id: core-repo
           with:
             result-encoding: string
@@ -48,7 +48,7 @@ jobs:
               }))
               return res.data.head.repo.full_name
         - name: Get mmtk-core refs from pull_request
-          uses: actions/github-script@v6
+          uses: actions/github-script@v7
           id: core-ref
           with:
             result-encoding: string
@@ -73,7 +73,7 @@ jobs:
           # Trunk - we always use master from the mmtk org
           # - binding
           - name: Checkout JikesRVM Binding Trunk
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
             with:
               repository: mmtk/mmtk-jikesrvm
               ref: master
@@ -83,7 +83,7 @@ jobs:
             run: ./.github/scripts/ci-checkout.sh
           # - core
           - name: Checkout MMTk Core
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
             with:
               repository: mmtk/mmtk-core
               ref: master
@@ -91,14 +91,14 @@ jobs:
           # Branch
           # - binding
           - name: Checkout JikesRVM Binding Branch
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
             with:
               repository: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo }}
               ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
               path: mmtk-jikesrvm-branch
           # - core
           - name: Checkout MMTk Core
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
             with:
               repository: ${{ needs.mmtk-refs.outputs.mmtk_repo }}
               ref: ${{ needs.mmtk-refs.outputs.mmtk_ref }}
@@ -108,7 +108,7 @@ jobs:
             run: ./.github/scripts/ci-checkout.sh
           # Checkout perf-kit
           - name: Checkout Perf Kit
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
@@ -120,7 +120,7 @@ jobs:
           - name: Setup Rust Toolchain
             run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
           # run compare
-          - uses: hasura/comment-progress@v2.1.0
+          - uses: hasura/comment-progress@v2.3.0
             with:
                 github-token: ${{ secrets.CI_ACCESS_TOKEN }}
                 repository: 'mmtk/mmtk-core'
@@ -139,23 +139,23 @@ jobs:
               path: jikesrvm-compare-report.md
           # upload run results
           - name: Upload build as artifacts
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
               name: jikesrvm-compare-build
               path: ${{ env.CI_PERF_KIT_BUILD }}
               if-no-files-found: error
           - name: Upload logs as artifacts
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
               name: jikesrvm-compare-logs
               path: ${{ env.CI_PERF_KIT_LOG }}
               if-no-files-found: error
-          - uses: actions/upload-artifact@v2
+          - uses: actions/upload-artifact@v4
             with:
               name: jikesrvm-compare-report.md
               path: jikesrvm-compare-report.md
           # report
-          - uses: hasura/comment-progress@v2.1.0
+          - uses: hasura/comment-progress@v2.3.0
             if: always()
             with:
                 github-token: ${{ secrets.CI_ACCESS_TOKEN }}
@@ -180,7 +180,7 @@ jobs:
             # Trunk - we always use master from the mmtk org
             # - binding
             - name: Checkout OpenJDK Binding Trunk
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 repository: mmtk/mmtk-openjdk
                 ref: master
@@ -190,7 +190,7 @@ jobs:
               run: ./.github/scripts/ci-checkout.sh
             # -core
             - name: Checkout MMTk Core
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 repository: mmtk/mmtk-core
                 ref: master
@@ -198,7 +198,7 @@ jobs:
             # Branch
             # - binding
             - name: Checkout OpenJDK Binding Branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 repository: ${{ needs.binding-refs.outputs.openjdk_binding_repo }}
                 ref: ${{ needs.binding-refs.outputs.openjdk_binding_ref }}
@@ -208,14 +208,14 @@ jobs:
               run: ./.github/scripts/ci-checkout.sh
             # - core
             - name: Checkout MMTk Core
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 repository: ${{ needs.mmtk-refs.outputs.mmtk_repo }}
                 ref: ${{ needs.mmtk-refs.outputs.mmtk_ref }}
                 path: mmtk-core-branch
             # checkout perf-kit
             - name: Checkout Perf Kit
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
@@ -227,7 +227,7 @@ jobs:
             - name: Setup Rust Toolchain
               run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core-trunk/rust-toolchain`" >> $GITHUB_ENV
             # run compare
-            - uses: hasura/comment-progress@v2.1.0
+            - uses: hasura/comment-progress@v2.3.0
               with:
                 github-token: ${{ secrets.CI_ACCESS_TOKEN }}
                 repository: 'mmtk/mmtk-core'
@@ -246,23 +246,23 @@ jobs:
                 path: openjdk-compare-report.md
             # upload run results
             - name: Upload build as artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: openjdk-compare-build
                 path: ${{ env.CI_PERF_KIT_BUILD }}
                 if-no-files-found: error
             - name: Upload logs as artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: openjdk-compare-logs
                 path: ${{ env.CI_PERF_KIT_LOG }}
                 if-no-files-found: error
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                 name: openjdk-compare-report.md
                 path: openjdk-compare-report.md
             # report
-            - uses: hasura/comment-progress@v2.1.0
+            - uses: hasura/comment-progress@v2.3.0
               if: always()
               with:
                 github-token: ${{ secrets.CI_ACCESS_TOKEN }}

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -28,11 +28,11 @@ jobs:
     timeout-minutes: 1440
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout JikesRVM Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-jikesrvm
           path: mmtk-jikesrvm
@@ -42,7 +42,7 @@ jobs:
           ./.github/scripts/ci-checkout.sh
       # checkout perf-kit
       - name: Checkout Perf Kit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
           ref: "0.7.5"
@@ -73,7 +73,7 @@ jobs:
       # deploy
       - name: Deploy to Github Page
         if: ${{ env.DEPLOY == 'true' }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
           external_repository: mmtk/ci-perf-result
@@ -81,13 +81,13 @@ jobs:
           publish_branch: gh-pages
           keep_files: true
       - name: Upload build as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jikesrvm-regression-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jikesrvm-regression-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
@@ -99,11 +99,11 @@ jobs:
     timeout-minutes: 1440
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout OpenJDK Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
           path: mmtk-openjdk
@@ -113,7 +113,7 @@ jobs:
           ./.github/scripts/ci-checkout.sh
       # checkout perf-kit
       - name: Checkout Perf Kit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
           ref: "0.7.5"
@@ -149,7 +149,7 @@ jobs:
       # deploy
       - name: Deploy to Github Page
         if: ${{ env.DEPLOY == 'true' }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
           external_repository: mmtk/ci-perf-result
@@ -157,13 +157,13 @@ jobs:
           publish_branch: gh-pages
           keep_files: true
       - name: Upload build as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openjdk-regression-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openjdk-regression-logs
           path: ${{ env.CI_PERF_KIT_LOG }}
@@ -174,11 +174,11 @@ jobs:
     timeout-minutes: 1440
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout OpenJDK Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
           path: mmtk-openjdk
@@ -188,7 +188,7 @@ jobs:
           ./.github/scripts/ci-checkout.sh
       # checkout perf-kit
       - name: Checkout Perf Kit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
           ref: "0.7.5"
@@ -225,7 +225,7 @@ jobs:
       # deploy
       - name: Deploy to Github Page
         if: ${{ env.DEPLOY == 'true' }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
           external_repository: mmtk/ci-perf-result
@@ -233,13 +233,13 @@ jobs:
           publish_branch: gh-pages
           keep_files: true
       - name: Upload build as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mutator-regression-build
           path: ${{ env.CI_PERF_KIT_BUILD }}
           if-no-files-found: error
       - name: Upload logs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mutator-regression-logs
           path: ${{ env.CI_PERF_KIT_LOG }}

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -10,7 +10,7 @@ jobs:
   publish-rustdoc-as-ghpages:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -30,7 +30,7 @@ jobs:
           cp -r docs/userguide/book to_publish
           cp -r target/doc to_publish/api
       - name: Deploy to Github Page
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
           publish_dir: to_publish

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -11,13 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          components: rustfmt, clippy
-          target: i686-unknown-linux-gnu
-          # This overwrites the default toolchain with the toolchain specified above.
-          override: true
       - name: Append sha to crate version
         run: |
           sed -i 's/^version = "[0-9]\+.[0-9]\+.[0-9]\+/&-'${GITHUB_SHA}'/' Cargo.toml

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      # Show the Rust toolchain we are actually using
+      - run: rustup show
+      - run: cargo --version
+
       - name: Append sha to crate version
         run: |
           sed -i 's/^version = "[0-9]\+.[0-9]\+.[0-9]\+/&-'${GITHUB_SHA}'/' Cargo.toml

--- a/.github/workflows/stress-ci.yml
+++ b/.github/workflows/stress-ci.yml
@@ -19,11 +19,11 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout JikesRVM Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-jikesrvm
           token: ${{ secrets.CI_ACCESS_TOKEN }}
@@ -103,11 +103,11 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Checkout MMTk Core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: mmtk-core
       - name: Checkout OpenJDK Binding
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
           token: ${{ secrets.CI_ACCESS_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ doctest = false
 [dependencies]
 atomic = "0.6.0"
 atomic_refcell = "0.1.7"
-atomic-traits = "0.3.0"
+atomic-traits = "0.4.0"
 bytemuck = { version = "1.14.0", features = ["derive"] }
 cfg-if = "1.0"
 crossbeam = "0.8.1"
-delegate = "0.10.0"
+delegate = "0.12.0"
 downcast-rs = "1.1.1"
 enum-map = "2.4.2"
-env_logger = "0.10.0"
+env_logger = "0.11.3"
 is-terminal = "0.4.7"
 itertools = "0.12.0"
 jemalloc-sys = { version = "0.5.3", features = ["disable_initial_exec_tls"], optional = true }
@@ -47,14 +47,14 @@ probe = "0.5"
 regex = "1.7.0"
 spin = "0.9.5"
 static_assertions = "1.1.0"
-strum = "0.25"
-strum_macros = "0.25"
-sysinfo = "0.29"
+strum = "0.26.2"
+strum_macros = "0.26.2"
+sysinfo = "0.30.9"
 
 [dev-dependencies]
 paste = "1.0.8"
 rand = "0.8.5"
-criterion = "0.4"
+criterion = "0.5.1"
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ sysinfo = "0.30.9"
 [dev-dependencies]
 paste = "1.0.8"
 rand = "0.8.5"
-criterion = "0.5.1"
+criterion = "0.4"
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2"] }

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -5,7 +5,8 @@ use crate::vm::{Collection, VMBinding};
 use bytemuck::NoUninit;
 use libc::{PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
 use std::io::{Error, Result};
-use sysinfo::{RefreshKind, System, SystemExt};
+use sysinfo::MemoryRefreshKind;
+use sysinfo::{RefreshKind, System};
 
 /// Check the result from an mmap function in this module.
 /// Return true if the mmap has failed due to an existing conflicting mapping.
@@ -247,7 +248,9 @@ pub(crate) fn get_system_total_memory() -> u64 {
     // start-up time.  During start-up, MMTk core only needs the total memory to initialize the
     // `Options`.  If we only load memory-related components on start-up, it should only take <1ms
     // to initialize the `System` instance.
-    let sys = System::new_with_specifics(RefreshKind::new().with_memory());
+    let sys = System::new_with_specifics(
+        RefreshKind::new().with_memory(MemoryRefreshKind::new().with_ram()),
+    );
     sys.total_memory()
 }
 


### PR DESCRIPTION
This PR updates Cargo crates dependencies and GitHub Actions dependencies after v0.24 was released, with two exceptions:

-   We do not update `criterion` because a later version unintentionally requires MSRV 1.74.  The problem has been fixed in the upstream criterion repo, but has not been released, yet.
-   We replaced `actions-rs/toolchain` with manual invocations of `rustup` because `actions-rs/toolchain` is no longer maintained.  For tasks that don't require a specific toolchain, we rely on `rustup` and `cargo` to automatically install the toolchain specified by the file `rust-toolchain` upon first invocation.

Also disabled Clippy checks on Darwin because the `clippy` program itself randomly crashes on Darwin.