### PR TITLE
Lock mark sweep block list during release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,9 @@ immix_smaller_block = []
 # Zero the unmarked lines after a GC cycle in immix. This helps debug untraced objects.
 immix_zero_on_release = []
 
+# Run sanity checks for BlockList in mark sweep.
+ms_block_list_sanity = []
+
 # Run sanity GC
 sanity = []
 # Run analysis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ nogc_no_zeroing = ["nogc_lock_free"]
 single_worker = []
 
 # To run expensive comprehensive runtime checks, such as checking duplicate edges
-extreme_assertions = []
+extreme_assertions = ["ms_block_list_sanity"]
 
 # Enable multiple spaces for NoGC, each allocator maps to an individual ImmortalSpace.
 nogc_multi_space = []

--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -136,35 +136,35 @@ impl Block {
             .is_ok()
     }
 
-    pub fn load_prev_block(&self) -> Option<Block> {
+    pub(in crate::policy::marksweepspace::native_ms) fn load_prev_block(&self) -> Option<Block> {
         let prev = unsafe { Block::PREV_BLOCK_TABLE.load::<usize>(self.start()) };
         NonZeroUsize::new(prev).map(Block)
     }
 
-    pub fn load_next_block(&self) -> Option<Block> {
+    pub(in crate::policy::marksweepspace::native_ms) fn load_next_block(&self) -> Option<Block> {
         let next = unsafe { Block::NEXT_BLOCK_TABLE.load::<usize>(self.start()) };
         NonZeroUsize::new(next).map(Block)
     }
 
-    pub fn store_next_block(&self, next: Block) {
+    pub(in crate::policy::marksweepspace::native_ms) fn store_next_block(&self, next: Block) {
         unsafe {
             Block::NEXT_BLOCK_TABLE.store::<usize>(self.start(), next.start().as_usize());
         }
     }
 
-    pub fn clear_next_block(&self) {
+    pub(in crate::policy::marksweepspace::native_ms) fn clear_next_block(&self) {
         unsafe {
             Block::NEXT_BLOCK_TABLE.store::<usize>(self.start(), 0);
         }
     }
 
-    pub fn store_prev_block(&self, prev: Block) {
+    pub(in crate::policy::marksweepspace::native_ms) fn store_prev_block(&self, prev: Block) {
         unsafe {
             Block::PREV_BLOCK_TABLE.store::<usize>(self.start(), prev.start().as_usize());
         }
     }
 
-    pub fn clear_prev_block(&self) {
+    pub(in crate::policy::marksweepspace::native_ms) fn clear_prev_block(&self) {
         unsafe {
             Block::PREV_BLOCK_TABLE.store::<usize>(self.start(), 0);
         }

--- a/src/policy/marksweepspace/native_ms/block_list.rs
+++ b/src/policy/marksweepspace/native_ms/block_list.rs
@@ -36,33 +36,15 @@ impl BlockList {
         }
     }
 
-    // fn access_block_list<R: Copy, F: FnOnce() -> R>(&self, access_func: F) -> R {
-    //     #[cfg(feature = "ms_block_list_sanity")]
-    //     let mut sanity_list = self.sanity_list.lock().unwrap();
-
-    //     let ret = access_func();
-
-    //     // Verify the block list is the same as the sanity list
-    //     #[cfg(feature = "ms_block_list_sanity")]
-    //     {
-    //         if !sanity_list.iter().map(|b| *b).eq(BlockListIterator { cursor: self.first }) {
-    //             eprintln!("Sanity block list: {:?}", &mut sanity_list as &mut Vec<Block>);
-    //             eprintln!("Actual block list: {:?}", self);
-    //             panic!("Incorrect block list");
-    //         }
-    //     }
-
-    //     ret
-    // }
     #[cfg(feature = "ms_block_list_sanity")]
     fn verify_block_list(&self, sanity_list: &mut Vec<Block>) {
         if !sanity_list
             .iter()
-            .map(|b| *b)
+            .cloned()
             .eq(BlockListIterator { cursor: self.first })
         {
             eprintln!("Sanity block list: {:?}", sanity_list);
-            eprintln!("First {:?}", sanity_list.get(0));
+            eprintln!("First {:?}", sanity_list.first());
             eprintln!("Actual block list: {:?}", self);
             eprintln!("First {:?}", self.first);
             eprintln!("Block list {:?}", self as *const _);
@@ -71,6 +53,7 @@ impl BlockList {
     }
 
     /// List has no blocks
+    #[allow(clippy::let_and_return)]
     pub fn is_empty(&self) -> bool {
         let ret = self.first.is_none();
 
@@ -296,6 +279,7 @@ impl BlockList {
     }
 
     /// Get the size of this block list.
+    #[allow(clippy::let_and_return)]
     pub fn size(&self) -> usize {
         let ret = self.size;
 

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -65,9 +65,13 @@ impl AbandonedBlockLists {
     fn move_consumed_to_unswept(&mut self) {
         let mut i = 0;
         while i < MI_BIN_FULL {
+            self.consumed[i].lock();
+            self.unswept[i].lock();
             if !self.consumed[i].is_empty() {
                 self.unswept[i].append(&mut self.consumed[i]);
             }
+            self.unswept[i].unlock();
+            self.consumed[i].unlock();
             i += 1;
         }
     }

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -218,10 +218,10 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
         debug_assert!(bin <= MAX_BIN);
 
         let available = &mut available_blocks[bin];
-        debug_assert!(available.size >= size);
+        debug_assert!(available.size() >= size);
 
         if !available.is_empty() {
-            let mut cursor = available.first;
+            let mut cursor = available.first();
 
             while let Some(block) = cursor {
                 if block.has_free_cells() {
@@ -230,7 +230,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
                 available.pop();
                 consumed_blocks.get_mut(bin).unwrap().push(block);
 
-                cursor = available.first;
+                cursor = available.first();
             }
         }
 
@@ -303,7 +303,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
 
                 crate::policy::marksweepspace::native_ms::BlockAcquireResult::Fresh(block) => {
                     self.add_to_available_blocks(bin, block, stress_test);
-                    self.init_block(block, self.available_blocks[bin].size);
+                    self.init_block(block, self.available_blocks[bin].size());
 
                     return Some(block);
                 }


### PR DESCRIPTION
This PR resolves the issue in https://github.com/mmtk/mmtk-core/issues/824#issuecomment-1558661794. It closes https://github.com/mmtk/mmtk-core/issues/824.
* Lock block lists in `AbandonedBlockLists` when they are accessed. This resolves the data race between `AbandonedBlockLists` and `SweepChunk` -- they both access blocks.
* Add a feature `ms_block_list_sanity`. This embeds a sanity block list `Vec<Block>` in `BlockList`, and checks if the actual block list with side metadata and linked list matches the sanity list. `ms_block_list_sanity` is enabled for `extreme_assertions`.