### PR TITLE
Use host toolchain and explicit target in CI script

### DIFF
--- a/.github/scripts/ci-common.sh
+++ b/.github/scripts/ci-common.sh
@@ -1,5 +1,7 @@
-arch=`rustc --print cfg | grep target_arch | cut -f2 -d"\""`
-os=`rustc --print cfg | grep target_os | cut -f2 -d"\""`
+# Note: cargo-rustc is influenced by the environment variable CARGO_BUILD_TARGET
+# which is specified in minimal-tests-core.yml
+arch=`cargo rustc -- --print cfg | grep target_arch | cut -f2 -d"\""`
+os=`cargo rustc -- --print cfg | grep target_os | cut -f2 -d"\""`
 
 project_root=$(dirname "$0")/../..
 

--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -22,6 +22,7 @@ if ! cat $project_root/src/plan/mod.rs | grep -q "pub mod mygc;"; then
 fi
 cargo build
 
-# Install mdbook using the stable toolchain
+# Install mdbook using the stable toolchain and the default target
+unset CARGO_BUILD_TARGET
 cargo +stable install mdbook
 mdbook build $project_root/docs/userguide

--- a/.github/workflows/minimal-tests-core.yml
+++ b/.github/workflows/minimal-tests-core.yml
@@ -62,9 +62,10 @@ jobs:
 
           rustup component add rustfmt clippy
 
-      # Show the Rust toolchain we are actually using
+      # Show the Rust toolchain and target we are actually using
       - run: rustup show
       - run: cargo --version
+      - run: cargo rustc -- --print cfg
 
       # Setup Environments
       - name: Setup Environments

--- a/.github/workflows/minimal-tests-core.yml
+++ b/.github/workflows/minimal-tests-core.yml
@@ -42,12 +42,24 @@ jobs:
     name: minimal-tests-core/${{ matrix.target.triple }}/${{ matrix.rust }}
     runs-on: ${{ matrix.target.os }}
 
+    env:
+      # This determines the default target which cargo-build, cargo-test, etc. use.
+      CARGO_BUILD_TARGET: "${{ matrix.target.triple }}"
+
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: |
-          rustup toolchain install ${{ matrix.rust }}-${{ matrix.target.triple }}
-          rustup override set ${{ matrix.rust }}-${{ matrix.target.triple }}
+          # "rustup toolchain install" should always install the host toolchain,
+          # so we don't specify the triple.
+          rustup toolchain install ${{ matrix.rust }}
+          rustup override set ${{ matrix.rust }}
+
+          # Ensure we install the target support for the target we are testing for.
+          # This is especially important for i686-unknown-linux-gnu
+          # because it's different from the host.
+          rustup target add ${{ matrix.target.triple }}
+
           rustup component add rustfmt clippy
 
       # Show the Rust toolchain we are actually using


### PR DESCRIPTION
This fixes a problem of installing i686 toolchain on an x86_64 host when running "Minimal tests - mmtk-core" on GitHub CI. Instead, we use the x86_64 toolchain, but add the i686 target and force all cargo commands to use that target using the `CARGO_BUILD_TARGET` environment variable.

Fixes: https://github.com/mmtk/mmtk-core/issues/1107