### PR TITLE
Add a simple implementation for find_object_from_internal_pointer

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -658,10 +658,6 @@ pub fn find_object_from_internal_pointer<VM: VMBinding>(
     internal_ptr: Address,
     max_search_bytes: usize,
 ) -> Option<(Address, Address)> {
-    if !is_mapped_address(internal_ptr) {
-        return None;
-    }
-
     crate::util::metadata::vo_bit::search_vo_bit_before_addr::<VM>(internal_ptr, max_search_bytes)
 }
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -631,33 +631,38 @@ pub fn is_mmtk_object(addr: Address) -> bool {
 }
 
 /// Find if there is an object with VO bit set for the given address range.
-/// This is used instead of [`is_mmtk_object`] for conservative stack scanning if
+/// This should be used instead of [`crate::memory_manager::is_mmtk_object`] for conservative stack scanning if
 /// the binding may have internal pointers on the stack.
 ///
 /// The function cannot directly return an object reference. Instead, it returns
-/// an address that is aligned to [`crate::util::is_mmtk_object::VO_BIT_REGION_SIZE`],
-/// and guarantees there is an object in `[return_address, return_address + VO_BIT_REGION_SIZE)`.
+/// an address range and guarantees the object ference is in the range.
 /// The reason behind this is that we use the VO
-/// bit to represent a valid object for every 8 bytes. When we find a set VO bit,
-/// we only know that in the 8 bytes there is an object, and we cannot know where
+/// bit to represent a valid object for every 8 bytes ([`crate::util::is_mmtk_object::VO_BIT_REGION_SIZE`]).
+/// We use VO bits to find the object for an internal pointer.
+/// When we find a set VO bit, we only know that in the 8 bytes there is an object, and we cannot know where
 /// exactly the object is. The binding needs to use their knowledge about the alignment
-/// and offset for object reference to find out the object reference from the return value.
+/// and offset for object references to find out the object reference from the return value.
 /// See Case 2 in [`crate::memory_manager::is_mmtk_object`] for more explanation.
+///
+/// Note that, in the similar situation as [`crate::memory_manager::is_mmtk_object`], the binding should filter
+/// out obvious non-pointers (e.g. alignment check, bound check, etc) before calling this function.
+/// This method is costly.
+///
+/// To minimize the cost, the user should also use a small `max_search_bytes`.
 ///
 /// Argument:
 /// * `internal_ptr`: The internal pointer to start. We search backwards from this internal pointer to find the base reference.
