### PR TITLE
Rename associated types in GCWorkContext

### DIFF
--- a/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
@@ -10,8 +10,8 @@ pub struct MyGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MyGC<VM>;
-    type ProcessEdgesWorkType = SFTProcessEdges<Self::VM>;
-    type TPProcessEdges = UnsupportedProcessEdges<Self::VM>;
+    type NormalProcessEdges = SFTProcessEdges<Self::VM>;
+    type PinningProcessEdges = UnsupportedProcessEdges<Self::VM>;
 }
 // ANCHOR_END: workcontext_sft
 
@@ -22,8 +22,8 @@ pub struct MyGCWorkContext2<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext2<VM> {
     type VM = VM;
     type PlanType = MyGC<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<Self::VM, MyGC<VM>, DEFAULT_TRACE>;
-    type TPProcessEdges = UnsupportedProcessEdges<Self::VM>;
+    type NormalProcessEdges = PlanProcessEdges<Self::VM, MyGC<VM>, DEFAULT_TRACE>;
+    type PinningProcessEdges = UnsupportedProcessEdges<Self::VM>;
 }
 // ANCHOR_END: workcontext_plan
 
@@ -104,7 +104,7 @@ pub struct MyGCWorkContext3<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext3<VM> {
     type VM = VM;
     type PlanType = MyGC<VM>;
-    type ProcessEdgesWorkType = MyGCProcessEdges<Self::VM>;
-    type TPProcessEdges = UnsupportedProcessEdges<Self::VM>;
+    type NormalProcessEdges = MyGCProcessEdges<Self::VM>;
+    type PinningProcessEdges = UnsupportedProcessEdges<Self::VM>;
 }
 // ANCHOR: workcontext_mygc

--- a/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
@@ -10,7 +10,7 @@ pub struct MyGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MyGC<VM>;
-    type NormalProcessEdges = SFTProcessEdges<Self::VM>;
+    type DefaultProcessEdges = SFTProcessEdges<Self::VM>;
     type PinningProcessEdges = UnsupportedProcessEdges<Self::VM>;
 }
 // ANCHOR_END: workcontext_sft
@@ -22,7 +22,7 @@ pub struct MyGCWorkContext2<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext2<VM> {
     type VM = VM;
     type PlanType = MyGC<VM>;
-    type NormalProcessEdges = PlanProcessEdges<Self::VM, MyGC<VM>, DEFAULT_TRACE>;
+    type DefaultProcessEdges = PlanProcessEdges<Self::VM, MyGC<VM>, DEFAULT_TRACE>;
     type PinningProcessEdges = UnsupportedProcessEdges<Self::VM>;
 }
 // ANCHOR_END: workcontext_plan
@@ -104,7 +104,7 @@ pub struct MyGCWorkContext3<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MyGCWorkContext3<VM> {
     type VM = VM;
     type PlanType = MyGC<VM>;
-    type NormalProcessEdges = MyGCProcessEdges<Self::VM>;
+    type DefaultProcessEdges = MyGCProcessEdges<Self::VM>;
     type PinningProcessEdges = UnsupportedProcessEdges<Self::VM>;
 }
 // ANCHOR: workcontext_mygc

