### PR TITLE
Remove data race for marksweep block lists

### DIFF
--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -65,6 +65,10 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.release(tls, true);
     }
 
+    fn end_of_gc(&mut self, _tls: VMWorkerThread) {
+        self.ms.end_of_gc();
+    }
+
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
         self.base().collection_required(self, space_full)
     }

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -492,6 +492,8 @@ impl<VM: VMBinding> MallocSpace<VM> {
         self.scheduler.work_buckets[WorkBucketStage::Release].bulk_add(work_packets);
     }
 
+    pub fn end_of_gc(&mut self) {}
+
     pub fn sweep_chunk(&self, chunk_start: Address) {
         // Call the relevant sweep function depending on the location of the mark bits
         match *VM::VMObjectModel::LOCAL_MARK_BIT_SPEC {

--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -225,18 +225,8 @@ impl Block {
         match self.get_state() {
             BlockState::Unallocated => false,
             BlockState::Unmarked => {
-                unsafe {
-                    let block_list = loop {
-                        let list = self.load_block_list();
-                        (*list).lock();
-                        if list == self.load_block_list() {
-                            break list;
-                        }
-                        (*list).unlock();
-                    };
-                    (*block_list).remove(self);
-                    (*block_list).unlock();
-                }
+                let block_list = self.load_block_list();
+                unsafe { &mut *block_list }.remove(self);
                 space.release_block(self);
                 true
             }

--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -188,6 +188,7 @@ impl Block {
     }
 
     pub fn store_block_cell_size(&self, size: usize) {
+        debug_assert_ne!(size, 0);
         unsafe { Block::SIZE_TABLE.store::<usize>(self.start(), size) }
     }
 
@@ -282,6 +283,7 @@ impl Block {
     /// that we need to use this method correctly.
     fn simple_sweep<VM: VMBinding>(&self) {
         let cell_size = self.load_block_cell_size();
+        debug_assert_ne!(cell_size, 0);
         let mut cell = self.start();
         let mut last = unsafe { Address::zero() };
         while cell + cell_size <= self.start() + Block::BYTES {

--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -220,10 +220,11 @@ impl Block {
         Self::MARK_TABLE.store_atomic::<u8>(self.start(), state, Ordering::SeqCst);
     }
 
-    /// Release this block if it is unmarked. Return true if the block is release.
+    /// Release this block if it is unmarked. Return true if the block is released.
     pub fn attempt_release<VM: VMBinding>(self, space: &MarkSweepSpace<VM>) -> bool {
         match self.get_state() {
-            BlockState::Unallocated => false,
+            // We should not have unallocated blocks in a block list
+            BlockState::Unallocated => unreachable!(),
             BlockState::Unmarked => {
                 let block_list = self.load_block_list();
                 unsafe { &mut *block_list }.remove(self);

--- a/src/policy/marksweepspace/native_ms/block_list.rs
+++ b/src/policy/marksweepspace/native_ms/block_list.rs
@@ -164,12 +164,19 @@ impl BlockList {
         BlockListIterator { cursor: self.first }
     }
 
-    /// Sweep all the blocks in the block list.
-    pub fn sweep_blocks<VM: VMBinding>(&self, space: &super::MarkSweepSpace<VM>) {
+    /// Release unmarked blocks, and sweep other blocks in the block list. Used by eager sweeping.
+    pub fn release_and_sweep_blocks<VM: VMBinding>(&self, space: &super::MarkSweepSpace<VM>) {
         for block in self.iter() {
             if !block.attempt_release(space) {
                 block.sweep::<VM>();
             }
+        }
+    }
+
+    /// Release unmarked blocks, and do not sweep any blocks. Used by lazy sweeping
+    pub fn release_blocks<VM: VMBinding>(&self, space: &super::MarkSweepSpace<VM>) {
+        for block in self.iter() {
+            block.attempt_release(space);
         }
     }
 }

--- a/src/policy/marksweepspace/native_ms/block_list.rs
+++ b/src/policy/marksweepspace/native_ms/block_list.rs
@@ -1,4 +1,4 @@
-use super::Block;
+use super::{Block, BlockState};
 use crate::util::alloc::allocator;
 use crate::util::linear_scan::Region;
 use crate::vm::VMBinding;
@@ -167,6 +167,8 @@ impl BlockList {
     /// Release unmarked blocks, and sweep other blocks in the block list. Used by eager sweeping.
     pub fn release_and_sweep_blocks<VM: VMBinding>(&self, space: &super::MarkSweepSpace<VM>) {
         for block in self.iter() {
+            // We should not have unallocated blocks in a block list
+            debug_assert_ne!(block.get_state(), BlockState::Unallocated);
             if !block.attempt_release(space) {
                 block.sweep::<VM>();
             }
@@ -176,6 +178,8 @@ impl BlockList {
     /// Release unmarked blocks, and do not sweep any blocks. Used by lazy sweeping
     pub fn release_blocks<VM: VMBinding>(&self, space: &super::MarkSweepSpace<VM>) {
         for block in self.iter() {
+            // We should not have unallocated blocks in a block list
+            debug_assert_ne!(block.get_state(), BlockState::Unallocated);
             block.attempt_release(space);
         }
     }

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -42,15 +42,15 @@ pub enum BlockAcquireResult {
 }
 
 /// A mark sweep space.
-/// 
+///
 /// The space and each free list allocator own some block lists.
 /// A block that is in use belongs to exactly one of the block lists. In this case,
 /// whoever owns a block list has exclusive access on the blocks in the list.
 /// There should be no data race to access blocks. A thread should NOT access a block list
 /// if it does not own the block list.
-/// 
+///
 /// The table below roughly describes what we do in each phase.
-/// 
+///
 /// | Phase          | Allocator local block lists                     | Global abandoned block lists                 | Chunk map |
 /// |----------------|-------------------------------------------------|----------------------------------------------|-----------|
 /// | Allocation     | Alloc from local                                | Move blocks from global to local block lists | -         |

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -87,9 +87,9 @@ impl AbandonedBlockLists {
 
     fn sweep<VM: VMBinding>(&mut self, space: &MarkSweepSpace<VM>) {
         for i in 0..MI_BIN_FULL {
-            self.available[i].sweep_blocks(space);
-            self.consumed[i].sweep_blocks(space);
-            self.unswept[i].sweep_blocks(space);
+            self.available[i].release_and_sweep_blocks(space);
+            self.consumed[i].release_and_sweep_blocks(space);
+            self.unswept[i].release_and_sweep_blocks(space);
 
             // As we have swept blocks, move blocks in the unswept list to available or consumed list.
             while let Some(block) = self.unswept[i].pop() {

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -433,8 +433,8 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
         for bin in 0..MI_BIN_FULL {
             let unswept = self.unswept_blocks.get_mut(bin).unwrap();
 
-            // We should have no unswept blocks here. Blocks should be either in avialable, or consumed.
-            debug_assert!(unswept.is_empty());
+            // If we abandon all the local blocks, we should have no unswept blocks here. Blocks should be either in available, or consumed.
+            debug_assert!(!Self::ABANDON_BLOCKS_IN_RESET || unswept.is_empty());
 
             let mut sweep_later = |list: &mut BlockList| {
                 list.release_blocks(self.space);


### PR DESCRIPTION
This PR refactors mark sweep.
* It removes the data race for accessing block lists, as discussed in https://github.com/mmtk/mmtk-core/issues/1103#issuecomment-2050805848.
* It fixes an issue that block state did not get reset before GC and caused marked blocks to stay alive forever: https://github.com/mmtk/mmtk-core/issues/688#issuecomment-2058193888
* It fixes an issue that empty blocks did not get released for lazy sweeping.