### PR TITLE
Only map with executable permissions when using code space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,11 @@ set_unlog_bits_vm_space = []
 # TODO: This is not properly implemented yet. We currently use an immortal space instead, and do not guarantee read-only semantics.
 ro_space = []
 # A code space with execution permission.
-# TODO: This is not properly implemented yet. We currently use an immortal space instead, and all our spaces have execution permission at the moment.
 code_space  = []
+
+# By default, we only allow execution permission for code spaces. With this feature, all the spaces have execution permission.
+# Use with care.
+exec_permission_on_all_spaces = []
 
 # Global valid object (VO) bit metadata.
 # The VO bit is set when an object is allocated, and cleared when the GC determines it is dead.

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -175,9 +175,9 @@ impl<VM: VMBinding> MyGC<VM> {
         let res = MyGC {
             hi: AtomicBool::new(false),
             // ANCHOR: copyspace_new
-            copyspace0: CopySpace::new(plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()), false),
+            copyspace0: CopySpace::new(plan_args.get_space_args("copyspace0", true, false, VMRequest::discontiguous()), false),
             // ANCHOR_END: copyspace_new
-            copyspace1: CopySpace::new(plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()), true),
+            copyspace1: CopySpace::new(plan_args.get_space_args("copyspace1", true, false, VMRequest::discontiguous()), true),
             common: CommonPlan::new(plan_args),
         };
 

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -203,10 +203,6 @@ impl<VM: VMBinding> MMTK<VM> {
             },
         );
 
