### PR TITLE
Fix bug in line mark when `MARK_LINE_AT_SCAN_TIME=false`

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -633,9 +633,6 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             // forwarding status and return the unmoved object
             object_forwarding::clear_forwarding_bits::<VM>(object);
 
-            if !super::MARK_LINE_AT_SCAN_TIME {
-                self.mark_lines(object);
-            }
 
             object
         } else {

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -632,6 +632,11 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             // We won the forwarding race but the object is already marked so we clear the
             // forwarding status and return the unmoved object
             object_forwarding::clear_forwarding_bits::<VM>(object);
+
+            if !super::MARK_LINE_AT_SCAN_TIME {
+                self.mark_lines(object);
+            }
+            
             object
         } else {
             // We won the forwarding race; actually forward and copy the object if it is not pinned
@@ -646,6 +651,10 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 #[cfg(feature = "vo_bit")]
                 vo_bit::helper::on_object_marked::<VM>(object);
 
+                if !super::MARK_LINE_AT_SCAN_TIME {
+                    self.mark_lines(object);
+                }
+                
                 object
             } else {
                 // We are forwarding objects. When the copy allocator allocates the block, it should

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -632,8 +632,6 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             // We won the forwarding race but the object is already marked so we clear the
             // forwarding status and return the unmoved object
             object_forwarding::clear_forwarding_bits::<VM>(object);
-
-
             object
         } else {
             // We won the forwarding race; actually forward and copy the object if it is not pinned

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -636,7 +636,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             if !super::MARK_LINE_AT_SCAN_TIME {
                 self.mark_lines(object);
             }
-            
+
             object
         } else {
             // We won the forwarding race; actually forward and copy the object if it is not pinned
@@ -654,7 +654,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 if !super::MARK_LINE_AT_SCAN_TIME {
                     self.mark_lines(object);
                 }
-                
+
                 object
             } else {
                 // We are forwarding objects. When the copy allocator allocates the block, it should


### PR DESCRIPTION
Previously we did not mark the line for an object in `trace_object_with_opportunistic_copy` if we leave the object in-place when `MARK_LINE_AT_SCAN_TIME=false`.