### PR TITLE
Clear pin bits

### DIFF
--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -8,6 +8,8 @@ use crate::util::linear_scan::{Region, RegionIterator};
 use crate::util::metadata::side_metadata::{MetadataByteArrayRef, SideMetadataSpec};
 #[cfg(feature = "vo_bit")]
 use crate::util::metadata::vo_bit;
+#[cfg(feature = "object_pinning")]
+use crate::util::metadata::MetadataSpec;
 use crate::util::Address;
 use crate::vm::*;
 use std::sync::atomic::Ordering;
@@ -201,8 +203,14 @@ impl Block {
                     #[cfg(feature = "vo_bit")]
                     vo_bit::helper::on_region_swept::<VM, _>(self, false);
 
+                    // If the pin bit is not on the side, we cannot bulk zero.
+                    // We shouldn't need to clear it here in that case, since the pin bit
+                    // should be overwritten at each object allocation. The same applies below
+                    // when we are sweeping on a line granularity.
                     #[cfg(feature = "object_pinning")]
-                    crate::util::metadata::pin_bit::bzero_pin_bit::<VM>(self.start(), Block::BYTES);
+                    if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_PINNING_BIT_SPEC {
+                        side.bzero_metadata(self.start(), Block::BYTES);
+                    }
 
                     // Release the block if it is allocated but not marked by the current GC.
                     space.release_block(*self);
@@ -236,9 +244,11 @@ impl Block {
                     #[cfg(feature = "immix_zero_on_release")]
                     crate::util::memory::zero(line.start(), Line::BYTES);
 
-                    // We need to clear the pin bit as this line can be reused
+                    // We need to clear the pin bit if it is on the side, as this line can be reused
                     #[cfg(feature = "object_pinning")]
-                    crate::util::metadata::pin_bit::bzero_pin_bit::<VM>(line.start(), Line::BYTES);
+                    if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_PINNING_BIT_SPEC {
+                        side.bzero_metadata(line.start(), Line::BYTES);
+                    }
 
                     prev_line_is_marked = false;
                 }

--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -201,6 +201,9 @@ impl Block {
                     #[cfg(feature = "vo_bit")]
                     vo_bit::helper::on_region_swept::<VM, _>(self, false);
 
+                    #[cfg(feature = "object_pinning")]
+                    crate::util::metadata::pin_bit::bzero_pin_bit::<VM>(self.start(), Block::BYTES);
+
                     // Release the block if it is allocated but not marked by the current GC.
                     space.release_block(*self);
                     true
@@ -232,6 +235,10 @@ impl Block {
 
                     #[cfg(feature = "immix_zero_on_release")]
                     crate::util::memory::zero(line.start(), Line::BYTES);
+
+                    // We need to clear the pin bit as this line can be reused
+                    #[cfg(feature = "object_pinning")]
+                    crate::util::metadata::pin_bit::bzero_pin_bit::<VM>(line.start(), Line::BYTES);
 
                     prev_line_is_marked = false;
                 }

--- a/src/util/metadata/pin_bit.rs
+++ b/src/util/metadata/pin_bit.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "object_pinning")]
+use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::vm::VMBinding;
 use crate::vm::VMLocalPinningBitSpec;
@@ -41,5 +43,22 @@ impl VMLocalPinningBitSpec {
         }
 
         false
+    }
+}
+
+/// Bulk zero the pin bit.
+#[cfg(feature = "object_pinning")]
+pub fn bzero_pin_bit<VM: VMBinding>(start: Address, size: usize) {
+    use crate::util::metadata::MetadataSpec;
+    use crate::vm::object_model::ObjectModel;
+
+    if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_PINNING_BIT_SPEC {
+        // We zero all the pin bits for the address range.
+        side.bzero_metadata(start, size);
+    } else {
+        // If the pin bit is not in side metadata, we cannot bulk zero.
+        // We will probably have to clear it for new objects, which means
+        // that we do not need to clear it at sweeping.
+        unimplemented!("We cannot bulk zero unlogged bit.")
     }
 }

--- a/src/util/metadata/pin_bit.rs
+++ b/src/util/metadata/pin_bit.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "object_pinning")]
-use crate::util::Address;
 use crate::util::ObjectReference;
 use crate::vm::VMBinding;
 use crate::vm::VMLocalPinningBitSpec;
@@ -43,22 +41,5 @@ impl VMLocalPinningBitSpec {
         }
 
         false
-    }
-}
-
-/// Bulk zero the pin bit.
-#[cfg(feature = "object_pinning")]
-pub fn bzero_pin_bit<VM: VMBinding>(start: Address, size: usize) {
-    use crate::util::metadata::MetadataSpec;
-    use crate::vm::object_model::ObjectModel;
-
-    if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::LOCAL_PINNING_BIT_SPEC {
-        // We zero all the pin bits for the address range.
-        side.bzero_metadata(start, size);
-    } else {
-        // If the pin bit is not in side metadata, we cannot bulk zero.
-        // We will probably have to clear it for new objects, which means
-        // that we do not need to clear it at sweeping.
-        unimplemented!("We cannot bulk zero pin bit.")
     }
 }

--- a/src/util/metadata/pin_bit.rs
+++ b/src/util/metadata/pin_bit.rs
@@ -59,6 +59,6 @@ pub fn bzero_pin_bit<VM: VMBinding>(start: Address, size: usize) {
         // If the pin bit is not in side metadata, we cannot bulk zero.
         // We will probably have to clear it for new objects, which means
         // that we do not need to clear it at sweeping.
-        unimplemented!("We cannot bulk zero unlogged bit.")
+        unimplemented!("We cannot bulk zero pin bit.")
     }
 }


### PR DESCRIPTION
If an object dies, we need to make sure his pin bit gets cleared. This PR enables clearing the pin bits when sweeping - clearing the whole block when `super::BLOCK_ONLY` is true, or at line granularity when a line is not marked. 
I've only added it to the immix policy, since for everything else pinning is either unsupported or it's a NOP. 