### PR TITLE
Fix write barrier parameter type

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -232,7 +232,7 @@ pub fn post_alloc<VM: VMBinding>(
 ///
 /// # Deprecated
 ///
-/// This form of write barrier has multiple issues.
+/// This function needs to be redesigned.  Its current form has multiple issues.
 ///
 /// -   It is only able to write non-null object references into the slot.  But dynamic language
 ///     VMs may write non-reference values, such as tagged small integers, special values such as
@@ -243,9 +243,10 @@ pub fn post_alloc<VM: VMBinding>(
 ///     type information, the offset (if it is an interior pointer), etc.  A write barrier is
 ///     associated to an assignment operation, which usually updates such information instead.
 ///
-/// VM bindings should use `object_reference_write_pre` and `object_reference_write_post` instead.
-/// Those functions leaves the actual write of the slot to the VM binding.
-#[deprecated = "Use `object_reference_write_pre` and `object_reference_write_post` instead"]
+/// We will redesign a more general subsuming write barrier to address those problems and replace
+/// the current `object_reference_write`.  Before that happens, VM bindings should use
+/// `object_reference_write_pre` and `object_reference_write_post` instead.
+#[deprecated = "Use `object_reference_write_pre` and `object_reference_write_post` instead, until this function is redesigned"]
 pub fn object_reference_write<VM: VMBinding>(
     mutator: &mut Mutator<VM>,
     src: ObjectReference,

--- a/src/plan/barriers.rs
+++ b/src/plan/barriers.rs
@@ -52,9 +52,9 @@ pub trait Barrier<VM: VMBinding>: 'static + Send + Downcast {
         slot: VM::VMEdge,
         target: ObjectReference,
     ) {
-        self.object_reference_write_pre(src, slot, target);
+        self.object_reference_write_pre(src, slot, Some(target));
         slot.store(target);
-        self.object_reference_write_post(src, slot, target);
+        self.object_reference_write_post(src, slot, Some(target));
     }
 
     /// Full pre-barrier for object reference write
@@ -62,7 +62,7 @@ pub trait Barrier<VM: VMBinding>: 'static + Send + Downcast {
         &mut self,
         _src: ObjectReference,
         _slot: VM::VMEdge,
-        _target: ObjectReference,
+        _target: Option<ObjectReference>,
     ) {
     }
 
@@ -71,7 +71,7 @@ pub trait Barrier<VM: VMBinding>: 'static + Send + Downcast {
         &mut self,
         _src: ObjectReference,
         _slot: VM::VMEdge,
-        _target: ObjectReference,
+        _target: Option<ObjectReference>,
     ) {
     }
 
@@ -81,7 +81,7 @@ pub trait Barrier<VM: VMBinding>: 'static + Send + Downcast {
         &mut self,
         _src: ObjectReference,
         _slot: VM::VMEdge,
-        _target: ObjectReference,
+        _target: Option<ObjectReference>,
     ) {
     }
 
@@ -147,7 +147,7 @@ pub trait BarrierSemantics: 'static + Send {
         &mut self,
         src: ObjectReference,
         slot: <Self::VM as VMBinding>::VMEdge,
-        target: ObjectReference,
+        target: Option<ObjectReference>,
     );
 
     /// Slow-path call for mempry slice copy operations. For example, array-copy operations.
@@ -217,7 +217,7 @@ impl<S: BarrierSemantics> Barrier<S::VM> for ObjectBarrier<S> {
         &mut self,
         src: ObjectReference,
         slot: <S::VM as VMBinding>::VMEdge,
-        target: ObjectReference,
+        target: Option<ObjectReference>,
     ) {
         if self.object_is_unlogged(src) {
             self.object_reference_write_slow(src, slot, target);
@@ -228,7 +228,7 @@ impl<S: BarrierSemantics> Barrier<S::VM> for ObjectBarrier<S> {
         &mut self,
         src: ObjectReference,
         slot: <S::VM as VMBinding>::VMEdge,
-        target: ObjectReference,
+        target: Option<ObjectReference>,
     ) {
         if self.log_object(src) {
             self.semantics

--- a/src/plan/generational/barrier.rs
+++ b/src/plan/generational/barrier.rs
@@ -75,7 +75,7 @@ impl<VM: VMBinding, P: GenerationalPlanExt<VM> + PlanTraceObject<VM>> BarrierSem
         &mut self,
         src: ObjectReference,
         _slot: VM::VMEdge,
-        _target: ObjectReference,
+        _target: Option<ObjectReference>,
     ) {
         // enqueue the object
         self.modbuf.push(src);

--- a/src/vm/tests/mock_tests/mock_test_barrier_slow_path_assertion.rs
+++ b/src/vm/tests/mock_tests/mock_test_barrier_slow_path_assertion.rs
@@ -30,7 +30,7 @@ fn test_assertion_barrier_invalid_ref() {
                 fixture.mutator_mut().barrier.object_reference_write_slow(
                     invalid_objref,
                     edge,
-                    objref,
+                    Some(objref),
                 );
             });
         },
@@ -51,10 +51,11 @@ fn test_assertion_barrier_valid_ref() {
                 let edge = Address::from_ref(&slot);
 
                 // Invoke barrier slowpath with the valid object ref
-                fixture
-                    .mutator_mut()
-                    .barrier
-                    .object_reference_write_slow(objref, edge, objref);
+                fixture.mutator_mut().barrier.object_reference_write_slow(
+                    objref,
+                    edge,
+                    Some(objref),
+                );
             });
         },
         no_cleanup,


### PR DESCRIPTION
Change the target type of write barrier functions to `Option<ObjectReference>`.  This allows VM bindings to use the write barrier API when storing NULL references or non-references values to slots.

Fixes: https://github.com/mmtk/mmtk-core/issues/1129