### PR TITLE
Add SweepChunk to native MarkSweepSpace

### DIFF
--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -65,10 +65,6 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.release(tls, true);
     }
 
-    fn end_of_gc(&mut self, _tls: VMWorkerThread) {
-        self.ms.end_of_gc();
-    }
-
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
         self.base().collection_required(self, space_full)
     }

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -937,6 +937,7 @@ impl<VM: VMBinding> GCWork<VM> for SweepChunk<VM> {
                     allocated_blocks += 1;
                 }
             }
+            probe!(mmtk, sweep_chunk, allocated_blocks);
             // Set this chunk as free if there is not live blocks.
             if allocated_blocks == 0 {
                 self.space.chunk_map.set(self.chunk, ChunkState::Free)

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -890,58 +890,58 @@ struct SweepChunk<VM: VMBinding> {
 
 impl<VM: VMBinding> GCWork<VM> for SweepChunk<VM> {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
+        assert_eq!(self.space.chunk_map.get(self.chunk), ChunkState::Allocated);
+
         let mut histogram = self.space.defrag.new_histogram();
-        if self.space.chunk_map.get(self.chunk) == ChunkState::Allocated {
-            let line_mark_state = if super::BLOCK_ONLY {
-                None
-            } else {
-                Some(self.space.line_mark_state.load(Ordering::Acquire))
-            };
-            // Hints for clearing side forwarding bits.
-            let is_moving_gc = mmtk.get_plan().current_gc_may_move_object();
-            let is_defrag_gc = self.space.defrag.in_defrag();
-            // number of allocated blocks.
-            let mut allocated_blocks = 0;
-            // Iterate over all allocated blocks in this chunk.
-            for block in self
-                .chunk
-                .iter_region::<Block>()
-                .filter(|block| block.get_state() != BlockState::Unallocated)
-            {
-                // Clear side forwarding bits.
-                // In the beginning of the next GC, no side forwarding bits shall be set.
-                // In this way, we can omit clearing forwarding bits when copying object.
-                // See `GCWorkerCopyContext::post_copy`.
-                // Note, `block.sweep()` overwrites `DEFRAG_STATE_TABLE` with the number of holes,
-                // but we need it to know if a block is a defrag source.
-                // We clear forwarding bits before `block.sweep()`.
-                if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC {
-                    if is_moving_gc {
-                        let objects_may_move = if is_defrag_gc {
-                            // If it is a defrag GC, we only clear forwarding bits for defrag sources.
-                            block.is_defrag_source()
-                        } else {
-                            // Otherwise, it must be a nursery GC of StickyImmix with copying nursery.
-                            // We don't have information about which block contains moved objects,
-                            // so we have to clear forwarding bits for all blocks.
-                            true
-                        };
-                        if objects_may_move {
-                            side.bzero_metadata(block.start(), Block::BYTES);
-                        }
+        let line_mark_state = if super::BLOCK_ONLY {
+            None
+        } else {
+            Some(self.space.line_mark_state.load(Ordering::Acquire))
+        };
+        // Hints for clearing side forwarding bits.
+        let is_moving_gc = mmtk.get_plan().current_gc_may_move_object();
+        let is_defrag_gc = self.space.defrag.in_defrag();
+        // number of allocated blocks.
+        let mut allocated_blocks = 0;
+        // Iterate over all allocated blocks in this chunk.
+        for block in self
+            .chunk
+            .iter_region::<Block>()
+            .filter(|block| block.get_state() != BlockState::Unallocated)
+        {
+            // Clear side forwarding bits.
+            // In the beginning of the next GC, no side forwarding bits shall be set.
+            // In this way, we can omit clearing forwarding bits when copying object.
+            // See `GCWorkerCopyContext::post_copy`.
+            // Note, `block.sweep()` overwrites `DEFRAG_STATE_TABLE` with the number of holes,
+            // but we need it to know if a block is a defrag source.
+            // We clear forwarding bits before `block.sweep()`.
+            if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC {
+                if is_moving_gc {
+                    let objects_may_move = if is_defrag_gc {
+                        // If it is a defrag GC, we only clear forwarding bits for defrag sources.
+                        block.is_defrag_source()
+                    } else {
+                        // Otherwise, it must be a nursery GC of StickyImmix with copying nursery.
+                        // We don't have information about which block contains moved objects,
+                        // so we have to clear forwarding bits for all blocks.
+                        true
+                    };
+                    if objects_may_move {
+                        side.bzero_metadata(block.start(), Block::BYTES);
                     }
                 }
+            }
 
-                if !block.sweep(self.space, &mut histogram, line_mark_state) {
-                    // Block is live. Increment the allocated block count.
-                    allocated_blocks += 1;
-                }
+            if !block.sweep(self.space, &mut histogram, line_mark_state) {
+                // Block is live. Increment the allocated block count.
+                allocated_blocks += 1;
             }
-            probe!(mmtk, sweep_chunk, allocated_blocks);
-            // Set this chunk as free if there is not live blocks.
-            if allocated_blocks == 0 {
-                self.space.chunk_map.set(self.chunk, ChunkState::Free)
-            }
+        }
+        probe!(mmtk, sweep_chunk, allocated_blocks);
+        // Set this chunk as free if there is not live blocks.
+        if allocated_blocks == 0 {
+            self.space.chunk_map.set(self.chunk, ChunkState::Free)
         }
         self.space.defrag.add_completed_mark_histogram(histogram);
         self.epilogue.finish_one_work_packet();

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -79,8 +79,8 @@ pub struct MarkSweepSpace<VM: VMBinding> {
     /// these block lists in the space. These lists are only filled in the release phase,
     /// and will be moved to the abandoned lists above at the end of a GC.
     abandoned_in_gc: Mutex<AbandonedBlockLists>,
-    /// Count the number of pending release packets during the `Release` stage.
-    /// If all such packets are done, we can start sweeping chunks.
+    /// Count the number of pending `ReleaseMarkSweepSpace` and `ReleaseMutator` work packets during
+    /// the `Release` stage.
     pending_release_packets: AtomicUsize,
 }
 

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -509,8 +509,10 @@ struct ReleaseMarkSweepSpace<VM: VMBinding> {
 
 impl<VM: VMBinding> GCWork<VM> for ReleaseMarkSweepSpace<VM> {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        let mut abandoned = self.space.abandoned.lock().unwrap();
-        abandoned.sweep_later(self.space);
+        {
+            let mut abandoned = self.space.abandoned.lock().unwrap();
+            abandoned.sweep_later(self.space);
+        }
 
         if cfg!(feature = "eager_sweeping") {
             self.space.release_packet_done();

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -124,7 +124,6 @@ impl AbandonedBlockLists {
     }
 
     fn recategorize_blocks(&mut self) {
-        assert!(cfg!(feature = "eager_sweeping"));
         for i in 0..MI_BIN_FULL {
             for block in self.consumed[i].iter() {
                 if block.has_free_cells() {

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -418,12 +418,6 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
     pub(crate) fn prepare(&mut self) {}
 
     pub(crate) fn release(&mut self) {
-        self.reset();
-    }
-
-    /// Lazy sweeping. We just move all the blocks to the unswept block list.
-    fn reset(&mut self) {
-        trace!("reset");
         for bin in 0..MI_BIN_FULL {
             let unswept = self.unswept_blocks.get_mut(bin).unwrap();
 
@@ -455,9 +449,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
             self.abandon_blocks(&mut global);
         }
 
-        if cfg!(feature = "eager_sweeping") {
-            self.space.release_packet_done();
-        }
+        self.space.release_packet_done();
     }
 
     fn abandon_blocks(&mut self, global: &mut AbandonedBlockLists) {

--- a/tools/tracing/README.md
+++ b/tools/tracing/README.md
@@ -30,6 +30,9 @@ Currently, the core provides the following tracepoints.
 -   `mmtk:process_slots(num_slots: int, is_roots: bool)`: an invocation of the `process_slots`
     method. The first argument is the number of slots to be processed, and the second argument is
     whether these slots are root slots.
+-   `mmtk:sweep_chunk(allocated_blocks: int)`: an execution of the `SweepChunk` work packet (for
+    both `MarkSweepSpace` and `ImmixSpace`).  `allocated_blocks` is the number of allocated blocks
+    in the chunk processed by the work packet.
 -   `mmtk:bucket_opened(id: int)`: a work bucket opened. The first argument is the numerical
     representation of `enum WorkBucketStage`.
 -   `mmtk:work_poll()`: a work packet is to be polled.

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -91,4 +91,10 @@ usdt:$MMTK:mmtk:plan_end_of_gc_end {
     }
 }
 
+usdt:$MMTK:mmtk:sweep_chunk {
+    if (@enable_print) {
+        printf("sweep_chunk,meta,%d,%lu,%lu\n", tid, nsecs, arg0);
+    }
+}
+
 // vim: ft=bpftrace ts=4 sw=4 sts=4 et

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -95,6 +95,12 @@ class LogProcessor:
                     current["args"]["num_slots"] = int(rest[0])
                     current["args"]["is_roots"] = int(rest[1])
 
+            case "sweep_chunk":
+                current = self.get_current_work_packet(tid)
+                # eBPF may drop events.  Be conservative.
+                if current is not None:
+                    current["args"]["allocated_blocks"] = int(rest[0])
+
         if be != "meta":
             self.results.append(result)
 


### PR DESCRIPTION
This PR re-introduce the `SweepChunk` work packet to the native `MarkSweepSpace` when using eager sweeping.  The main intention of this PS is fixing a pathological case where there is only one mutator and the single `ReleaseMutator` work packet cannot be parallelized.

The algorithm is unchanged for lazy sweeping.

When doing eager sweeping,

1.  We first release all unmarked blocks in `MarkSweepSpace::abandoned` and each mutator.
2.  And then we sweep blocks in parallel using `SweepChunk` work packets.
3.  We then go through all "consumed" blocks and move them into "available" lists if they have any free cells.

In step (1), we release blocks for each mutator in `ReleaseMutator`.  Releasing blocks is very fast, so parallelism is not a bottleneck.  During step (2), all blocks are either unallocated or marked, so we don't need to move any block out of linked lists, avoiding the data race we observed in https://github.com/mmtk/mmtk-core/issues/1103.  Step (3) is done by one thread, but it is fast enough not to be a performance bottleneck.

We also introduced a work packet `ReleaseMarkSweepSpace` which does what `MarkSweepSpace::release` did, but is executed concurrently with `ReleaseMutator` work packets.  In this way, we don't do too much work in the `Release` work packet, which is a problem we discussed in https://github.com/mmtk/mmtk-core/issues/1147.

We removed the constant `ABANDON_BLOCKS_IN_RESET` because it is obviously necessary to do so.  Otherwise one mutator will keep too many blocks locally, preventing other mutators to get available blocks to use.

We added an USDT tracepoint in `SweepChunk` in both `MarkSweepSpace` and `ImmixSpace` so that we can see the number of allocated blocks a `SweepChunk` work packet visited in the timeline generated by eBPF tracing tools.

We also changed `immixspace::SweepChunk` so that it now *asserts* that the chunk is allocated rather than skipping unallocated chunks.  `ChunkMap::generate_tasks` already filters out unallocated chunks.

Fixes: https://github.com/mmtk/mmtk-core/issues/1146