### PR TITLE
Ensure reference objects are either traced or cleared

### DIFF
--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -112,9 +112,9 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
             scheduler.work_buckets[WorkBucketStage::SoftRefClosure]
                 .add(SoftRefProcessing::<MarkingProcessEdges<VM>>::new());
             scheduler.work_buckets[WorkBucketStage::WeakRefClosure]
-                .add(WeakRefProcessing::<MarkingProcessEdges<VM>>::new());
+                .add(WeakRefProcessing::<VM>::new());
             scheduler.work_buckets[WorkBucketStage::PhantomRefClosure]
-                .add(PhantomRefProcessing::<MarkingProcessEdges<VM>>::new());
+                .add(PhantomRefProcessing::<VM>::new());
 
             use crate::util::reference_processor::RefForwarding;
             scheduler.work_buckets[WorkBucketStage::RefForwarding]

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -251,7 +251,9 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             queue.enqueue(object);
         }
 
-        Self::get_header_forwarding_pointer(object)
+        let result = Self::get_header_forwarding_pointer(object);
+        assert!(!result.is_null(), "Object {object} does not have a forwarding pointer");
+        result
     }
 
     pub fn test_and_mark(object: ObjectReference) -> bool {

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -173,9 +173,9 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             self.work_buckets[WorkBucketStage::SoftRefClosure]
                 .add(SoftRefProcessing::<C::DefaultProcessEdges>::new());
             self.work_buckets[WorkBucketStage::WeakRefClosure]
-                .add(WeakRefProcessing::<C::DefaultProcessEdges>::new());
+                .add(WeakRefProcessing::<VM>::new());
             self.work_buckets[WorkBucketStage::PhantomRefClosure]
-                .add(PhantomRefProcessing::<C::DefaultProcessEdges>::new());
+                .add(PhantomRefProcessing::<VM>::new());
 
             use crate::util::reference_processor::RefForwarding;
             if plan.constraints().needs_forward_after_liveness {


### PR DESCRIPTION
After retaining soft references, we postpone the scanning of soft references until the transitive closure from retained soft references is fully expanded.  While tracing and scanning new objects reached from the referents of soft references, new soft references may be discovered, and they will be added to the reference processor.  By postponing the scanning, we ensure the newly discovered soft references are scanned, too.

To ensure we do not accidentally enqueue more objects than we should,  we no longer call `trace_object` when *scanning* soft, weak and phantom references.  Instead, we call `ObjectReference::get_forwarded_object` to get the forwarded references and referents.  We still call `trace_object` when *retaining* soft references, and when forwarding references in MarkCompact during the second transitive closure.

Fixes: https://github.com/mmtk/mmtk-core/issues/1125