-/// * `object_max_bytes`: The maximum of the possible object size. We will search for this many before deciding there is no object.
-///   The binding should keep this value low for better performance.
+/// * `max_search_bytes`: The maximum number of bytes we may search for an object with VO bit set.
 #[cfg(feature = "is_mmtk_object")]
 pub fn find_object_from_internal_pointer<VM: VMBinding>(
     internal_ptr: Address,
-    object_max_bytes: usize,
-) -> Option<Address> {
+    max_search_bytes: usize,
+) -> Option<(Address, Address)> {
     if !is_mapped_address(internal_ptr) {
         return None;
     }
 
-    crate::util::metadata::vo_bit::search_vo_bit_before_addr::<VM>(internal_ptr, object_max_bytes)
+    crate::util::metadata::vo_bit::search_vo_bit_before_addr::<VM>(internal_ptr, max_search_bytes)
 }
 
 /// Return true if the `object` lies in a region of memory where

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -75,7 +75,7 @@ impl<VM: VMBinding> SFT for CopySpace<VM> {
 
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
 
     fn sft_trace_object(

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -142,7 +142,7 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
     fn sft_trace_object(
         &self,

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -65,7 +65,7 @@ impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
     fn sft_trace_object(
         &self,

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -84,7 +84,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
     fn sft_trace_object(
         &self,

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -75,7 +75,7 @@ impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
     fn sft_trace_object(
         &self,

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -76,7 +76,7 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
 
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
 
     fn sft_trace_object(

--- a/src/policy/marksweepspace/malloc_ms/metadata.rs
+++ b/src/policy/marksweepspace/malloc_ms/metadata.rs
@@ -167,7 +167,12 @@ pub fn has_object_alloced_by_malloc<VM: VMBinding>(addr: Address) -> Option<Obje
     if !is_meta_space_mapped_for_address(addr) {
         return None;
     }
-    vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+    if vo_bit::is_vo_bit_set_for_addr::<VM>(addr) {
+        // Safety: addr has vo bit set, it cannot be null.
+        Some(unsafe { ObjectReference::from_raw_address_unchecked(addr) })
+    } else {
+        None
+    }
 }
 
 pub fn is_marked<VM: VMBinding>(object: ObjectReference, ordering: Ordering) -> bool {

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -185,7 +185,7 @@ impl<VM: VMBinding> SFT for MarkSweepSpace<VM> {
 
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
 
     fn sft_trace_object(

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -65,7 +65,7 @@ impl<VM: VMBinding> SFT for VMSpace<VM> {
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> bool {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr).is_some()
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
     }
     fn sft_trace_object(
         &self,

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -49,7 +49,9 @@ impl<VM: VMBinding, S: LinearScanObjectSize, const ATOMIC_LOAD_VO_BIT: bool> std
                 unsafe { vo_bit::is_vo_bit_set_unsafe::<VM>(self.cursor) }
             };
 
-            if let Some(object) = is_object {
+            if is_object {
+                // Safety: addr has vo bit set, it cannot be null.
+                let object = unsafe { ObjectReference::from_raw_address_unchecked(self.cursor) };
                 self.cursor += S::size(object);
                 return Some(object);
             } else {

--- a/src/util/metadata/vo_bit/mod.rs
+++ b/src/util/metadata/vo_bit/mod.rs
@@ -164,6 +164,10 @@ pub fn search_vo_bit_before_addr<VM: VMBinding>(
     // Search from start, searching backwrads
     let mut cur = start;
     while cur > start.saturating_sub(max_search_bytes) {
+        // If the address is not mapped, we don't need to search further.
+        if !cur.is_mapped() {
+            return None;
+        }
         // Check if vo bit is set for addr
         if is_vo_bit_set_for_addr::<VM>(cur) {
             // This is the actual address we checked its vo bit.

--- a/src/util/test_util/fixtures.rs
+++ b/src/util/test_util/fixtures.rs
@@ -217,6 +217,7 @@ unsafe impl Send for MutatorFixture {}
 
 pub struct SingleObject {
     pub objref: ObjectReference,
+    pub objsize: usize,
     mutator: MutatorFixture,
 }
 
@@ -235,7 +236,11 @@ impl FixtureContent for SingleObject {
         let objref = MockVM::address_to_ref(addr);
         memory_manager::post_alloc(&mut mutator.mutator, objref, size, semantics);
 
-        SingleObject { objref, mutator }
+        SingleObject {
+            objref,
+            objsize: size,
+            mutator,
+        }
     }
 }
 

--- a/src/vm/tests/mock_tests/mock_test_conservatism.rs
+++ b/src/vm/tests/mock_tests/mock_test_conservatism.rs
@@ -282,26 +282,7 @@ pub fn internal_pointer_unmapped_memory() {
                 let start = objref.to_raw_address().align_down(VO_BIT_REGION_SIZE);
                 let res = memory_manager::find_object_from_internal_pointer::<MockVM>(
                     start - 8,
-                    fixture.objsize,
-                );
-                assert!(res.is_none());
-            })
-        },
-        no_cleanup,
-    )
-}
-
-#[test]
-pub fn internal_pointer_search_usize_max() {
-    with_mockvm(
-        default_setup,
-        || {
-            SINGLE_OBJECT.with_fixture(|fixture| {
-                let objref = fixture.objref;
-                let start = objref.to_raw_address().align_down(VO_BIT_REGION_SIZE);
-                let res = memory_manager::find_object_from_internal_pointer::<MockVM>(
-                    start - 8,
-                    fixture.objsize,
+                    usize::MAX,
                 );
                 assert!(res.is_none());
             })


### PR DESCRIPTION
This PR adds a function to our API `find_object_from_internal_pointer`. It uses a simple implementation with `is_vo_bit_set_for_addr` which is not efficient. 

An efficient implementation should be able to bulk load side metadata, check the last bit set and deduce the data address from the bit. However, there are many corner cases for this that I haven't sorted out, and it would need more testing before we can make it ready. I think it might be a good idea to have the API first with a naive implementation which works. We can optimize it later.