### PR TITLE
Pass `ObjectReference` to the `is_movable` API

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -47,7 +47,7 @@ impl<VM: VMBinding> SFT for CopySpace<VM> {
         false
     }
 
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         true
     }
 

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -128,7 +128,11 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
     fn is_object_pinned(&self, object: ObjectReference) -> bool {
         VM::VMObjectModel::LOCAL_PINNING_BIT_SPEC.is_object_pinned::<VM>(object)
     }
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
+        #[cfg(feature = "object_pinning")]
+        if self.is_object_pinned(_object) {
+            return false;
+        }
         !super::NEVER_MOVE_OBJECTS
     }
 

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -47,7 +47,7 @@ impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
     fn is_object_pinned(&self, _object: ObjectReference) -> bool {
         true
     }
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         false
     }
     #[cfg(feature = "sanity")]

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -49,7 +49,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
     fn is_object_pinned(&self, _object: ObjectReference) -> bool {
         true
     }
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         false
     }
     #[cfg(feature = "sanity")]

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -62,7 +62,7 @@ impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
     fn is_object_pinned(&self, _object: ObjectReference) -> bool {
         true
     }
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         unimplemented!()
     }
     #[cfg(feature = "sanity")]

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -61,7 +61,7 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
         false
     }
 
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         true
     }
 

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -86,7 +86,7 @@ impl<VM: VMBinding> SFT for MallocSpace<VM> {
         false
     }
 
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         false
     }
 

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -178,7 +178,7 @@ impl<VM: VMBinding> SFT for MarkSweepSpace<VM> {
         false
     }
 
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         false
     }
 

--- a/src/policy/sft.rs
+++ b/src/policy/sft.rs
@@ -56,7 +56,7 @@ pub trait SFT {
 
     /// Is the object movable, determined by the policy? E.g. the policy is non-moving,
     /// or the object is pinned.
-    fn is_movable(&self) -> bool;
+    fn is_movable(&self, object: ObjectReference) -> bool;
 
     /// Is the object sane? A policy should return false if there is any abnormality about
     /// object - the sanity checker will fail if an object is not sane.
@@ -146,7 +146,7 @@ impl SFT for EmptySpaceSFT {
     fn is_object_pinned(&self, _object: ObjectReference) -> bool {
         false
     }
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         /*
          * FIXME steveb I think this should panic (ie the function should not
          * be invoked on an empty space).   However, JikesRVM currently does

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -49,7 +49,7 @@ impl<VM: VMBinding> SFT for VMSpace<VM> {
     fn is_object_pinned(&self, _object: ObjectReference) -> bool {
         true
     }
-    fn is_movable(&self) -> bool {
+    fn is_movable(&self, _object: ObjectReference) -> bool {
         false
     }
     #[cfg(feature = "sanity")]

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -600,7 +600,7 @@ impl ObjectReference {
 
     /// Can the object be moved?
     pub fn is_movable<VM: VMBinding>(self) -> bool {
-        unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.is_movable()
+        unsafe { SFT_MAP.get_unchecked(self.to_address::<VM>()) }.is_movable(self)
     }
 
     /// Get forwarding pointer if the object is forwarded.


### PR DESCRIPTION
This allows policies that implement object pinning (such as ImmixSpace) to return a more accurate answer.