### PR TITLE
Fix mark bit clearing in PrepareChunkMap

### DIFF
--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -432,9 +432,7 @@ impl<VM: VMBinding> GCWork<VM> for PrepareChunkMap<VM> {
         } else {
             // Otherwise this chunk is occupied, and we reset the mark bit if it is on the side.
             if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_MARK_BIT_SPEC {
-                for chunk in self.space.chunk_map.all_chunks() {
-                    side.bzero_metadata(chunk.start(), Chunk::BYTES);
-                }
+                side.bzero_metadata(self.chunk.start(), Chunk::BYTES);
             }
         }
     }


### PR DESCRIPTION
Each PrepareChunkMap work packet (used by native MS) should only clear the side mark bits of the single chunk it is responsible for.

Fixes: https://github.com/mmtk/mmtk-core/issues/1144