--- a/docs/userguide/src/tutorial/mygc/ss/collection.md
+++ b/docs/userguide/src/tutorial/mygc/ss/collection.md
@@ -202,7 +202,7 @@ With the derive macro, your `MyGC` struct should look like this:
 {{#include ../../code/mygc_semispace/global.rs:plan_def}}
 ```
 
-Once this is done, you can specify `PlanProcessEdges` as the `NormalProcessEdges` in your GC work context:
+Once this is done, you can specify `PlanProcessEdges` as the `DefaultProcessEdges` in your GC work context:
 ```rust
 {{#include ../../code/mygc_semispace/gc_work.rs:workcontext_plan}}
 ```
@@ -238,7 +238,7 @@ dereferenced as `ProcessEdgesBase`.
 {{#include ../../code/mygc_semispace/gc_work.rs:mygc_process_edges_deref}}
 ```
 
-In the end, use `MyGCProcessEdges` as `NormalProcessEdges` in the `GCWorkContext`:
+In the end, use `MyGCProcessEdges` as `DefaultProcessEdges` in the `GCWorkContext`:
 ```rust
 {{#include ../../code/mygc_semispace/gc_work.rs:workcontext_mygc}}
 ```

--- a/docs/userguide/src/tutorial/mygc/ss/collection.md
+++ b/docs/userguide/src/tutorial/mygc/ss/collection.md
@@ -202,7 +202,7 @@ With the derive macro, your `MyGC` struct should look like this:
 {{#include ../../code/mygc_semispace/global.rs:plan_def}}
 ```
 
-Once this is done, you can specify `PlanProcessEdges` as the `ProcessEdgesWorkType` in your GC work context:
+Once this is done, you can specify `PlanProcessEdges` as the `NormalProcessEdges` in your GC work context:
 ```rust
 {{#include ../../code/mygc_semispace/gc_work.rs:workcontext_plan}}
 ```
@@ -238,7 +238,7 @@ dereferenced as `ProcessEdgesBase`.
 {{#include ../../code/mygc_semispace/gc_work.rs:mygc_process_edges_deref}}
 ```
 
-In the end, use `MyGCProcessEdges` as `ProcessEdgesWorkType` in the `GCWorkContext`:
+In the end, use `MyGCProcessEdges` as `NormalProcessEdges` in the `GCWorkContext`:
 ```rust
 {{#include ../../code/mygc_semispace/gc_work.rs:workcontext_mygc}}
 ```

--- a/src/plan/generational/copying/gc_work.rs
+++ b/src/plan/generational/copying/gc_work.rs
@@ -9,7 +9,7 @@ pub struct GenCopyNurseryGCWorkContext<VM: VMBinding>(std::marker::PhantomData<V
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for GenCopyNurseryGCWorkContext<VM> {
     type VM = VM;
     type PlanType = GenCopy<VM>;
-    type NormalProcessEdges = GenNurseryProcessEdges<Self::VM, Self::PlanType>;
+    type DefaultProcessEdges = GenNurseryProcessEdges<Self::VM, Self::PlanType>;
     type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }
 
@@ -17,6 +17,6 @@ pub struct GenCopyGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for GenCopyGCWorkContext<VM> {
     type VM = VM;
     type PlanType = GenCopy<VM>;
-    type NormalProcessEdges = PlanProcessEdges<Self::VM, GenCopy<VM>, DEFAULT_TRACE>;
+    type DefaultProcessEdges = PlanProcessEdges<Self::VM, GenCopy<VM>, DEFAULT_TRACE>;
     type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/generational/copying/gc_work.rs
+++ b/src/plan/generational/copying/gc_work.rs
@@ -9,14 +9,14 @@ pub struct GenCopyNurseryGCWorkContext<VM: VMBinding>(std::marker::PhantomData<V
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for GenCopyNurseryGCWorkContext<VM> {
     type VM = VM;
     type PlanType = GenCopy<VM>;
-    type ProcessEdgesWorkType = GenNurseryProcessEdges<Self::VM, Self::PlanType>;
-    type TPProcessEdges = UnsupportedProcessEdges<VM>;
+    type NormalProcessEdges = GenNurseryProcessEdges<Self::VM, Self::PlanType>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }
 
 pub struct GenCopyGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for GenCopyGCWorkContext<VM> {
     type VM = VM;
     type PlanType = GenCopy<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<Self::VM, GenCopy<VM>, DEFAULT_TRACE>;
-    type TPProcessEdges = UnsupportedProcessEdges<VM>;
+    type NormalProcessEdges = PlanProcessEdges<Self::VM, GenCopy<VM>, DEFAULT_TRACE>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/generational/immix/gc_work.rs
+++ b/src/plan/generational/immix/gc_work.rs
@@ -9,7 +9,7 @@ pub struct GenImmixNurseryGCWorkContext<VM: VMBinding>(std::marker::PhantomData<
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for GenImmixNurseryGCWorkContext<VM> {
     type VM = VM;
     type PlanType = GenImmix<VM>;
-    type NormalProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
+    type DefaultProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
     type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }
 
@@ -21,6 +21,6 @@ impl<VM: VMBinding, const KIND: TraceKind> crate::scheduler::GCWorkContext
 {
     type VM = VM;
     type PlanType = GenImmix<VM>;
-    type NormalProcessEdges = PlanProcessEdges<VM, GenImmix<VM>, KIND>;
+    type DefaultProcessEdges = PlanProcessEdges<VM, GenImmix<VM>, KIND>;
     type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/generational/immix/gc_work.rs
+++ b/src/plan/generational/immix/gc_work.rs
@@ -9,8 +9,8 @@ pub struct GenImmixNurseryGCWorkContext<VM: VMBinding>(std::marker::PhantomData<
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for GenImmixNurseryGCWorkContext<VM> {
     type VM = VM;
     type PlanType = GenImmix<VM>;
-    type ProcessEdgesWorkType = GenNurseryProcessEdges<VM, Self::PlanType>;
-    type TPProcessEdges = UnsupportedProcessEdges<VM>;
+    type NormalProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }
 
 pub(super) struct GenImmixMatureGCWorkContext<VM: VMBinding, const KIND: TraceKind>(
@@ -21,6 +21,6 @@ impl<VM: VMBinding, const KIND: TraceKind> crate::scheduler::GCWorkContext
 {
     type VM = VM;
     type PlanType = GenImmix<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<VM, GenImmix<VM>, KIND>;
-    type TPProcessEdges = UnsupportedProcessEdges<VM>;
+    type NormalProcessEdges = PlanProcessEdges<VM, GenImmix<VM>, KIND>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/immix/gc_work.rs
+++ b/src/plan/immix/gc_work.rs
@@ -12,6 +12,6 @@ impl<VM: VMBinding, const KIND: TraceKind> crate::scheduler::GCWorkContext
 {
     type VM = VM;
     type PlanType = Immix<VM>;
-    type NormalProcessEdges = PlanProcessEdges<VM, Immix<VM>, KIND>;
+    type DefaultProcessEdges = PlanProcessEdges<VM, Immix<VM>, KIND>;
     type PinningProcessEdges = PlanProcessEdges<VM, Immix<VM>, TRACE_KIND_TRANSITIVE_PIN>;
 }

--- a/src/plan/immix/gc_work.rs
+++ b/src/plan/immix/gc_work.rs
@@ -12,6 +12,6 @@ impl<VM: VMBinding, const KIND: TraceKind> crate::scheduler::GCWorkContext
 {
     type VM = VM;
     type PlanType = Immix<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<VM, Immix<VM>, KIND>;
-    type TPProcessEdges = PlanProcessEdges<VM, Immix<VM>, TRACE_KIND_TRANSITIVE_PIN>;
+    type NormalProcessEdges = PlanProcessEdges<VM, Immix<VM>, KIND>;
+    type PinningProcessEdges = PlanProcessEdges<VM, Immix<VM>, TRACE_KIND_TRANSITIVE_PIN>;
 }

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -102,7 +102,7 @@ pub struct MarkCompactGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>)
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MarkCompactGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MarkCompact<VM>;
-    type NormalProcessEdges = MarkingProcessEdges<VM>;
+    type DefaultProcessEdges = MarkingProcessEdges<VM>;
     type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }
 
@@ -110,6 +110,6 @@ pub struct MarkCompactForwardingGCWorkContext<VM: VMBinding>(std::marker::Phanto
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MarkCompactForwardingGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MarkCompact<VM>;
-    type NormalProcessEdges = ForwardingProcessEdges<VM>;
+    type DefaultProcessEdges = ForwardingProcessEdges<VM>;
     type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -102,14 +102,14 @@ pub struct MarkCompactGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>)
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MarkCompactGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MarkCompact<VM>;
-    type ProcessEdgesWorkType = MarkingProcessEdges<VM>;
-    type TPProcessEdges = UnsupportedProcessEdges<VM>;
+    type NormalProcessEdges = MarkingProcessEdges<VM>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }
 
 pub struct MarkCompactForwardingGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MarkCompactForwardingGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MarkCompact<VM>;
-    type ProcessEdgesWorkType = ForwardingProcessEdges<VM>;
-    type TPProcessEdges = UnsupportedProcessEdges<VM>;
+    type NormalProcessEdges = ForwardingProcessEdges<VM>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/marksweep/gc_work.rs
+++ b/src/plan/marksweep/gc_work.rs
@@ -7,6 +7,6 @@ pub struct MSGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MSGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MarkSweep<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<Self::VM, MarkSweep<VM>, DEFAULT_TRACE>;
-    type TPProcessEdges = PlanProcessEdges<Self::VM, MarkSweep<VM>, DEFAULT_TRACE>;
+    type NormalProcessEdges = PlanProcessEdges<Self::VM, MarkSweep<VM>, DEFAULT_TRACE>;
+    type PinningProcessEdges = PlanProcessEdges<Self::VM, MarkSweep<VM>, DEFAULT_TRACE>;
 }

--- a/src/plan/marksweep/gc_work.rs
+++ b/src/plan/marksweep/gc_work.rs
@@ -7,6 +7,6 @@ pub struct MSGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for MSGCWorkContext<VM> {
     type VM = VM;
     type PlanType = MarkSweep<VM>;
-    type NormalProcessEdges = PlanProcessEdges<Self::VM, MarkSweep<VM>, DEFAULT_TRACE>;
+    type DefaultProcessEdges = PlanProcessEdges<Self::VM, MarkSweep<VM>, DEFAULT_TRACE>;
     type PinningProcessEdges = PlanProcessEdges<Self::VM, MarkSweep<VM>, DEFAULT_TRACE>;
 }

--- a/src/plan/pageprotect/gc_work.rs
+++ b/src/plan/pageprotect/gc_work.rs
@@ -7,6 +7,6 @@ pub struct PPGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for PPGCWorkContext<VM> {
     type VM = VM;
     type PlanType = PageProtect<VM>;
-    type NormalProcessEdges = PlanProcessEdges<Self::VM, PageProtect<VM>, DEFAULT_TRACE>;
+    type DefaultProcessEdges = PlanProcessEdges<Self::VM, PageProtect<VM>, DEFAULT_TRACE>;
     type PinningProcessEdges = PlanProcessEdges<Self::VM, PageProtect<VM>, DEFAULT_TRACE>;
 }

--- a/src/plan/pageprotect/gc_work.rs
+++ b/src/plan/pageprotect/gc_work.rs
@@ -7,6 +7,6 @@ pub struct PPGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for PPGCWorkContext<VM> {
     type VM = VM;
     type PlanType = PageProtect<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<Self::VM, PageProtect<VM>, DEFAULT_TRACE>;
-    type TPProcessEdges = PlanProcessEdges<Self::VM, PageProtect<VM>, DEFAULT_TRACE>;
+    type NormalProcessEdges = PlanProcessEdges<Self::VM, PageProtect<VM>, DEFAULT_TRACE>;
+    type PinningProcessEdges = PlanProcessEdges<Self::VM, PageProtect<VM>, DEFAULT_TRACE>;
 }

--- a/src/plan/semispace/gc_work.rs
+++ b/src/plan/semispace/gc_work.rs
@@ -7,6 +7,6 @@ pub struct SSGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for SSGCWorkContext<VM> {
     type VM = VM;
     type PlanType = SemiSpace<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<Self::VM, SemiSpace<VM>, DEFAULT_TRACE>;
-    type TPProcessEdges = UnsupportedProcessEdges<VM>;
+    type NormalProcessEdges = PlanProcessEdges<Self::VM, SemiSpace<VM>, DEFAULT_TRACE>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/semispace/gc_work.rs
+++ b/src/plan/semispace/gc_work.rs
@@ -7,6 +7,6 @@ pub struct SSGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for SSGCWorkContext<VM> {
     type VM = VM;
     type PlanType = SemiSpace<VM>;
-    type NormalProcessEdges = PlanProcessEdges<Self::VM, SemiSpace<VM>, DEFAULT_TRACE>;
+    type DefaultProcessEdges = PlanProcessEdges<Self::VM, SemiSpace<VM>, DEFAULT_TRACE>;
     type PinningProcessEdges = UnsupportedProcessEdges<VM>;
 }

--- a/src/plan/sticky/immix/gc_work.rs
+++ b/src/plan/sticky/immix/gc_work.rs
@@ -9,7 +9,7 @@ pub struct StickyImmixNurseryGCWorkContext<VM: VMBinding>(std::marker::PhantomDa
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for StickyImmixNurseryGCWorkContext<VM> {
     type VM = VM;
     type PlanType = StickyImmix<VM>;
-    type NormalProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
+    type DefaultProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
     type PinningProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
 }
 
@@ -21,6 +21,6 @@ impl<VM: VMBinding, const KIND: TraceKind> crate::scheduler::GCWorkContext
 {
     type VM = VM;
     type PlanType = StickyImmix<VM>;
-    type NormalProcessEdges = PlanProcessEdges<VM, Self::PlanType, KIND>;
+    type DefaultProcessEdges = PlanProcessEdges<VM, Self::PlanType, KIND>;
     type PinningProcessEdges = PlanProcessEdges<VM, Self::PlanType, TRACE_KIND_TRANSITIVE_PIN>;
 }

--- a/src/plan/sticky/immix/gc_work.rs
+++ b/src/plan/sticky/immix/gc_work.rs
@@ -9,8 +9,8 @@ pub struct StickyImmixNurseryGCWorkContext<VM: VMBinding>(std::marker::PhantomDa
 impl<VM: VMBinding> crate::scheduler::GCWorkContext for StickyImmixNurseryGCWorkContext<VM> {
     type VM = VM;
     type PlanType = StickyImmix<VM>;
-    type ProcessEdgesWorkType = GenNurseryProcessEdges<VM, Self::PlanType>;
-    type TPProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
+    type NormalProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
+    type PinningProcessEdges = GenNurseryProcessEdges<VM, Self::PlanType>;
 }
 
 pub struct StickyImmixMatureGCWorkContext<VM: VMBinding, const KIND: TraceKind>(
@@ -21,6 +21,6 @@ impl<VM: VMBinding, const KIND: TraceKind> crate::scheduler::GCWorkContext
 {
     type VM = VM;
     type PlanType = StickyImmix<VM>;
-    type ProcessEdgesWorkType = PlanProcessEdges<VM, Self::PlanType, KIND>;
-    type TPProcessEdges = PlanProcessEdges<VM, Self::PlanType, TRACE_KIND_TRANSITIVE_PIN>;
+    type NormalProcessEdges = PlanProcessEdges<VM, Self::PlanType, KIND>;
+    type PinningProcessEdges = PlanProcessEdges<VM, Self::PlanType, TRACE_KIND_TRANSITIVE_PIN>;
 }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -401,8 +401,8 @@ impl<C: GCWorkContext> GCWork<C::VM> for ScanMutatorRoots<C> {
         let mutators = <C::VM as VMBinding>::VMActivePlan::number_of_mutators();
         let factory = ProcessEdgesWorkRootsWorkFactory::<
             C::VM,
-            C::ProcessEdgesWorkType,
-            C::TPProcessEdges,
+            C::NormalProcessEdges,
+            C::PinningProcessEdges,
         >::new(mmtk);
         <C::VM as VMBinding>::VMScanning::scan_roots_in_mutator_thread(
             worker.tls,
@@ -434,8 +434,8 @@ impl<C: GCWorkContext> GCWork<C::VM> for ScanVMSpecificRoots<C> {
         trace!("ScanStaticRoots");
         let factory = ProcessEdgesWorkRootsWorkFactory::<
             C::VM,
-            C::ProcessEdgesWorkType,
-            C::TPProcessEdges,
+            C::NormalProcessEdges,
+            C::PinningProcessEdges,
         >::new(mmtk);
         <C::VM as VMBinding>::VMScanning::scan_vm_specific_roots(worker.tls, factory);
     }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -684,8 +684,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SFTProcessEdges<VM> {
 
 /// An implementation of `RootsWorkFactory` that creates work packets based on `ProcessEdgesWork`
 /// for handling roots.  The `DPE` and the `PPE` type parameters correspond to the
-/// `DefaultProcessEdge` and the `PinningProcessEdges` type members of the
-/// [`GCWorkContext`](crate::scheduler::work::GCWorkContext) trait.
+/// `DefaultProcessEdge` and the `PinningProcessEdges` type members of the [`GCWorkContext`] trait.
 pub(crate) struct ProcessEdgesWorkRootsWorkFactory<
     VM: VMBinding,
     DPE: ProcessEdgesWork<VM = VM>,

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -171,16 +171,16 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                 PhantomRefProcessing, SoftRefProcessing, WeakRefProcessing,
             };
             self.work_buckets[WorkBucketStage::SoftRefClosure]
-                .add(SoftRefProcessing::<C::NormalProcessEdges>::new());
+                .add(SoftRefProcessing::<C::DefaultProcessEdges>::new());
             self.work_buckets[WorkBucketStage::WeakRefClosure]
-                .add(WeakRefProcessing::<C::NormalProcessEdges>::new());
+                .add(WeakRefProcessing::<C::DefaultProcessEdges>::new());
             self.work_buckets[WorkBucketStage::PhantomRefClosure]
-                .add(PhantomRefProcessing::<C::NormalProcessEdges>::new());
+                .add(PhantomRefProcessing::<C::DefaultProcessEdges>::new());
 
             use crate::util::reference_processor::RefForwarding;
             if plan.constraints().needs_forward_after_liveness {
                 self.work_buckets[WorkBucketStage::RefForwarding]
-                    .add(RefForwarding::<C::NormalProcessEdges>::new());
+                    .add(RefForwarding::<C::DefaultProcessEdges>::new());
             }
 
             use crate::util::reference_processor::RefEnqueue;
@@ -192,11 +192,11 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             use crate::util::finalizable_processor::{Finalization, ForwardFinalization};
             // finalization
             self.work_buckets[WorkBucketStage::FinalRefClosure]
-                .add(Finalization::<C::NormalProcessEdges>::new());
+                .add(Finalization::<C::DefaultProcessEdges>::new());
             // forward refs
             if plan.constraints().needs_forward_after_liveness {
                 self.work_buckets[WorkBucketStage::FinalizableForwarding]
-                    .add(ForwardFinalization::<C::NormalProcessEdges>::new());
+                    .add(ForwardFinalization::<C::DefaultProcessEdges>::new());
             }
         }
 
@@ -222,12 +222,12 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         // because there are no other packets in the bucket.  We set it as sentinel for
         // consistency.
         self.work_buckets[WorkBucketStage::VMRefClosure]
-            .set_sentinel(Box::new(VMProcessWeakRefs::<C::NormalProcessEdges>::new()));
+            .set_sentinel(Box::new(VMProcessWeakRefs::<C::DefaultProcessEdges>::new()));
 
         if plan.constraints().needs_forward_after_liveness {
             // VM-specific weak ref forwarding
             self.work_buckets[WorkBucketStage::VMRefForwarding]
-                .add(VMForwardWeakRefs::<C::NormalProcessEdges>::new());
+                .add(VMForwardWeakRefs::<C::DefaultProcessEdges>::new());
         }
 
         self.work_buckets[WorkBucketStage::Release].add(VMPostForwarding::<VM>::default());

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -171,16 +171,16 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                 PhantomRefProcessing, SoftRefProcessing, WeakRefProcessing,
             };
             self.work_buckets[WorkBucketStage::SoftRefClosure]
-                .add(SoftRefProcessing::<C::ProcessEdgesWorkType>::new());
+                .add(SoftRefProcessing::<C::NormalProcessEdges>::new());
             self.work_buckets[WorkBucketStage::WeakRefClosure]
-                .add(WeakRefProcessing::<C::ProcessEdgesWorkType>::new());
+                .add(WeakRefProcessing::<C::NormalProcessEdges>::new());
             self.work_buckets[WorkBucketStage::PhantomRefClosure]
-                .add(PhantomRefProcessing::<C::ProcessEdgesWorkType>::new());
+                .add(PhantomRefProcessing::<C::NormalProcessEdges>::new());
 
             use crate::util::reference_processor::RefForwarding;
             if plan.constraints().needs_forward_after_liveness {
                 self.work_buckets[WorkBucketStage::RefForwarding]
-                    .add(RefForwarding::<C::ProcessEdgesWorkType>::new());
+                    .add(RefForwarding::<C::NormalProcessEdges>::new());
             }
 
             use crate::util::reference_processor::RefEnqueue;
@@ -192,11 +192,11 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             use crate::util::finalizable_processor::{Finalization, ForwardFinalization};
             // finalization
             self.work_buckets[WorkBucketStage::FinalRefClosure]
-                .add(Finalization::<C::ProcessEdgesWorkType>::new());
+                .add(Finalization::<C::NormalProcessEdges>::new());
             // forward refs
             if plan.constraints().needs_forward_after_liveness {
                 self.work_buckets[WorkBucketStage::FinalizableForwarding]
-                    .add(ForwardFinalization::<C::ProcessEdgesWorkType>::new());
+                    .add(ForwardFinalization::<C::NormalProcessEdges>::new());
             }
         }
 
@@ -222,12 +222,12 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         // because there are no other packets in the bucket.  We set it as sentinel for
         // consistency.
         self.work_buckets[WorkBucketStage::VMRefClosure]
-            .set_sentinel(Box::new(VMProcessWeakRefs::<C::ProcessEdgesWorkType>::new()));
+            .set_sentinel(Box::new(VMProcessWeakRefs::<C::NormalProcessEdges>::new()));
 
         if plan.constraints().needs_forward_after_liveness {
             // VM-specific weak ref forwarding
             self.work_buckets[WorkBucketStage::VMRefForwarding]
-                .add(VMForwardWeakRefs::<C::ProcessEdgesWorkType>::new());
+                .add(VMForwardWeakRefs::<C::NormalProcessEdges>::new());
         }
 
         self.work_buckets[WorkBucketStage::Release].add(VMPostForwarding::<VM>::default());

--- a/src/scheduler/work.rs
+++ b/src/scheduler/work.rs
@@ -74,8 +74,28 @@ use crate::plan::Plan;
 pub trait GCWorkContext: Send + 'static {
     type VM: VMBinding;
     type PlanType: Plan<VM = Self::VM>;
-    // We should use SFTProcessEdges as the default value for this associate type. However, this requires
+
+    // FIXME: We should use `SFTProcessEdges` as the default value for `NormalProcessEdges`, and
+    // `UnsupportedProcessEdges` for `PinningProcessEdges`.  However, this requires
     // `associated_type_defaults` which has not yet been stablized.
-    type ProcessEdgesWorkType: ProcessEdgesWork<VM = Self::VM>;
-    type TPProcessEdges: ProcessEdgesWork<VM = Self::VM>;
+    // See: https://github.com/rust-lang/rust/issues/29661
+
+    /// The `ProcessEdgesWork` implementation to use for tracing edges that do not have special
+    /// pinning requirements.  Concrete plans and spaces may choose to move or not to move the
+    /// objects the traced edges point to.
+    type NormalProcessEdges: ProcessEdgesWork<VM = Self::VM>;
+
+    /// The `ProcessEdgesWork` implementation to use for trcing edges that must not be updated
+    /// (i.e. the objects the traced edges pointed to must not be moved).  This is used for
+    /// implementing pinning roots and transitive pinning roots.
+    ///
+    /// -   For non-transitive pinning roots, `PinningProcessEdges` will be used to trace the edges
+    ///     from roots to objects, but their descendents will be traced using `NormalProcessEdges`.
+    /// -   For transitive pinning roots, `PinningProcessEdges` will be used to trace the edges
+    ///     from roots to objects, and the outgoing edges of all objects reachable from transitive
+    ///     pinning roots.
+    ///
+    /// If a plan does not support object pinning, it should use `UnsupportedProcessEdges` for this
+    /// type member.
+    type PinningProcessEdges: ProcessEdgesWork<VM = Self::VM>;
 }

--- a/src/scheduler/work.rs
+++ b/src/scheduler/work.rs
@@ -75,7 +75,7 @@ pub trait GCWorkContext: Send + 'static {
     type VM: VMBinding;
     type PlanType: Plan<VM = Self::VM>;
 
-    // FIXME: We should use `SFTProcessEdges` as the default value for `NormalProcessEdges`, and
+    // FIXME: We should use `SFTProcessEdges` as the default value for `DefaultProcessEdges`, and
     // `UnsupportedProcessEdges` for `PinningProcessEdges`.  However, this requires
     // `associated_type_defaults` which has not yet been stablized.
     // See: https://github.com/rust-lang/rust/issues/29661
@@ -83,17 +83,17 @@ pub trait GCWorkContext: Send + 'static {
     /// The `ProcessEdgesWork` implementation to use for tracing edges that do not have special
     /// pinning requirements.  Concrete plans and spaces may choose to move or not to move the
     /// objects the traced edges point to.
-    type NormalProcessEdges: ProcessEdgesWork<VM = Self::VM>;
+    type DefaultProcessEdges: ProcessEdgesWork<VM = Self::VM>;
 
-    /// The `ProcessEdgesWork` implementation to use for trcing edges that must not be updated
+    /// The `ProcessEdgesWork` implementation to use for tracing edges that must not be updated
     /// (i.e. the objects the traced edges pointed to must not be moved).  This is used for
     /// implementing pinning roots and transitive pinning roots.
     ///
     /// -   For non-transitive pinning roots, `PinningProcessEdges` will be used to trace the edges
-    ///     from roots to objects, but their descendents will be traced using `NormalProcessEdges`.
+    ///     from roots to objects, but their descendents will be traced using `DefaultProcessEdges`.
     /// -   For transitive pinning roots, `PinningProcessEdges` will be used to trace the edges
-    ///     from roots to objects, and the outgoing edges of all objects reachable from transitive
-    ///     pinning roots.
+    ///     from roots to objects, and will also be used to trace the outgoing edges of all objects
+    ///     reachable from transitive pinning roots.
     ///
     /// If a plan does not support object pinning, it should use `UnsupportedProcessEdges` for this
     /// type member.


### PR DESCRIPTION
This PR renames the associated types `ProcessEdgesWorkType` to `DefaultProcessEdges`, and `TPProcessEdges` to `PinningProcessEdges`.

The old name `TPProcessEdges` was very confusing because that type alone is not sufficient to implement transitive pinning roots.  We rename it to `PinningProcessEdges`, removing "transitive" from its name.  We also renamed `ProcessEdgesWorkType` to `DefaultProcessEdges` for symmetry.  We also updated comments to clarify the purposes of those type members.

We also updated the type parameters of `ProcessEdgesWorkRootsWorkFactory<VM, DPE, PPE>` and `ProcessRootNode<VM, R2OPE, O2OPE>` to clarify their purposes, at the expense of being slightly more verbose.
