### PR TITLE
Fix ignores in merge check

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -24,6 +24,7 @@ env:
       "extended-tests-v8",
       "extended-tests-jikesrvm",
       "extended-tests-julia",
+      "extended-tests-openjdk",
       "extended-tests-ruby (release)",
       "extended-tests-ruby (debug)"
     ]

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -20,7 +20,7 @@ jobs:
           # - this action
           # - minimal tests for stable Rust (we allow them to fail)
           # - binding tests (it may take long to run)
-          ignoreActions: "ready-to-merge,check-broken-links-in-docs,check-public-api-changes,minimal-tests-core/x86_64-unknown-linux-gnu/stable,minimal-tests-core/i686-unknown-linux-gnu/stable,minimal-tests-core/x86_64-apple-darwin/stable,v8-binding-test,openjdk-binding-test,jikesrvm-binding-test,julia-binding-test,ruby-binding-test (release),ruby-binding-test (debug)"
+          ignoreActions: "ready-to-merge,check-broken-links-in-docs,check-public-api-changes,minimal-tests-core/x86_64-unknown-linux-gnu/stable,minimal-tests-core/i686-unknown-linux-gnu/stable,minimal-tests-core/x86_64-apple-darwin/stable,extended-test-v8,extended-test-openjdk,extended-test-jikesrvm,extended-test-julia,extended-test-ruby (release),extended-test-ruby (debug)"
           # This action uses API. We have a quota of 1000 per hour.
           checkInterval: 600
         env:

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -21,20 +21,17 @@ env:
       "minimal-tests-core/x86_64-unknown-linux-gnu/stable",
       "minimal-tests-core/i686-unknown-linux-gnu/stable",
       "minimal-tests-core/x86_64-apple-darwin/stable",
-      "extended-test-v8",
-      "extended-test-jikesrvm",
-      "extended-test-julia",
-      "extended-test-ruby (release)",
-      "extended-test-ruby (debug)"
+      "extended-tests-v8",
+      "extended-tests-jikesrvm",
+      "extended-tests-julia",
+      "extended-tests-ruby (release)",
+      "extended-tests-ruby (debug)"
     ]
 
 jobs:
   ready-to-merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Print ignored actions
-        run: |
-          echo "Ignored actions: ${{ join(fromJson(env.IGNORED_ACTIONS)) }}"
       - name: 'Wait for status checks'
         id: waitforstatuschecks
         timeout-minutes: 120

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -7,20 +7,40 @@ on:
     branches:
       - master
 
+env:
+  # Ignore some actions for the merge check:
+  # - This action itself
+  # - Public API check, doc broken link check: we allow them to fail.
+  # - Minimal tests for stable Rust: we allow them to fail.
+  # - Extended binding tests: it may take long to run. We don't want to wait for them.
+  IGNORED_ACTIONS: |
+    [
+      "ready-to-merge",
+      "check-broken-links-in-docs",
+      "check-public-api-changes",
+      "minimal-tests-core/x86_64-unknown-linux-gnu/stable",
+      "minimal-tests-core/i686-unknown-linux-gnu/stable",
+      "minimal-tests-core/x86_64-apple-darwin/stable",
+      "extended-test-v8",
+      "extended-test-jikesrvm",
+      "extended-test-julia",
+      "extended-test-ruby (release)",
+      "extended-test-ruby (debug)"
+    ]
+
 jobs:
   ready-to-merge:
     runs-on: ubuntu-latest
     steps:
+      - name: Print ignored actions
+        run: |
+          echo "Ignored actions: ${{ join(fromJson(env.IGNORED_ACTIONS)) }}"
       - name: 'Wait for status checks'
         id: waitforstatuschecks
         timeout-minutes: 120
         uses: "WyriHaximus/github-action-wait-for-status@v1.8.0"
         with:
-          # Ignore some actions (based on what merge_group triggers):
-          # - this action
-          # - minimal tests for stable Rust (we allow them to fail)
-          # - binding tests (it may take long to run)
-          ignoreActions: "ready-to-merge,check-broken-links-in-docs,check-public-api-changes,minimal-tests-core/x86_64-unknown-linux-gnu/stable,minimal-tests-core/i686-unknown-linux-gnu/stable,minimal-tests-core/x86_64-apple-darwin/stable,extended-test-v8,extended-test-openjdk,extended-test-jikesrvm,extended-test-julia,extended-test-ruby (release),extended-test-ruby (debug)"
+          ignoreActions: "${{ join(fromJson(env.IGNORED_ACTIONS)) }}"
           # This action uses API. We have a quota of 1000 per hour.
           checkInterval: 600
         env:


### PR DESCRIPTION
We renamed CI tests in https://github.com/mmtk/mmtk-core/pull/1073, but forgot to rename them in the ignored list for the merge check. This PR fixes this.