### PR TITLE
Add missing pinning metadata to mock_vm

### DIFF
--- a/src/util/test_util/mock_vm.rs
+++ b/src/util/test_util/mock_vm.rs
@@ -478,6 +478,9 @@ impl crate::vm::ObjectModel<MockVM> for MockVM {
     const LOCAL_LOS_MARK_NURSERY_SPEC: VMLocalLOSMarkNurserySpec =
         VMLocalLOSMarkNurserySpec::in_header(0);
 
+    #[cfg(feature = "object_pinning")]
+    const LOCAL_PINNING_BIT_SPEC: VMLocalPinningBitSpec = VMLocalPinningBitSpec::in_header(0);
+
     const OBJECT_REF_OFFSET_LOWER_BOUND: isize = DEFAULT_OBJECT_REF_OFFSET as isize;
 
     fn copy(


### PR DESCRIPTION
If the "object_pinning" feature is enabled, we add the `LOCAL_PINNING_BIT_SPEC` constant when implementing `ObjectModel` for `MockVM`.  That fixes compilation error if we attempt to run `cargo clippy` with many features including both "mock_test" and "object_pinning", although we currently don't do mock tests for the pinning metadata.