### PR TITLE
Fix compiler errors and warnings for Rust 1.78.0

### DIFF
--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -361,7 +361,7 @@ mod dense_chunk_map {
 
             let space_name = unsafe { &*space }.name().to_string();
             // We shouldn't have this space in our map yet. Otherwise, this method is called multiple times for the same space.
-            assert!(self.index_map.get(&space_name).is_none());
+            assert!(self.index_map.contains_key(&space_name));
             // Index for the space
             let index = self.sft.len();
             // Insert to hashmap and vec

--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -361,7 +361,7 @@ mod dense_chunk_map {
 
             let space_name = unsafe { &*space }.name().to_string();
             // We shouldn't have this space in our map yet. Otherwise, this method is called multiple times for the same space.
-            assert!(self.index_map.contains_key(&space_name));
+            assert!(!self.index_map.contains_key(&space_name));
             // Index for the space
             let index = self.sft.len();
             // Insert to hashmap and vec

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -763,10 +763,7 @@ pub trait ScanObjectsWork<VM: VMBinding>: GCWork<VM> + Sized {
     /// Called after each object is scanned.
     fn post_scan_object(&self, object: ObjectReference);
 
-    /// Create another object-scanning work packet of the same kind, to scan adjacent objects of
-    /// the objects in this packet.
-    fn make_another(&self, buffer: Vec<ObjectReference>) -> Self;
-
+    /// Return the work bucket for this work packet and its derived work packets.
     fn get_bucket(&self) -> WorkBucketStage;
 
     /// The common code for ScanObjects and PlanScanObjects.
@@ -868,10 +865,6 @@ impl<VM: VMBinding, E: ProcessEdgesWork<VM = VM>> ScanObjectsWork<VM> for ScanOb
 
     fn post_scan_object(&self, _object: ObjectReference) {
         // Do nothing.
-    }
-
-    fn make_another(&self, buffer: Vec<ObjectReference>) -> Self {
-        Self::new(buffer, self.concurrent, self.bucket)
     }
 }
 
@@ -996,10 +989,6 @@ impl<E: ProcessEdgesWork, P: Plan<VM = E::VM> + PlanTraceObject<E::VM>> ScanObje
 
     fn post_scan_object(&self, object: ObjectReference) {
         self.plan.post_scan_object(object);
-    }
-
-    fn make_another(&self, buffer: Vec<ObjectReference>) -> Self {
-        Self::new(self.plan, buffer, self.concurrent, self.bucket)
     }
 }
 

--- a/src/scheduler/work_counter.rs
+++ b/src/scheduler/work_counter.rs
@@ -44,8 +44,6 @@ pub(super) trait WorkCounter: WorkCounterClone + std::fmt::Debug + Send {
     fn name(&self) -> String;
     /// Return a reference to [`WorkCounterBase`]
     fn get_base(&self) -> &WorkCounterBase;
-    /// Return a mutatable reference to [`WorkCounterBase`]
-    fn get_base_mut(&mut self) -> &mut WorkCounterBase;
 }
 
 impl Clone for Box<dyn WorkCounter> {
@@ -128,10 +126,6 @@ impl WorkCounter for WorkDuration {
     fn get_base(&self) -> &WorkCounterBase {
         &self.base
     }
-
-    fn get_base_mut(&mut self) -> &mut WorkCounterBase {
-        &mut self.base
-    }
 }
 
 #[cfg(feature = "perf_counter")]
@@ -206,9 +200,6 @@ mod perf_event {
         }
         fn get_base(&self) -> &WorkCounterBase {
             &self.base
-        }
-        fn get_base_mut(&mut self) -> &mut WorkCounterBase {
-            &mut self.base
         }
     }
 }

--- a/src/util/heap/freelistpageresource.rs
+++ b/src/util/heap/freelistpageresource.rs
@@ -190,7 +190,7 @@ impl<VM: VMBinding> FreeListPageResource<VM> {
             // Since `Space` instances are always stored as global variables, so it is okay here
             // to turn `&CommonFreeListPageResource` into `&'static CommonFreeListPageResource`
             unsafe {
-                vm_map.bind_freelist(&*(&common_flpr as &CommonFreeListPageResource as *const _));
+                vm_map.bind_freelist(common_flpr.as_ref() as *const _);
             }
             common_flpr
         };
@@ -220,7 +220,7 @@ impl<VM: VMBinding> FreeListPageResource<VM> {
             // Since `Space` instances are always stored as global variables, so it is okay here
             // to turn `&CommonFreeListPageResource` into `&'static CommonFreeListPageResource`
             unsafe {
-                vm_map.bind_freelist(&*(&common_flpr as &CommonFreeListPageResource as *const _));
+                vm_map.bind_freelist(common_flpr.as_ref() as *const _);
             }
             common_flpr
         };

--- a/src/vm/tests/mock_tests/mock_test_malloc_counted.rs
+++ b/src/vm/tests/mock_tests/mock_test_malloc_counted.rs
@@ -58,7 +58,7 @@ pub fn realloc_grow() {
             MMTK.with_fixture(|fixture| {
                 let bytes_before = memory_manager::get_malloc_bytes(fixture.get_mmtk());
 
-                let res1 = memory_manager::counted_malloc(&fixture.get_mmtk(), 8);
+                let res1 = memory_manager::counted_malloc(fixture.get_mmtk(), 8);
                 assert!(!res1.is_zero());
                 let bytes_after_alloc = memory_manager::get_malloc_bytes(fixture.get_mmtk());
                 assert_eq!(bytes_before + 8, bytes_after_alloc);
@@ -69,7 +69,7 @@ pub fn realloc_grow() {
                 let bytes_after_realloc = memory_manager::get_malloc_bytes(fixture.get_mmtk());
                 assert_eq!(bytes_before + 16, bytes_after_realloc);
 
-                memory_manager::free_with_size(&fixture.get_mmtk(), res2, 16);
+                memory_manager::free_with_size(fixture.get_mmtk(), res2, 16);
                 let bytes_after_free = memory_manager::get_malloc_bytes(fixture.get_mmtk());
                 assert_eq!(bytes_before, bytes_after_free);
             });

--- a/src/vm/tests/mock_tests/mock_test_mmtk_julia_pr_143.rs
+++ b/src/vm/tests/mock_tests/mock_test_mmtk_julia_pr_143.rs
@@ -5,8 +5,6 @@
 // It tries to set a certain range as VM space. The range does not conflict with the virtual
 // address range we use for spaces. We cannot use SFTSpaceMap as the SFT map implementation.
 
-use lazy_static::lazy_static;
-
 use super::mock_test_prelude::*;
 use crate::memory_manager;
 use crate::util::Address;


### PR DESCRIPTION
`ScanObjectsWork::make_another` is unused.  It was used when `ScanObjectsWork` was used for scanning node roots.  Now that node roots are scanned by the dedicated `ProcessRootNode` work packet, we can remove it.

`WorkCounter::get_base_mut` is never used.  All derived counters use `merge_val` to update all fields at the same time.

We use `Box::as_ref()` to get the reference to its underlying element. It fixes a compilation error related to CommonFreeListPageResource.  But we should eventually remove CommonFreeListPageResource completely as it is a workaround for mimicking the legacy design from JikesRVM that allow VMMap to enumerate and patch existing FreeListPageResource instances by registering them in a global list, which is not idiomatic in Rust.  See https://github.com/mmtk/mmtk-core/pull/934 and https://github.com/mmtk/mmtk-core/pull/953.