### PR TITLE
Use to_address for SFT access

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -557,8 +557,8 @@ pub fn handle_user_collection_request<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMMut
 ///
 /// Arguments:
 /// * `object`: The object reference to query.
-pub fn is_live_object(object: ObjectReference) -> bool {
-    object.is_live()
+pub fn is_live_object<VM: VMBinding>(object: ObjectReference) -> bool {
+    object.is_live::<VM>()
 }
 
 /// Check if `addr` is the address of an object reference to an MMTk object.

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -650,7 +650,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             );
 
             queue.enqueue(new_object);
-            debug_assert!(new_object.is_live());
+            debug_assert!(new_object.is_live::<VM>());
             self.unlog_object_if_needed(new_object);
             new_object
         }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -546,49 +546,44 @@ impl ObjectReference {
         self.0 == 0
     }
 
-    /// returns the ObjectReference
-    pub fn value(self) -> usize {
-        self.0
-    }
-
     /// Is the object reachable, determined by the policy?
     /// Note: Objects in ImmortalSpace may have `is_live = true` but are actually unreachable.
-    pub fn is_reachable(self) -> bool {
+    pub fn is_reachable<VM: VMBinding>(self) -> bool {
         if self.is_null() {
             false
         } else {
-            unsafe { SFT_MAP.get_unchecked(Address(self.0)) }.is_reachable(self)
+            unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.is_reachable(self)
         }
     }
 
     /// Is the object live, determined by the policy?
-    pub fn is_live(self) -> bool {
+    pub fn is_live<VM: VMBinding>(self) -> bool {
         if self.0 == 0 {
             false
         } else {
-            unsafe { SFT_MAP.get_unchecked(Address(self.0)) }.is_live(self)
+            unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.is_live(self)
         }
     }
 
     /// Can the object be moved?
-    pub fn is_movable(self) -> bool {
-        unsafe { SFT_MAP.get_unchecked(Address(self.0)) }.is_movable()
+    pub fn is_movable<VM: VMBinding>(self) -> bool {
+        unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.is_movable()
     }
 
     /// Get forwarding pointer if the object is forwarded.
-    pub fn get_forwarded_object(self) -> Option<Self> {
-        unsafe { SFT_MAP.get_unchecked(Address(self.0)) }.get_forwarded_object(self)
+    pub fn get_forwarded_object<VM: VMBinding>(self) -> Option<Self> {
+        unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.get_forwarded_object(self)
     }
 
     /// Is the object in any MMTk spaces?
-    pub fn is_in_any_space(self) -> bool {
-        unsafe { SFT_MAP.get_unchecked(Address(self.0)) }.is_in_space(self)
+    pub fn is_in_any_space<VM: VMBinding>(self) -> bool {
+        unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.is_in_space(self)
     }
 
     /// Is the object sane?
     #[cfg(feature = "sanity")]
-    pub fn is_sane(self) -> bool {
-        unsafe { SFT_MAP.get_unchecked(Address(self.0)) }.is_sane()
+    pub fn is_sane<VM: VMBinding>(self) -> bool {
+        unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.is_sane()
     }
 }
 

--- a/src/util/finalizable_processor.rs
+++ b/src/util/finalizable_processor.rs
@@ -53,7 +53,7 @@ impl<F: Finalizable> FinalizableProcessor<F> {
         for mut f in self.candidates.drain(start..).collect::<Vec<F>>() {
             let reff = f.get_reference();
             trace!("Pop {:?} for finalization", reff);
-            if reff.is_live() {
+            if reff.is_live::<E::VM>() {
                 FinalizableProcessor::<F>::forward_finalizable_reference(e, &mut f);
                 trace!("{:?} is live, push {:?} back to candidates", reff, f);
                 self.candidates.push(f);

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -195,7 +195,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SanityGCProcessEdges<VM> {
         let mut sanity_checker = self.mmtk().sanity_checker.lock().unwrap();
         if !sanity_checker.refs.contains(&object) {
             // FIXME steveb consider VM-specific integrity check on reference.
-            assert!(object.is_sane(), "Invalid reference {:?}", object);
+            assert!(object.is_sane::<VM>(), "Invalid reference {:?}", object);
 
             // Let plan check object
             assert!(

--- a/src/util/test_util/mock_vm.rs
+++ b/src/util/test_util/mock_vm.rs
@@ -478,6 +478,9 @@ impl crate::vm::ObjectModel<MockVM> for MockVM {
     const LOCAL_LOS_MARK_NURSERY_SPEC: VMLocalLOSMarkNurserySpec =
         VMLocalLOSMarkNurserySpec::in_header(0);
 
+    #[cfg(feature = "object_pinning")]
+    const LOCAL_PINNING_BIT_SPEC: VMLocalPinningBitSpec = VMLocalPinningBitSpec::in_header(0);
+
     const OBJECT_REF_OFFSET_LOWER_BOUND: isize = DEFAULT_OBJECT_REF_OFFSET as isize;
 
     fn copy(


### PR DESCRIPTION
Changed convenient methods in `ObjectReference` so that if they use SFT, we use `self.to_address()` to get the address instead of `self.0` which returns the raw address.
