### PR TITLE
Let MarkSweepSpace use BlockPageResource

### DIFF
--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -4,6 +4,7 @@ use atomic::Ordering;
 
 use super::BlockList;
 use super::MarkSweepSpace;
+use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::heap::chunk_map::*;
 use crate::util::linear_scan::Region;
 use crate::vm::ObjectModel;
@@ -48,6 +49,9 @@ impl Region for Block {
 }
 
 impl Block {
+    /// Log pages in block
+    pub const LOG_PAGES: usize = Self::LOG_BYTES - LOG_BYTES_IN_PAGE as usize;
+
     pub const METADATA_SPECS: [SideMetadataSpec; 7] = [
         Self::MARK_TABLE,
         Self::NEXT_BLOCK_TABLE,

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -359,6 +359,11 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
 
         #[cfg(debug_assertions)]
         from.assert_empty();
+
+        // BlockPageResource uses worker-local block queues to eliminate contention when releasing
+        // blocks, similar to how the MarkSweepSpace caches blocks in `abandoned_in_gc` before
+        // returning to the global pool.  We flush the BlockPageResource, too.
+        self.pr.flush_all();
     }
 
     /// Release a block.

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -530,6 +530,12 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         // Tell GC trigger that GC ended - this happens before we resume mutators.
         mmtk.gc_trigger.policy.on_gc_end(mmtk);
 
+        // All other workers are parked, so it is safe to access the Plan instance mutably.
+        probe!(mmtk, plan_end_of_gc_begin);
+        let plan_mut: &mut dyn Plan<VM = VM> = unsafe { mmtk.get_plan_mut() };
+        plan_mut.end_of_gc(worker.tls);
+        probe!(mmtk, plan_end_of_gc_end);
+
         // Compute the elapsed time of the GC.
         let start_time = {
             let mut gc_start_time = worker.mmtk.state.gc_start_time.borrow_mut();
@@ -564,10 +570,6 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                 mmtk.get_plan().get_used_pages()
             );
         }
-
-        // All other workers are parked, so it is safe to access the Plan instance mutably.
-        let plan_mut: &mut dyn Plan<VM = VM> = unsafe { mmtk.get_plan_mut() };
-        plan_mut.end_of_gc(worker.tls);
 
         #[cfg(feature = "extreme_assertions")]
         if crate::util::slot_logger::should_check_duplicate_slots(mmtk.get_plan()) {

--- a/src/util/heap/freelistpageresource.rs
+++ b/src/util/heap/freelistpageresource.rs
@@ -320,6 +320,14 @@ impl<VM: VMBinding> FreeListPageResource<VM> {
         self.common.release_discontiguous_chunks(chunk);
     }
 
+    /// Release pages previously allocated by `alloc_pages`.
+    ///
+    /// Warning: This method acquires the mutex `self.sync`.  If multiple threads release pages
+    /// concurrently, the lock contention will become a performance bottleneck.  This is especially
+    /// problematic for plans that sweep objects in bulk in the `Release` stage.  Spaces except the
+    /// large object space are recommended to use [`BlockPageResource`] whenever possible.
+    ///
+    /// [`BlockPageResource`]: crate::util::heap::blockpageresource::BlockPageResource
     pub fn release_pages(&self, first: Address) {
         debug_assert!(conversions::is_page_aligned(first));
         let mut sync = self.sync.lock().unwrap();

--- a/tools/tracing/README.md
+++ b/tools/tracing/README.md
@@ -38,6 +38,8 @@ Currently, the core provides the following tracepoints.
     argument is the length of the string.
 -   `mmtk:alloc_slow_once_start()`: the allocation slow path starts.
 -   `mmtk:alloc_slow_once_end()`: the allocation slow path ends.
+-   `mmtk:plan_end_of_gc_begin()`: before executing `Plan::end_of_gc`.
+-   `mmtk:plan_end_of_gc_end()`: after executing `Plan::end_of_gc`.
 
 ## Tracing tools
 

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -79,4 +79,16 @@ usdt:$MMTK:mmtk:process_slots {
     }
 }
 
+usdt:$MMTK:mmtk:plan_end_of_gc_begin {
+    if (@enable_print) {
+        printf("plan_end_of_gc,B,%d,%lu\n", tid, nsecs);
+    }
+}
+
+usdt:$MMTK:mmtk:plan_end_of_gc_end {
+    if (@enable_print) {
+        printf("plan_end_of_gc,E,%d,%lu\n", tid, nsecs);
+    }
+}
+
 // vim: ft=bpftrace ts=4 sw=4 sts=4 et


### PR DESCRIPTION
Let `MarkSweepSpace` use the `BlockPageResource` instead of the raw `FreeListPageResource`.  This solves a problem where multiple GC workers contend for the mutex `FreeListPageResource::sync` when calling `FreeListPageResource::release_pages` concurrently during the `Release` stage.

We flush the `BlockPageResource` in `MarkSweepSpace::end_of_gc`.  To monitor the performance, we added a pair of USDT trace points before and after calling `Plan.end_of_gc`.  We also count the invocation of `end_of_gc` into the GC time.

We changed `BlockQueue` so that it uses `MaybeUninit` to hold uninitialized elements instead of relying on `B::from_aligned_address(Address::ZERO)` because the `Block` type used by `MarkSweepSpace` is based on `NonZeroUsize`, and cannot be zero.

Fixes: https://github.com/mmtk/mmtk-core/issues/1145