-        if *options.transparent_hugepages {
-            MMAPPER.set_mmap_strategy(crate::util::memory::MmapStrategy::TransparentHugePages);
-        }
-
         MMTK {
             options,
             state,

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -209,11 +209,11 @@ impl<VM: VMBinding> GenCopy<VM> {
         };
 
         let copyspace0 = CopySpace::new(
-            plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
+            plan_args.get_space_args("copyspace0", true, false, VMRequest::discontiguous()),
             false,
         );
         let copyspace1 = CopySpace::new(
-            plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
+            plan_args.get_space_args("copyspace1", true, false, VMRequest::discontiguous()),
             true,
         );
 

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -41,7 +41,7 @@ pub struct CommonGenPlan<VM: VMBinding> {
 impl<VM: VMBinding> CommonGenPlan<VM> {
     pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> Self {
         let nursery = CopySpace::new(
-            args.get_space_args("nursery", true, VMRequest::discontiguous()),
+            args.get_space_args("nursery", true, false, VMRequest::discontiguous()),
             true,
         );
         let full_heap_gc_count = args

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -247,7 +247,7 @@ impl<VM: VMBinding> GenImmix<VM> {
                 crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
         };
         let immix_space = ImmixSpace::new(
-            plan_args.get_space_args("immix_mature", true, VMRequest::discontiguous()),
+            plan_args.get_space_args("immix_mature", true, false, VMRequest::discontiguous()),
             ImmixSpaceArgs {
                 reset_log_bit_in_major_gc: false,
                 // We don't need to unlog objects at tracing. Instead, we unlog objects at copying.

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -396,11 +396,13 @@ impl<'a, VM: VMBinding> CreateSpecificPlanArgs<'a, VM> {
         &mut self,
         name: &'static str,
         zeroed: bool,
+        permission_exec: bool,
         vmrequest: VMRequest,
     ) -> PlanCreateSpaceArgs<VM> {
         PlanCreateSpaceArgs {
             name,
             zeroed,
+            permission_exec,
             vmrequest,
             global_side_metadata_specs: self.global_side_metadata_specs.clone(),
             vm_map: self.global_args.vm_map,
@@ -409,7 +411,7 @@ impl<'a, VM: VMBinding> CreateSpecificPlanArgs<'a, VM> {
             constraints: self.constraints,
             gc_trigger: self.global_args.gc_trigger.clone(),
             scheduler: self.global_args.scheduler.clone(),
-            options: &self.global_args.options,
+            options: self.global_args.options.clone(),
             global_state: self.global_args.state.clone(),
         }
     }
@@ -423,11 +425,13 @@ impl<VM: VMBinding> BasePlan<VM> {
             code_space: ImmortalSpace::new(args.get_space_args(
                 "code_space",
                 true,
+                true,
                 VMRequest::discontiguous(),
             )),
             #[cfg(feature = "code_space")]
             code_lo_space: ImmortalSpace::new(args.get_space_args(
                 "code_lo_space",
+                true,
                 true,
                 VMRequest::discontiguous(),
             )),
@@ -435,12 +439,14 @@ impl<VM: VMBinding> BasePlan<VM> {
             ro_space: ImmortalSpace::new(args.get_space_args(
                 "ro_space",
                 true,
+                false,
                 VMRequest::discontiguous(),
             )),
             #[cfg(feature = "vm_space")]
             vm_space: VMSpace::new(args.get_space_args(
                 "vm_space",
                 false,
+                false, // it doesn't matter -- we are not mmapping for VM space.
                 VMRequest::discontiguous(),
             )),
 
@@ -585,15 +591,17 @@ impl<VM: VMBinding> CommonPlan<VM> {
             immortal: ImmortalSpace::new(args.get_space_args(
                 "immortal",
                 true,
+                false,
                 VMRequest::discontiguous(),
             )),
             los: LargeObjectSpace::new(
-                args.get_space_args("los", true, VMRequest::discontiguous()),
+                args.get_space_args("los", true, false, VMRequest::discontiguous()),
                 false,
             ),
             nonmoving: ImmortalSpace::new(args.get_space_args(
                 "nonmoving",
                 true,
+                false,
                 VMRequest::discontiguous(),
             )),
             base: BasePlan::new(args),

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -150,7 +150,7 @@ impl<VM: VMBinding> Immix<VM> {
     ) -> Self {
         let immix = Immix {
             immix_space: ImmixSpace::new(
-                plan_args.get_space_args("immix", true, VMRequest::discontiguous()),
+                plan_args.get_space_args("immix", true, false, VMRequest::discontiguous()),
                 space_args,
             ),
             common: CommonPlan::new(plan_args),

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -195,8 +195,12 @@ impl<VM: VMBinding> MarkCompact<VM> {
             global_side_metadata_specs,
         };
 
-        let mc_space =
-            MarkCompactSpace::new(plan_args.get_space_args("mc", true, VMRequest::discontiguous()));
+        let mc_space = MarkCompactSpace::new(plan_args.get_space_args(
+            "mc",
+            true,
+            false,
+            VMRequest::discontiguous(),
+        ));
 
         let res = MarkCompact {
             mc_space,

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -109,6 +109,7 @@ impl<VM: VMBinding> MarkSweep<VM> {
             ms: MarkSweepSpace::new(plan_args.get_space_args(
                 "ms",
                 true,
+                false,
                 VMRequest::discontiguous(),
             )),
             common: CommonPlan::new(plan_args),

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -98,16 +98,19 @@ impl<VM: VMBinding> NoGC<VM> {
             nogc_space: NoGCImmortalSpace::new(plan_args.get_space_args(
                 "nogc_space",
                 cfg!(not(feature = "nogc_no_zeroing")),
+                false,
                 VMRequest::discontiguous(),
             )),
             immortal: ImmortalSpace::new(plan_args.get_space_args(
                 "immortal",
                 true,
+                false,
                 VMRequest::discontiguous(),
             )),
             los: ImmortalSpace::new(plan_args.get_space_args(
                 "los",
                 true,
+                false,
                 VMRequest::discontiguous(),
             )),
             base: BasePlan::new(plan_args),

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -105,7 +105,7 @@ impl<VM: VMBinding> PageProtect<VM> {
 
         let ret = PageProtect {
             space: LargeObjectSpace::new(
-                plan_args.get_space_args("pageprotect", true, VMRequest::discontiguous()),
+                plan_args.get_space_args("pageprotect", true, false, VMRequest::discontiguous()),
                 true,
             ),
             common: CommonPlan::new(plan_args),

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -143,11 +143,11 @@ impl<VM: VMBinding> SemiSpace<VM> {
         let res = SemiSpace {
             hi: AtomicBool::new(false),
             copyspace0: CopySpace::new(
-                plan_args.get_space_args("copyspace0", true, VMRequest::discontiguous()),
+                plan_args.get_space_args("copyspace0", true, false, VMRequest::discontiguous()),
                 false,
             ),
             copyspace1: CopySpace::new(
-                plan_args.get_space_args("copyspace1", true, VMRequest::discontiguous()),
+                plan_args.get_space_args("copyspace1", true, false, VMRequest::discontiguous()),
                 true,
             ),
             common: CommonPlan::new(plan_args),

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -212,7 +212,11 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
         } else {
             FreeListPageResource::new_contiguous(common.start, common.extent, vm_map)
         };
-        pr.protect_memory_on_release = protect_memory_on_release;
+        pr.protect_memory_on_release = if protect_memory_on_release {
+            Some(common.mmap_strategy().prot)
+        } else {
+            None
+        };
         LargeObjectSpace {
             pr,
             common,

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -232,11 +232,10 @@ impl<VM: VMBinding> LockFreeImmortalSpace<VM> {
         };
 
         // Eagerly memory map the entire heap (also zero all the memory)
-        let strategy = if *args.options.transparent_hugepages {
-            MmapStrategy::TransparentHugePages
-        } else {
-            MmapStrategy::Normal
-        };
+        let strategy = MmapStrategy::new(
+            *args.options.transparent_hugepages,
+            crate::util::memory::MmapProtection::ReadWrite,
+        );
         crate::util::memory::dzmmap_noreplace(start, aligned_total_bytes, strategy).unwrap();
         if space
             .metadata

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -28,7 +28,7 @@ use crate::util::heap::layout::Mmapper;
 use crate::util::heap::layout::VMMap;
 use crate::util::heap::space_descriptor::SpaceDescriptor;
 use crate::util::heap::HeapMeta;
-use crate::util::memory;
+use crate::util::memory::{self, HugePageSupport, MmapProtection, MmapStrategy};
 use crate::vm::VMBinding;
 
 use std::marker::PhantomData;
@@ -137,13 +137,13 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                     );
                     let bytes = conversions::pages_to_bytes(res.pages);
 
-                    let map_sidemetadata = || {
+                    let mmap = || {
                         // Mmap the pages and the side metadata, and handle error. In case of any error,
                         // we will either call back to the VM for OOM, or simply panic.
                         if let Err(mmap_error) = self
                             .common()
                             .mmapper
-                            .ensure_mapped(res.start, res.pages)
+                            .ensure_mapped(res.start, res.pages, self.common().mmap_strategy())
                             .and(
                                 self.common()
                                     .metadata
@@ -160,7 +160,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                     // The scope of the lock is important in terms of performance when we have many allocator threads.
                     if SFT_MAP.get_side_metadata().is_some() {
                         // If the SFT map uses side metadata, so we have to initialize side metadata first.
-                        map_sidemetadata();
+                        mmap();
                         // then grow space, which will use the side metadata we mapped above
                         grow_space();
                         // then we can drop the lock after grow_space()
@@ -170,7 +170,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
                         grow_space();
                         drop(lock);
                         // and map side metadata without holding the lock
-                        map_sidemetadata();
+                        mmap();
                     }
 
                     // TODO: Concurrent zeroing
@@ -421,10 +421,12 @@ pub struct CommonSpace<VM: VMBinding> {
     // the copy semantics for the space.
     pub copy: Option<CopySemantics>,
 
-    immortal: bool,
-    movable: bool,
+    pub immortal: bool,
+    pub movable: bool,
     pub contiguous: bool,
     pub zeroed: bool,
+
+    pub permission_exec: bool,
 
     pub start: Address,
     pub extent: usize,
@@ -443,6 +445,7 @@ pub struct CommonSpace<VM: VMBinding> {
 
     pub gc_trigger: Arc<GCTrigger<VM>>,
     pub global_state: Arc<GlobalState>,
+    pub options: Arc<Options>,
 
     p: PhantomData<VM>,
 }
@@ -459,6 +462,7 @@ pub struct PolicyCreateSpaceArgs<'a, VM: VMBinding> {
 pub struct PlanCreateSpaceArgs<'a, VM: VMBinding> {
     pub name: &'static str,
     pub zeroed: bool,
+    pub permission_exec: bool,
     pub vmrequest: VMRequest,
     pub global_side_metadata_specs: Vec<SideMetadataSpec>,
     pub vm_map: &'static dyn VMMap,
@@ -467,7 +471,7 @@ pub struct PlanCreateSpaceArgs<'a, VM: VMBinding> {
     pub constraints: &'a PlanConstraints,
     pub gc_trigger: Arc<GCTrigger<VM>>,
     pub scheduler: Arc<GCWorkScheduler<VM>>,
-    pub options: &'a Options,
+    pub options: Arc<Options>,
     pub global_state: Arc<GlobalState>,
 }
 
@@ -498,6 +502,7 @@ impl<VM: VMBinding> CommonSpace<VM> {
             immortal: args.immortal,
             movable: args.movable,
             contiguous: true,
+            permission_exec: args.plan_args.permission_exec,
             zeroed: args.plan_args.zeroed,
             start: unsafe { Address::zero() },
             extent: 0,
@@ -511,6 +516,7 @@ impl<VM: VMBinding> CommonSpace<VM> {
             },
             acquire_lock: Mutex::new(()),
             global_state: args.plan_args.global_state,
+            options: args.plan_args.options.clone(),
             p: PhantomData,
         };
 
@@ -618,6 +624,21 @@ impl<VM: VMBinding> CommonSpace<VM> {
 
     pub fn vm_map(&self) -> &'static dyn VMMap {
         self.vm_map
+    }
+
+    pub fn mmap_strategy(&self) -> MmapStrategy {
+        MmapStrategy {
+            huge_page: if *self.options.transparent_hugepages {
+                HugePageSupport::TransparentHugePages
+            } else {
+                HugePageSupport::No
+            },
+            prot: if self.permission_exec || cfg!(feature = "exec_permission_on_all_spaces") {
+                MmapProtection::ReadWriteExec
+            } else {
+                MmapProtection::ReadWrite
+            },
+        }
     }
 }
 

--- a/src/util/heap/layout/byte_map_mmapper.rs
+++ b/src/util/heap/layout/byte_map_mmapper.rs
@@ -237,7 +237,7 @@ mod tests {
                 || {
                     let mmapper = ByteMapMmapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST)
                         .unwrap();
 
                     for chunk in start_chunk..end_chunk {
@@ -266,7 +266,7 @@ mod tests {
                 || {
                     let mmapper = ByteMapMmapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST)
                         .unwrap();
 
                     for chunk in start_chunk..end_chunk {
@@ -295,7 +295,7 @@ mod tests {
                 || {
                     let mmapper = ByteMapMmapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST)
                         .unwrap();
 
                     let start_chunk = ByteMapMmapper::address_to_mmap_chunks_down(FIXED_ADDRESS);
@@ -332,7 +332,7 @@ mod tests {
                         .ensure_mapped(
                             FIXED_ADDRESS,
                             test_memory_pages,
-                            MmapStrategy::test_strategy(),
+                            MmapStrategy::TEST,
                         )
                         .unwrap();
 
@@ -371,7 +371,7 @@ mod tests {
                         .ensure_mapped(
                             FIXED_ADDRESS,
                             test_memory_pages,
-                            MmapStrategy::test_strategy(),
+                            MmapStrategy::TEST,
                         )
                         .unwrap();
 
@@ -393,7 +393,7 @@ mod tests {
                         .ensure_mapped(
                             FIXED_ADDRESS,
                             protect_memory_pages_2,
-                            MmapStrategy::test_strategy(),
+                            MmapStrategy::TEST,
                         )
                         .unwrap();
                     assert_eq!(

--- a/src/util/heap/layout/byte_map_mmapper.rs
+++ b/src/util/heap/layout/byte_map_mmapper.rs
@@ -329,11 +329,7 @@ mod tests {
                     // map 2 chunks
                     let mmapper = ByteMapMmapper::new();
                     mmapper
-                        .ensure_mapped(
-                            FIXED_ADDRESS,
-                            test_memory_pages,
-                            MmapStrategy::TEST,
-                        )
+                        .ensure_mapped(FIXED_ADDRESS, test_memory_pages, MmapStrategy::TEST)
                         .unwrap();
 
                     // protect 1 chunk
@@ -368,11 +364,7 @@ mod tests {
                     // map 2 chunks
                     let mmapper = ByteMapMmapper::new();
                     mmapper
-                        .ensure_mapped(
-                            FIXED_ADDRESS,
-                            test_memory_pages,
-                            MmapStrategy::TEST,
-                        )
+                        .ensure_mapped(FIXED_ADDRESS, test_memory_pages, MmapStrategy::TEST)
                         .unwrap();
 
                     // protect 1 chunk
@@ -390,11 +382,7 @@ mod tests {
 
                     // ensure mapped - this will unprotect the previously protected chunk
                     mmapper
-                        .ensure_mapped(
-                            FIXED_ADDRESS,
-                            protect_memory_pages_2,
-                            MmapStrategy::TEST,
-                        )
+                        .ensure_mapped(FIXED_ADDRESS, protect_memory_pages_2, MmapStrategy::TEST)
                         .unwrap();
                     assert_eq!(
                         mmapper.mapped[chunk].load(Ordering::Relaxed),

--- a/src/util/heap/layout/byte_map_mmapper.rs
+++ b/src/util/heap/layout/byte_map_mmapper.rs
@@ -23,7 +23,6 @@ pub const VERBOSE: bool = true;
 pub struct ByteMapMmapper {
     lock: Mutex<()>,
     mapped: [Atomic<MapState>; MMAP_NUM_CHUNKS],
-    strategy: Atomic<MmapStrategy>,
 }
 
 impl fmt::Debug for ByteMapMmapper {
@@ -33,10 +32,6 @@ impl fmt::Debug for ByteMapMmapper {
 }
 
 impl Mmapper for ByteMapMmapper {
-    fn set_mmap_strategy(&self, strategy: MmapStrategy) {
-        self.strategy.store(strategy, Ordering::Relaxed);
-    }
-
     fn eagerly_mmap_all_spaces(&self, _space_map: &[Address]) {
         unimplemented!()
     }
@@ -49,7 +44,7 @@ impl Mmapper for ByteMapMmapper {
         }
     }
 
-    fn ensure_mapped(&self, start: Address, pages: usize) -> Result<()> {
+    fn ensure_mapped(&self, start: Address, pages: usize, strategy: MmapStrategy) -> Result<()> {
         let start_chunk = Self::address_to_mmap_chunks_down(start);
         let end_chunk = Self::address_to_mmap_chunks_up(start + pages_to_bytes(pages));
         trace!(
@@ -67,18 +62,18 @@ impl Mmapper for ByteMapMmapper {
 
             let mmap_start = Self::mmap_chunks_to_address(chunk);
             let _guard = self.lock.lock().unwrap();
-            MapState::transition_to_mapped(
-                &self.mapped[chunk],
-                mmap_start,
-                self.strategy.load(Ordering::Relaxed),
-            )
-            .unwrap();
+            MapState::transition_to_mapped(&self.mapped[chunk], mmap_start, strategy).unwrap();
         }
 
         Ok(())
     }
 
-    fn quarantine_address_range(&self, start: Address, pages: usize) -> Result<()> {
+    fn quarantine_address_range(
+        &self,
+        start: Address,
+        pages: usize,
+        strategy: MmapStrategy,
+    ) -> Result<()> {
         let start_chunk = Self::address_to_mmap_chunks_down(start);
         let end_chunk = Self::address_to_mmap_chunks_up(start + pages_to_bytes(pages));
         trace!(
@@ -96,12 +91,7 @@ impl Mmapper for ByteMapMmapper {
 
             let mmap_start = Self::mmap_chunks_to_address(chunk);
             let _guard = self.lock.lock().unwrap();
-            MapState::transition_to_quarantined(
-                &self.mapped[chunk],
-                mmap_start,
-                self.strategy.load(Ordering::Relaxed),
-            )
-            .unwrap();
+            MapState::transition_to_quarantined(&self.mapped[chunk], mmap_start, strategy).unwrap();
         }
 
         Ok(())
@@ -149,7 +139,6 @@ impl ByteMapMmapper {
         ByteMapMmapper {
             lock: Mutex::new(()),
             mapped: [INITIAL_ENTRY; MMAP_NUM_CHUNKS],
-            strategy: Atomic::new(MmapStrategy::Normal),
         }
     }
 
@@ -190,7 +179,7 @@ mod tests {
     use crate::util::conversions::pages_to_bytes;
     use crate::util::heap::layout::mmapper::MapState;
     use crate::util::heap::layout::vm_layout::MMAP_CHUNK_BYTES;
-    use crate::util::memory;
+    use crate::util::memory::{self, MmapStrategy};
     use crate::util::test_util::BYTE_MAP_MMAPPER_TEST_REGION;
     use crate::util::test_util::{serial_test, with_cleanup};
     use std::sync::atomic::Ordering;
@@ -247,7 +236,9 @@ mod tests {
             with_cleanup(
                 || {
                     let mmapper = ByteMapMmapper::new();
-                    mmapper.ensure_mapped(FIXED_ADDRESS, pages).unwrap();
+                    mmapper
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .unwrap();
 
                     for chunk in start_chunk..end_chunk {
                         assert_eq!(
@@ -274,7 +265,9 @@ mod tests {
             with_cleanup(
                 || {
                     let mmapper = ByteMapMmapper::new();
-                    mmapper.ensure_mapped(FIXED_ADDRESS, pages).unwrap();
+                    mmapper
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .unwrap();
 
                     for chunk in start_chunk..end_chunk {
                         assert_eq!(
@@ -301,7 +294,9 @@ mod tests {
             with_cleanup(
                 || {
                     let mmapper = ByteMapMmapper::new();
-                    mmapper.ensure_mapped(FIXED_ADDRESS, pages).unwrap();
+                    mmapper
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .unwrap();
 
                     let start_chunk = ByteMapMmapper::address_to_mmap_chunks_down(FIXED_ADDRESS);
                     let end_chunk = ByteMapMmapper::address_to_mmap_chunks_up(
@@ -334,7 +329,11 @@ mod tests {
                     // map 2 chunks
                     let mmapper = ByteMapMmapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, test_memory_pages)
+                        .ensure_mapped(
+                            FIXED_ADDRESS,
+                            test_memory_pages,
+                            MmapStrategy::test_strategy(),
+                        )
                         .unwrap();
 
                     // protect 1 chunk
@@ -369,7 +368,11 @@ mod tests {
                     // map 2 chunks
                     let mmapper = ByteMapMmapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, test_memory_pages)
+                        .ensure_mapped(
+                            FIXED_ADDRESS,
+                            test_memory_pages,
+                            MmapStrategy::test_strategy(),
+                        )
                         .unwrap();
 
                     // protect 1 chunk
@@ -387,7 +390,11 @@ mod tests {
 
                     // ensure mapped - this will unprotect the previously protected chunk
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, protect_memory_pages_2)
+                        .ensure_mapped(
+                            FIXED_ADDRESS,
+                            protect_memory_pages_2,
+                            MmapStrategy::test_strategy(),
+                        )
                         .unwrap();
                     assert_eq!(
                         mmapper.mapped[chunk].load(Ordering::Relaxed),

--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -533,11 +533,7 @@ mod tests {
                     let mmapper = FragmentedMapper::new();
                     let pages_per_chunk = MMAP_CHUNK_BYTES >> LOG_BYTES_IN_PAGE as usize;
                     mmapper
-                        .ensure_mapped(
-                            FIXED_ADDRESS,
-                            pages_per_chunk * 2,
-                            MmapStrategy::TEST,
-                        )
+                        .ensure_mapped(FIXED_ADDRESS, pages_per_chunk * 2, MmapStrategy::TEST)
                         .unwrap();
 
                     // protect 1 chunk
@@ -568,11 +564,7 @@ mod tests {
                     let mmapper = FragmentedMapper::new();
                     let pages_per_chunk = MMAP_CHUNK_BYTES >> LOG_BYTES_IN_PAGE as usize;
                     mmapper
-                        .ensure_mapped(
-                            FIXED_ADDRESS,
-                            pages_per_chunk * 2,
-                            MmapStrategy::TEST,
-                        )
+                        .ensure_mapped(FIXED_ADDRESS, pages_per_chunk * 2, MmapStrategy::TEST)
                         .unwrap();
 
                     // protect 1 chunk
@@ -589,11 +581,7 @@ mod tests {
 
                     // ensure mapped - this will unprotect the previously protected chunk
                     mmapper
-                        .ensure_mapped(
-                            FIXED_ADDRESS,
-                            pages_per_chunk * 2,
-                            MmapStrategy::TEST,
-                        )
+                        .ensure_mapped(FIXED_ADDRESS, pages_per_chunk * 2, MmapStrategy::TEST)
                         .unwrap();
                     assert_eq!(
                         get_chunk_map_state(&mmapper, FIXED_ADDRESS),

--- a/src/util/heap/layout/fragmented_mapper.rs
+++ b/src/util/heap/layout/fragmented_mapper.rs
@@ -446,7 +446,7 @@ mod tests {
                 || {
                     let mmapper = FragmentedMapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST)
                         .unwrap();
 
                     let chunks = pages_to_chunks_up(pages);
@@ -474,7 +474,7 @@ mod tests {
                 || {
                     let mmapper = FragmentedMapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST)
                         .unwrap();
 
                     let chunks = pages_to_chunks_up(pages);
@@ -503,7 +503,7 @@ mod tests {
                 || {
                     let mmapper = FragmentedMapper::new();
                     mmapper
-                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::test_strategy())
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST)
                         .unwrap();
 
                     let chunks = pages_to_chunks_up(pages);
@@ -536,7 +536,7 @@ mod tests {
                         .ensure_mapped(
                             FIXED_ADDRESS,
                             pages_per_chunk * 2,
-                            MmapStrategy::test_strategy(),
+                            MmapStrategy::TEST,
                         )
                         .unwrap();
 
@@ -571,7 +571,7 @@ mod tests {
                         .ensure_mapped(
                             FIXED_ADDRESS,
                             pages_per_chunk * 2,
-                            MmapStrategy::test_strategy(),
+                            MmapStrategy::TEST,
                         )
                         .unwrap();
 
@@ -592,7 +592,7 @@ mod tests {
                         .ensure_mapped(
                             FIXED_ADDRESS,
                             pages_per_chunk * 2,
-                            MmapStrategy::test_strategy(),
+                            MmapStrategy::TEST,
                         )
                         .unwrap();
                     assert_eq!(

--- a/src/util/heap/layout/map64.rs
+++ b/src/util/heap/layout/map64.rs
@@ -100,7 +100,7 @@ impl VMMap for Map64 {
             units as _,
             grain,
             heads,
-            MmapStrategy::internal_memory_strategy(),
+            MmapStrategy::INTERNAL_MEMORY,
         ));
 
         /* Adjust the base address and highwater to account for the allocated chunks for the map */

--- a/src/util/heap/layout/map64.rs
+++ b/src/util/heap/layout/map64.rs
@@ -100,7 +100,7 @@ impl VMMap for Map64 {
             units as _,
             grain,
             heads,
-            MmapStrategy::Normal,
+            MmapStrategy::internal_memory_strategy(),
         ));
 
         /* Adjust the base address and highwater to account for the allocated chunks for the map */

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -144,10 +144,10 @@ pub fn dzmmap_noreplace(start: Address, size: usize, strategy: MmapStrategy) -> 
 /// This function does not reserve swap space for this mapping, which means there is no guarantee that writes to the
 /// mapping can always be successful. In case of out of physical memory, one may get a segfault for writing to the mapping.
 /// We can use this to reserve the address range, and then later overwrites the mapping with dzmmap().
-pub fn mmap_noreserve(start: Address, size: usize, mut options: MmapStrategy) -> Result<()> {
-    options.prot = MmapProtection::NoAccess;
+pub fn mmap_noreserve(start: Address, size: usize, mut strategy: MmapStrategy) -> Result<()> {
+    strategy.prot = MmapProtection::NoAccess;
     let flags = MMAP_FLAGS | libc::MAP_NORESERVE;
-    mmap_fixed(start, size, flags, options)
+    mmap_fixed(start, size, flags, strategy)
 }
 
 fn mmap_fixed(

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -5,7 +5,8 @@ use crate::vm::{Collection, VMBinding};
 use bytemuck::NoUninit;
 use libc::{PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
 use std::io::{Error, Result};
-use sysinfo::{RefreshKind, System, SystemExt};
+use sysinfo::MemoryRefreshKind;
+use sysinfo::{RefreshKind, System};
 
 #[allow(unused)]
 const PROT_RW:  libc::c_int = PROT_READ | PROT_WRITE;

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -186,7 +186,7 @@ pub fn handle_mmap_error<VM: VMBinding>(error: Error, tls: VMThread) -> ! {
         }
         _ => {}
     }
-    println!("{}", get_process_memory_maps());
+    eprintln!("{}", get_process_memory_maps());
     panic!("Unexpected mmap failure: {:?}", error)
 }
 

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -346,12 +346,10 @@ mod tests {
         serial_test(|| {
             with_cleanup(
                 || {
-                    let res =
-                        unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
+                    let res = unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
                     assert!(res.is_ok());
                     // We can overwrite with dzmmap
-                    let res =
-                        unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
+                    let res = unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
                     assert!(res.is_ok());
                 },
                 || {
@@ -385,8 +383,7 @@ mod tests {
             with_cleanup(
                 || {
                     // Make sure we mmapped the memory
-                    let res =
-                        unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
+                    let res = unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
                     assert!(res.is_ok());
                     // Use dzmmap_noreplace will fail
                     let res = dzmmap_noreplace(START, BYTES_IN_PAGE, MmapStrategy::TEST);
@@ -407,8 +404,7 @@ mod tests {
                     let res = mmap_noreserve(START, BYTES_IN_PAGE, MmapStrategy::TEST);
                     assert!(res.is_ok());
                     // Try reserve it
-                    let res =
-                        unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
+                    let res = unsafe { dzmmap(START, BYTES_IN_PAGE, MmapStrategy::TEST) };
                     assert!(res.is_ok());
                 },
                 || {
@@ -440,10 +436,7 @@ mod tests {
         serial_test(|| {
             with_cleanup(
                 || {
-                    assert!(
-                        dzmmap_noreplace(START, BYTES_IN_PAGE, MmapStrategy::TEST)
-                            .is_ok()
-                    );
+                    assert!(dzmmap_noreplace(START, BYTES_IN_PAGE, MmapStrategy::TEST).is_ok());
                     panic_if_unmapped(START, BYTES_IN_PAGE);
                 },
                 || {
@@ -461,10 +454,7 @@ mod tests {
             with_cleanup(
                 || {
                     // map 1 page from START
-                    assert!(
-                        dzmmap_noreplace(START, BYTES_IN_PAGE, MmapStrategy::TEST)
-                            .is_ok()
-                    );
+                    assert!(dzmmap_noreplace(START, BYTES_IN_PAGE, MmapStrategy::TEST).is_ok());
 
                     // check if the next page is mapped - which should panic
                     panic_if_unmapped(START + BYTES_IN_PAGE, BYTES_IN_PAGE);
@@ -486,10 +476,7 @@ mod tests {
             with_cleanup(
                 || {
                     // map 1 page from START
-                    assert!(
-                        dzmmap_noreplace(START, BYTES_IN_PAGE, MmapStrategy::TEST)
-                            .is_ok()
-                    );
+                    assert!(dzmmap_noreplace(START, BYTES_IN_PAGE, MmapStrategy::TEST).is_ok());
 
                     // check if the 2 pages from START are mapped. The second page is unmapped, so it should panic.
                     panic_if_unmapped(START, BYTES_IN_PAGE * 2);

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -59,10 +59,6 @@ pub enum MmapProtection {
     ReadWrite,
     /// Allow read + write + code execution
     ReadWriteExec,
-    /// Allow read + code executiojn
-    ReadExec,
-    /// Allow read only
-    ReadOnly,
     /// Do not allow any access
     NoAccess,
 }
@@ -72,9 +68,7 @@ impl MmapProtection {
     pub fn into_native_flags(self) -> libc::c_int {
         match self {
             Self::ReadWrite => PROT_READ | PROT_WRITE,
-            Self::ReadWriteExec => PROT_READ | PROT_EXEC,
-            Self::ReadExec => PROT_READ | PROT_WRITE | PROT_EXEC,
-            Self::ReadOnly => PROT_READ,
+            Self::ReadWriteExec => PROT_READ | PROT_WRITE | PROT_EXEC,
             Self::NoAccess => PROT_NONE,
         }
     }

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -9,9 +9,9 @@ use sysinfo::MemoryRefreshKind;
 use sysinfo::{RefreshKind, System};
 
 #[allow(unused)]
-const PROT_RW:  libc::c_int = PROT_READ | PROT_WRITE;
+const PROT_RW: libc::c_int = PROT_READ | PROT_WRITE;
 #[allow(unused)]
-const PROT_RX:  libc::c_int = PROT_READ | PROT_EXEC;
+const PROT_RX: libc::c_int = PROT_READ | PROT_EXEC;
 #[allow(unused)]
 const PROT_RWX: libc::c_int = PROT_READ | PROT_WRITE | PROT_EXEC;
 

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1588,6 +1588,7 @@ mod tests {
 
     use crate::util::heap::layout::vm_layout;
     use crate::util::test_util::{serial_test, with_cleanup};
+    use memory::MmapStrategy;
     use paste::paste;
 
     const TEST_LOG_BYTES_IN_REGION: usize = 12;
@@ -1613,7 +1614,9 @@ mod tests {
 
             let data_addr = vm_layout::vm_layout().heap_start;
             // Make sure the address is mapped.
-            crate::MMAPPER.ensure_mapped(data_addr, 1).unwrap();
+            crate::MMAPPER
+                .ensure_mapped(data_addr, 1, MmapStrategy::test_strategy())
+                .unwrap();
             let meta_addr = address_to_meta_address(&spec, data_addr);
             with_cleanup(
                 || {

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1615,7 +1615,7 @@ mod tests {
             let data_addr = vm_layout::vm_layout().heap_start;
             // Make sure the address is mapped.
             crate::MMAPPER
-                .ensure_mapped(data_addr, 1, MmapStrategy::test_strategy())
+                .ensure_mapped(data_addr, 1, MmapStrategy::TEST)
                 .unwrap();
             let meta_addr = address_to_meta_address(&spec, data_addr);
             with_cleanup(

--- a/src/util/metadata/side_metadata/helpers.rs
+++ b/src/util/metadata/side_metadata/helpers.rs
@@ -109,13 +109,13 @@ pub(super) fn try_mmap_contiguous_metadata_space(
             MMAPPER.ensure_mapped(
                 mmap_start,
                 mmap_size >> LOG_BYTES_IN_PAGE,
-                MmapStrategy::side_metadata_strategy(),
+                MmapStrategy::SIDE_METADATA,
             )
         } else {
             MMAPPER.quarantine_address_range(
                 mmap_start,
                 mmap_size >> LOG_BYTES_IN_PAGE,
-                MmapStrategy::side_metadata_strategy(),
+                MmapStrategy::SIDE_METADATA,
             )
         }
         .map(|_| mmap_size)

--- a/src/util/metadata/side_metadata/helpers.rs
+++ b/src/util/metadata/side_metadata/helpers.rs
@@ -2,6 +2,7 @@ use super::SideMetadataSpec;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
 use crate::util::constants::{BITS_IN_WORD, BYTES_IN_PAGE, LOG_BITS_IN_BYTE};
 use crate::util::heap::layout::vm_layout::VMLayout;
+use crate::util::memory::MmapStrategy;
 #[cfg(target_pointer_width = "32")]
 use crate::util::metadata::side_metadata::address_to_chunked_meta_address;
 use crate::util::Address;
@@ -105,9 +106,17 @@ pub(super) fn try_mmap_contiguous_metadata_space(
     let mmap_size = (metadata_start + metadata_size).align_up(BYTES_IN_PAGE) - mmap_start;
     if mmap_size > 0 {
         if !no_reserve {
-            MMAPPER.ensure_mapped(mmap_start, mmap_size >> LOG_BYTES_IN_PAGE)
+            MMAPPER.ensure_mapped(
+                mmap_start,
+                mmap_size >> LOG_BYTES_IN_PAGE,
+                MmapStrategy::side_metadata_strategy(),
+            )
         } else {
-            MMAPPER.quarantine_address_range(mmap_start, mmap_size >> LOG_BYTES_IN_PAGE)
+            MMAPPER.quarantine_address_range(
+                mmap_start,
+                mmap_size >> LOG_BYTES_IN_PAGE,
+                MmapStrategy::side_metadata_strategy(),
+            )
         }
         .map(|_| mmap_size)
     } else {

--- a/src/util/metadata/side_metadata/helpers_32.rs
+++ b/src/util/metadata/side_metadata/helpers_32.rs
@@ -181,8 +181,16 @@ pub(super) fn try_mmap_metadata_chunk(
     let pages = crate::util::conversions::bytes_to_pages_up(local_per_chunk);
     if !no_reserve {
         // We have reserved the memory
-        MMAPPER.ensure_mapped(policy_meta_start, pages)
+        MMAPPER.ensure_mapped(
+            policy_meta_start,
+            pages,
+            memory::MmapStrategy::side_metadata_strategy(),
+        )
     } else {
-        MMAPPER.quarantine_address_range(policy_meta_start, pages)
+        MMAPPER.quarantine_address_range(
+            policy_meta_start,
+            pages,
+            memory::MmapStrategy::side_metadata_strategy(),
+        )
     }
 }

--- a/src/util/metadata/side_metadata/helpers_32.rs
+++ b/src/util/metadata/side_metadata/helpers_32.rs
@@ -184,13 +184,13 @@ pub(super) fn try_mmap_metadata_chunk(
         MMAPPER.ensure_mapped(
             policy_meta_start,
             pages,
-            memory::MmapStrategy::side_metadata_strategy(),
+            memory::MmapStrategy::SIDE_METADATA,
         )
     } else {
         MMAPPER.quarantine_address_range(
             policy_meta_start,
             pages,
-            memory::MmapStrategy::side_metadata_strategy(),
+            memory::MmapStrategy::SIDE_METADATA,
         )
     }
 }

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -862,7 +862,8 @@ options! {
     /// Set the GC trigger. This defines the heap size and how MMTk triggers a GC.
     /// Default to a fixed heap size of 0.5x physical memory.
     gc_trigger:             GCTriggerSelector    [env_var: true, command_line: true] [|v: &GCTriggerSelector| v.validate()] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.5f64) as usize),
-    /// Enable transparent hugepage support via madvise (only Linux is supported)
+    /// Enable transparent hugepage support for MMTk spaces via madvise (only Linux is supported)
+    /// This only affects the memory for MMTk spaces.
     transparent_hugepages: bool                  [env_var: true, command_line: true]  [|v: &bool| !v || cfg!(target_os = "linux")] = false
 }
 

--- a/src/util/raw_memory_freelist.rs
+++ b/src/util/raw_memory_freelist.rs
@@ -273,7 +273,7 @@ mod tests {
             list_size as _,
             grain,
             1,
-            MmapStrategy::Normal,
+            MmapStrategy::test_strategy(),
         );
         // Grow the free-list to do the actual memory-mapping.
         l.grow_freelist(list_size as _);

--- a/src/util/raw_memory_freelist.rs
+++ b/src/util/raw_memory_freelist.rs
@@ -273,7 +273,7 @@ mod tests {
             list_size as _,
             grain,
             1,
-            MmapStrategy::test_strategy(),
+            MmapStrategy::TEST,
         );
         // Grow the free-list to do the actual memory-mapping.
         l.grow_freelist(list_size as _);

--- a/src/vm/tests/mock_tests/mock_test_handle_mmap_conflict.rs
+++ b/src/vm/tests/mock_tests/mock_test_handle_mmap_conflict.rs
@@ -11,19 +11,13 @@ pub fn test_handle_mmap_conflict() {
         || {
             let start = unsafe { Address::from_usize(0x100_0000) };
             let one_megabyte = 1000000;
-            let mmap1_res = memory::dzmmap_noreplace(
-                start,
-                one_megabyte,
-                memory::MmapStrategy::TEST,
-            );
+            let mmap1_res =
+                memory::dzmmap_noreplace(start, one_megabyte, memory::MmapStrategy::TEST);
             assert!(mmap1_res.is_ok());
 
             let panic_res = std::panic::catch_unwind(|| {
-                let mmap2_res = memory::dzmmap_noreplace(
-                    start,
-                    one_megabyte,
-                    memory::MmapStrategy::TEST,
-                );
+                let mmap2_res =
+                    memory::dzmmap_noreplace(start, one_megabyte, memory::MmapStrategy::TEST);
                 assert!(mmap2_res.is_err());
                 memory::handle_mmap_error::<MockVM>(
                     mmap2_res.err().unwrap(),

--- a/src/vm/tests/mock_tests/mock_test_handle_mmap_conflict.rs
+++ b/src/vm/tests/mock_tests/mock_test_handle_mmap_conflict.rs
@@ -14,7 +14,7 @@ pub fn test_handle_mmap_conflict() {
             let mmap1_res = memory::dzmmap_noreplace(
                 start,
                 one_megabyte,
-                memory::MmapStrategy::test_strategy(),
+                memory::MmapStrategy::TEST,
             );
             assert!(mmap1_res.is_ok());
 
@@ -22,7 +22,7 @@ pub fn test_handle_mmap_conflict() {
                 let mmap2_res = memory::dzmmap_noreplace(
                     start,
                     one_megabyte,
-                    memory::MmapStrategy::test_strategy(),
+                    memory::MmapStrategy::TEST,
                 );
                 assert!(mmap2_res.is_err());
                 memory::handle_mmap_error::<MockVM>(

--- a/src/vm/tests/mock_tests/mock_test_handle_mmap_conflict.rs
+++ b/src/vm/tests/mock_tests/mock_test_handle_mmap_conflict.rs
@@ -11,13 +11,19 @@ pub fn test_handle_mmap_conflict() {
         || {
             let start = unsafe { Address::from_usize(0x100_0000) };
             let one_megabyte = 1000000;
-            let mmap1_res =
-                memory::dzmmap_noreplace(start, one_megabyte, memory::MmapStrategy::Normal);
+            let mmap1_res = memory::dzmmap_noreplace(
+                start,
+                one_megabyte,
+                memory::MmapStrategy::test_strategy(),
+            );
             assert!(mmap1_res.is_ok());
 
             let panic_res = std::panic::catch_unwind(|| {
-                let mmap2_res =
-                    memory::dzmmap_noreplace(start, one_megabyte, memory::MmapStrategy::Normal);
+                let mmap2_res = memory::dzmmap_noreplace(
+                    start,
+                    one_megabyte,
+                    memory::MmapStrategy::test_strategy(),
+                );
                 assert!(mmap2_res.is_err());
                 memory::handle_mmap_error::<MockVM>(
                     mmap2_res.err().unwrap(),

--- a/src/vm/tests/mock_tests/mock_test_handle_mmap_oom.rs
+++ b/src/vm/tests/mock_tests/mock_test_handle_mmap_oom.rs
@@ -18,8 +18,11 @@ pub fn test_handle_mmap_oom() {
                 let start = unsafe { Address::from_usize(0x100_0000) };
                 // mmap 1 terabyte memory - we expect this will fail due to out of memory.
                 // If that's not the case, increase the size we mmap.
-                let mmap_res =
-                    memory::dzmmap_noreplace(start, LARGE_SIZE, memory::MmapStrategy::Normal);
+                let mmap_res = memory::dzmmap_noreplace(
+                    start,
+                    LARGE_SIZE,
+                    memory::MmapStrategy::test_strategy(),
+                );
 
                 memory::handle_mmap_error::<MockVM>(
                     mmap_res.err().unwrap(),

--- a/src/vm/tests/mock_tests/mock_test_handle_mmap_oom.rs
+++ b/src/vm/tests/mock_tests/mock_test_handle_mmap_oom.rs
@@ -18,11 +18,8 @@ pub fn test_handle_mmap_oom() {
                 let start = unsafe { Address::from_usize(0x100_0000) };
                 // mmap 1 terabyte memory - we expect this will fail due to out of memory.
                 // If that's not the case, increase the size we mmap.
-                let mmap_res = memory::dzmmap_noreplace(
-                    start,
-                    LARGE_SIZE,
-                    memory::MmapStrategy::TEST,
-                );
+                let mmap_res =
+                    memory::dzmmap_noreplace(start, LARGE_SIZE, memory::MmapStrategy::TEST);
 
                 memory::handle_mmap_error::<MockVM>(
                     mmap_res.err().unwrap(),

--- a/src/vm/tests/mock_tests/mock_test_handle_mmap_oom.rs
+++ b/src/vm/tests/mock_tests/mock_test_handle_mmap_oom.rs
@@ -21,7 +21,7 @@ pub fn test_handle_mmap_oom() {
                 let mmap_res = memory::dzmmap_noreplace(
                     start,
                     LARGE_SIZE,
-                    memory::MmapStrategy::test_strategy(),
+                    memory::MmapStrategy::TEST,
                 );
 
                 memory::handle_mmap_error::<MockVM>(


### PR DESCRIPTION
This PR closes https://github.com/mmtk/mmtk-core/issues/7. This PR
* refactors `MmapStrategy` to include protection flags, and allows each space to pass `Mmapstrategy` to the mmapper.
* removes exec permission from most spaces. Only code spaces will have exec permission.
* adds a feature `exec_permission_on_all_spaces` for bindings that may allocate code into normal spaces.