### PR TITLE
Refactor bulk metadata visiting

### DIFF
--- a/benches/bulk_meta/bzero.rs
+++ b/benches/bulk_meta/bzero.rs
@@ -21,6 +21,13 @@ pub fn bench(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("bzero_bset_modern_callback", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_callback(start, 0, end, 0);
+            SideMetadataSpec::zero_meta_bits_callback(start, 0, end, 0);
+        })
+    });
+
     c.bench_function("bzero_bset_classic", |b| {
         b.iter(|| {
             SideMetadataSpec::set_meta_bits_classic(start, 0, end, 0);

--- a/benches/bulk_meta/bzero.rs
+++ b/benches/bulk_meta/bzero.rs
@@ -1,0 +1,30 @@
+use criterion::Criterion;
+use mmtk::util::{metadata::side_metadata::SideMetadataSpec, Address};
+
+pub fn bench(c: &mut Criterion) {
+    let size = 256usize; // Match an Immix line size.
+
+    let allocate_u32 = || -> Address {
+        let ptr = unsafe {
+            std::alloc::alloc_zeroed(std::alloc::Layout::from_size_align(size, 8).unwrap())
+        };
+        Address::from_mut_ptr(ptr)
+    };
+
+    let start = allocate_u32();
+    let end = start + size;
+
+    c.bench_function("bzero_bset_modern", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits(start, 0, end, 0);
+            SideMetadataSpec::zero_meta_bits(start, 0, end, 0);
+        })
+    });
+
+    c.bench_function("bzero_bset_classic", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_classic(start, 0, end, 0);
+            SideMetadataSpec::zero_meta_bits_classic(start, 0, end, 0);
+        })
+    });
+}

--- a/benches/bulk_meta/bzero.rs
+++ b/benches/bulk_meta/bzero.rs
@@ -1,5 +1,8 @@
 use criterion::Criterion;
-use mmtk::util::{metadata::side_metadata::SideMetadataSpec, Address};
+use mmtk::util::{
+    metadata::side_metadata::{grain::AddressToBitAddress, SideMetadataSpec},
+    Address,
+};
 
 pub fn bench(c: &mut Criterion) {
     let size = 256usize; // Match an Immix line size.
@@ -13,18 +16,34 @@ pub fn bench(c: &mut Criterion) {
 
     let start = allocate_u32();
     let end = start + size;
+    let start_ba = start.with_bit_offset(0);
+    let end_ba = end.with_bit_offset(0);
 
-    c.bench_function("bzero_bset_modern", |b| {
+    c.bench_function("bzero_bset_modern_64", |b| {
         b.iter(|| {
-            SideMetadataSpec::set_meta_bits(start, 0, end, 0);
-            SideMetadataSpec::zero_meta_bits(start, 0, end, 0);
+            SideMetadataSpec::set_meta_bits_modern_inner::<u64, false>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, false>(start_ba, end_ba);
         })
     });
 
-    c.bench_function("bzero_bset_modern_callback", |b| {
+    c.bench_function("bzero_bset_modern_64_callback", |b| {
         b.iter(|| {
-            SideMetadataSpec::set_meta_bits_callback(start, 0, end, 0);
-            SideMetadataSpec::zero_meta_bits_callback(start, 0, end, 0);
+            SideMetadataSpec::set_meta_bits_modern_inner::<u64, true>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, true>(start_ba, end_ba);
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_32", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u32, false>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, false>(start_ba, end_ba);
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_32_callback", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u32, true>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, true>(start_ba, end_ba);
         })
     });
 

--- a/benches/bulk_meta/bzero.rs
+++ b/benches/bulk_meta/bzero.rs
@@ -1,56 +1,160 @@
 use criterion::Criterion;
 use mmtk::util::{
+    constants::{BITS_IN_BYTE, BYTES_IN_WORD},
     metadata::side_metadata::{grain::AddressToBitAddress, SideMetadataSpec},
     Address,
 };
 
 pub fn bench(c: &mut Criterion) {
-    let size = 256usize; // Match an Immix line size.
+    let data_bytes = 256usize; // Match an Immix line size.
+    let meta_bits = data_bytes / BYTES_IN_WORD;
+    let meta_bytes = meta_bits / BITS_IN_BYTE;
 
     let allocate_u32 = || -> Address {
         let ptr = unsafe {
-            std::alloc::alloc_zeroed(std::alloc::Layout::from_size_align(size, 8).unwrap())
+            std::alloc::alloc_zeroed(std::alloc::Layout::from_size_align(meta_bytes, 8).unwrap())
         };
         Address::from_mut_ptr(ptr)
     };
 
     let start = allocate_u32();
-    let end = start + size;
+    let end = start + meta_bytes;
     let start_ba = start.with_bit_offset(0);
     let end_ba = end.with_bit_offset(0);
 
     c.bench_function("bzero_bset_modern_64", |b| {
         b.iter(|| {
-            SideMetadataSpec::set_meta_bits_modern_inner::<u64, false>(start_ba, end_ba);
-            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, false>(start_ba, end_ba);
+            SideMetadataSpec::set_meta_bits_modern_inner::<u64, false, false, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, false, false, false>(
+                start_ba, end_ba,
+            );
         })
     });
 
     c.bench_function("bzero_bset_modern_64_callback", |b| {
         b.iter(|| {
-            SideMetadataSpec::set_meta_bits_modern_inner::<u64, true>(start_ba, end_ba);
-            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, true>(start_ba, end_ba);
+            SideMetadataSpec::set_meta_bits_modern_inner::<u64, true, false, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, true, false, false>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_64_callback_normalize", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u64, true, true, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, true, true, false>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_64_callback_normalize_fastpath", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u64, true, true, true>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u64, true, true, true>(
+                start_ba, end_ba,
+            );
         })
     });
 
     c.bench_function("bzero_bset_modern_32", |b| {
         b.iter(|| {
-            SideMetadataSpec::set_meta_bits_modern_inner::<u32, false>(start_ba, end_ba);
-            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, false>(start_ba, end_ba);
+            SideMetadataSpec::set_meta_bits_modern_inner::<u32, false, false, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, false, false, false>(
+                start_ba, end_ba,
+            );
         })
     });
 
     c.bench_function("bzero_bset_modern_32_callback", |b| {
         b.iter(|| {
-            SideMetadataSpec::set_meta_bits_modern_inner::<u32, true>(start_ba, end_ba);
-            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, true>(start_ba, end_ba);
+            SideMetadataSpec::set_meta_bits_modern_inner::<u32, true, false, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, true, false, false>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_32_callback_normalize", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u32, true, true, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, true, true, false>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_32_callback_normalize_fastpath", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u32, true, true, true>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u32, true, true, true>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_8", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u8, false, false, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u8, false, false, false>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_8_callback", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u8, true, false, false>(
+                start_ba, end_ba,
+            );
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u8, true, false, false>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_8_callback_normalize", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u8, true, true, false>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u8, true, true, false>(
+                start_ba, end_ba,
+            );
+        })
+    });
+
+    c.bench_function("bzero_bset_modern_8_callback_normalize_fastpath", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_modern_inner::<u8, true, true, true>(start_ba, end_ba);
+            SideMetadataSpec::zero_meta_bits_modern_inner::<u8, true, true, true>(start_ba, end_ba);
         })
     });
 
     c.bench_function("bzero_bset_classic", |b| {
         b.iter(|| {
-            SideMetadataSpec::set_meta_bits_classic(start, 0, end, 0);
-            SideMetadataSpec::zero_meta_bits_classic(start, 0, end, 0);
+            SideMetadataSpec::set_meta_bits_classic::<false>(start, 0, end, 0);
+            SideMetadataSpec::zero_meta_bits_classic::<false>(start, 0, end, 0);
+        })
+    });
+
+    c.bench_function("bzero_bset_classic_fast", |b| {
+        b.iter(|| {
+            SideMetadataSpec::set_meta_bits_classic::<true>(start, 0, end, 0);
+            SideMetadataSpec::zero_meta_bits_classic::<true>(start, 0, end, 0);
         })
     });
 }

--- a/benches/bulk_meta/mod.rs
+++ b/benches/bulk_meta/mod.rs
@@ -1,0 +1,1 @@
+pub mod bzero;

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -19,6 +19,8 @@ use criterion::Criterion;
 // However, I will just keep these benchmarks here. If we find it not useful, and we do not plan to improve MockVM, we can delete
 // them.
 
+mod bulk_meta;
+
 #[cfg(feature = "mock_test")]
 mod mock_bench;
 
@@ -29,15 +31,17 @@ pub fn bench_main(_c: &mut Criterion) {
             "alloc" => mock_bench::alloc::bench(_c),
             "internal_pointer" => mock_bench::internal_pointer::bench(_c),
             "sft" => mock_bench::sft::bench(_c),
-            _ => panic!("Unknown benchmark {:?}", bench),
+            _ => {} // Fall back to non-mock test.
         },
         Err(_) => panic!("Need to name a benchmark by the env var MMTK_BENCH"),
     }
 
-    #[cfg(not(feature = "mock_test"))]
-    {
-        eprintln!("ERROR: Currently there are no benchmarks when the \"mock_test\" feature is not enabled.");
-        std::process::exit(1);
+    match std::env::var("MMTK_BENCH") {
+        Ok(bench) => match bench.as_str() {
+            "bzero" => bulk_meta::bzero::bench(_c),
+            _ => panic!("Unknown benchmark {:?}", bench),
+        },
+        Err(_) => panic!("Need to name a benchmark by the env var MMTK_BENCH"),
     }
 }
 

--- a/src/util/metadata/side_metadata/grain.rs
+++ b/src/util/metadata/side_metadata/grain.rs
@@ -1,0 +1,159 @@
+//! Mechanisms for breaking a range in a bitmap into whole-grain and sub-grain ranges to maximize
+//! bulk bitmap access.
+//!
+//! In this module, the term "grain" refers to the unit at which we access a bitmap. It can be a
+//! byte (u8), a word (usize) or other power-of-two byte sizes.
+//!
+//! The `std::simd` module is still a nightly feature as of Rust 1.79.  When it stablizes, we can
+//! allow the granularity to be a SIMD vector, too.
+
+use num_traits::Num;
+
+use crate::util::{constants::BITS_IN_BYTE, Address};
+
+/// Offset of bits in a grain.
+type BitOffset = usize;
+
+/// Bit address within a grain.
+#[derive(Debug, Clone, Copy)]
+pub struct BitAddress {
+    pub addr: Address,
+    pub bit: BitOffset,
+}
+
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+pub struct Granularity {
+    log_bytes: usize,
+}
+
+impl Granularity {
+    pub const fn of_log_bytes(log_bytes: usize) -> Self {
+        Self { log_bytes }
+    }
+
+    pub const fn of_log_bits(log_bits: usize) -> Self {
+        Self {
+            log_bytes: log_bits >> BITS_IN_BYTE,
+        }
+    }
+
+    pub fn of_type<T: Num>() -> Self {
+        let bytes = std::mem::size_of::<T>();
+        let log_bytes = bytes.ilog2() as usize;
+
+        debug_assert_eq!(1 << log_bytes, bytes, "Not power-of-two size: {bytes}");
+
+        Self::of_log_bytes(log_bytes)
+    }
+
+    pub const fn log_bytes(&self) -> usize {
+        self.log_bytes
+    }
+
+    pub const fn log_bits(&self) -> usize {
+        self.log_bytes() << BITS_IN_BYTE
+    }
+
+    pub const fn bytes(&self) -> usize {
+        1 << self.log_bytes()
+    }
+
+    pub const fn bits(&self) -> usize {
+        1 << self.log_bits()
+    }
+}
+
+impl BitAddress {
+    pub fn is_grain_aligned(&self, granularity: Granularity) -> bool {
+        self.bit == 0 && self.addr.is_aligned_to(granularity.bytes())
+    }
+
+    pub fn is_normalized(&self, granularity: Granularity) -> bool {
+        self.addr.is_aligned_to(granularity.bytes()) && self.bit < granularity.bytes()
+    }
+
+    pub fn normalize(&self, granularity: Granularity) -> Self {
+        let addr = self.addr.align_down(granularity.bytes());
+        let rem_bytes = addr.as_usize() % granularity.bytes();
+        let bit = self.bit + rem_bytes * BITS_IN_BYTE;
+        Self { addr, bit }
+    }
+
+    pub fn align_down_to_grain(&self, granularity: Granularity) -> Address {
+        debug_assert!(self.is_normalized(granularity));
+        self.addr.align_down(granularity.bytes())
+    }
+
+    pub fn align_up_to_grain(&self, granularity: Granularity) -> Address {
+        debug_assert!(self.is_normalized(granularity));
+        if self.bit == 0 {
+            (self.addr + 1usize).align_up(granularity.bytes())
+        } else {
+            self.addr.align_up(granularity.bytes())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum VisitRange {
+    WholeGrain {
+        start: Address,
+        end: Address,
+    },
+    SubGrain {
+        addr: Address,
+        bit_start: BitOffset,
+        bit_end: BitOffset,
+    },
+}
+
+pub fn break_range(
+    granularity: Granularity,
+    start: BitAddress,
+    end: BitAddress,
+) -> Vec<VisitRange> {
+    debug_assert!(
+        start.is_normalized(granularity),
+        "{start:?} is not normalized for {granularity:?}"
+    );
+    debug_assert!(
+        end.is_normalized(granularity),
+        "{end:?} is not normalized for {granularity:?}"
+    );
+
+    if start.addr == end.addr {
+        // The start and the end are in the same grain.  Yield only one SubGrain range.
+        return vec![VisitRange::SubGrain {
+            addr: start.addr,
+            bit_start: start.bit,
+            bit_end: end.bit,
+        }];
+    }
+
+    // Start with a sub-grain range if the start is not aligned.
+    let start_subgrain = (!start.is_grain_aligned(granularity)).then(|| VisitRange::SubGrain {
+        addr: start.addr,
+        bit_start: start.bit,
+        bit_end: granularity.bits(),
+    });
+
+    // Yield a whole-grain in the middle if long enough.
+    let start_whole = start.align_up_to_grain(granularity);
+    let end_whole = end.align_down_to_grain(granularity);
+    let whole = (start_whole < end_whole).then(|| VisitRange::WholeGrain {
+        start: start_whole,
+        end: end_whole,
+    });
+
+    // Finally yield a sub-grain range in the end if not aligned.
+    let end_subgrain = (!end.is_grain_aligned(granularity)).then(|| VisitRange::SubGrain {
+        addr: end.addr,
+        bit_start: 0,
+        bit_end: end.bit,
+    });
+
+    [start_subgrain, whole, end_subgrain]
+        .into_iter()
+        .flatten()
+        .collect()
+}

--- a/src/util/metadata/side_metadata/grain.rs
+++ b/src/util/metadata/side_metadata/grain.rs
@@ -7,19 +7,15 @@
 //! The `std::simd` module is still a nightly feature as of Rust 1.79.  When it stablizes, we can
 //! allow the granularity to be a SIMD vector, too.
 
-use num_traits::Num;
+use num_traits::{Num, PrimInt};
 
-use crate::util::{constants::BITS_IN_BYTE, Address};
+use crate::util::{
+    constants::{BITS_IN_BYTE, LOG_BITS_IN_BYTE},
+    Address,
+};
 
 /// Offset of bits in a grain.
 type BitOffset = usize;
-
-/// Bit address within a grain.
-#[derive(Debug, Clone, Copy)]
-pub struct BitAddress {
-    pub addr: Address,
-    pub bit: BitOffset,
-}
 
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Granularity {
@@ -33,16 +29,13 @@ impl Granularity {
 
     pub const fn of_log_bits(log_bits: usize) -> Self {
         Self {
-            log_bytes: log_bits >> BITS_IN_BYTE,
+            log_bytes: log_bits >> LOG_BITS_IN_BYTE,
         }
     }
 
-    pub fn of_type<T: Num>() -> Self {
+    pub const fn of_type<T: Num>() -> Self {
         let bytes = std::mem::size_of::<T>();
         let log_bytes = bytes.ilog2() as usize;
-
-        debug_assert_eq!(1 << log_bytes, bytes, "Not power-of-two size: {bytes}");
-
         Self::of_log_bytes(log_bytes)
     }
 
@@ -51,7 +44,7 @@ impl Granularity {
     }
 
     pub const fn log_bits(&self) -> usize {
-        self.log_bytes() << BITS_IN_BYTE
+        self.log_bytes() + LOG_BITS_IN_BYTE as usize
     }
 
     pub const fn bytes(&self) -> usize {
@@ -63,13 +56,20 @@ impl Granularity {
     }
 }
 
+/// Bit address within a grain.
+#[derive(Debug, Clone, Copy)]
+pub struct BitAddress {
+    pub addr: Address,
+    pub bit: BitOffset,
+}
+
 impl BitAddress {
     pub fn is_grain_aligned(&self, granularity: Granularity) -> bool {
         self.bit == 0 && self.addr.is_aligned_to(granularity.bytes())
     }
 
     pub fn is_normalized(&self, granularity: Granularity) -> bool {
-        self.addr.is_aligned_to(granularity.bytes()) && self.bit < granularity.bytes()
+        self.addr.is_aligned_to(granularity.bytes()) && self.bit < granularity.bits()
     }
 
     pub fn normalize(&self, granularity: Granularity) -> Self {
@@ -86,7 +86,7 @@ impl BitAddress {
 
     pub fn align_up_to_grain(&self, granularity: Granularity) -> Address {
         debug_assert!(self.is_normalized(granularity));
-        if self.bit == 0 {
+        if self.bit > 0 {
             (self.addr + 1usize).align_up(granularity.bytes())
         } else {
             self.addr.align_up(granularity.bytes())
@@ -94,7 +94,20 @@ impl BitAddress {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+pub trait AddressToBitAddress {
+    fn with_bit_offset(&self, offset: BitOffset) -> BitAddress;
+}
+
+impl AddressToBitAddress for Address {
+    fn with_bit_offset(&self, offset: BitOffset) -> BitAddress {
+        BitAddress {
+            addr: *self,
+            bit: offset,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VisitRange {
     WholeGrain {
         start: Address,
@@ -105,6 +118,25 @@ pub enum VisitRange {
         bit_start: BitOffset,
         bit_end: BitOffset,
     },
+}
+
+pub fn bit_mask<T: PrimInt>(granularity: Granularity, bit_start: usize, bit_end: usize) -> T {
+    debug_assert!(
+        bit_start < bit_end,
+        "bit_start ({bit_start}) must be less than bit_end ({bit_end})"
+    );
+    debug_assert!(
+        bit_end <= granularity.bits(),
+        "Bit offset too high.  Granularity is {} bits, bit_end is {}",
+        granularity.bits(),
+        bit_end
+    );
+
+    if bit_end == granularity.bits() {
+        !T::zero() << bit_start
+    } else {
+        (!T::zero() << bit_start) & !(!T::zero() << bit_end)
+    }
 }
 
 pub fn break_range(
@@ -121,13 +153,21 @@ pub fn break_range(
         "{end:?} is not normalized for {granularity:?}"
     );
 
+    warn!("break_range: {granularity:?} {start:?} {end:?}");
+
     if start.addr == end.addr {
-        // The start and the end are in the same grain.  Yield only one SubGrain range.
-        return vec![VisitRange::SubGrain {
-            addr: start.addr,
-            bit_start: start.bit,
-            bit_end: end.bit,
-        }];
+        // The start and the end are in the same grain.
+        if start.bit == end.bit {
+            // Empty.
+            return vec![];
+        } else {
+            // Yield only one SubGrain range.
+            return vec![VisitRange::SubGrain {
+                addr: start.addr,
+                bit_start: start.bit,
+                bit_end: end.bit,
+            }];
+        }
     }
 
     // Start with a sub-grain range if the start is not aligned.
@@ -156,4 +196,214 @@ pub fn break_range(
         .into_iter()
         .flatten()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_addr(addr: usize) -> Address {
+        unsafe { Address::from_usize(addr) }
+    }
+
+    fn mk_ba(addr: usize, bit: usize) -> BitAddress {
+        BitAddress {
+            addr: mk_addr(addr),
+            bit,
+        }
+    }
+
+    const G64BIT: Granularity = Granularity::of_log_bytes(3);
+
+    #[test]
+    fn test_empty_range() {
+        let g = G64BIT;
+        let base = 0x1000;
+        for bit in 0..g.bits() {
+            let ba = mk_ba(base, bit);
+            let result = break_range(g, ba, ba);
+            assert!(
+                result.is_empty(),
+                "Not empty. bit: {bit}, result: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_subgrain_range() {
+        let g = G64BIT;
+        let base = 0x1000;
+        for bit0 in 0..g.bits() {
+            let ba0 = mk_ba(base, bit0);
+            for bit1 in (bit0 + 1)..g.bits() {
+                let ba1 = mk_ba(base, bit1);
+                let result = break_range(g, ba0, ba1);
+                assert_eq!(
+                    result,
+                    vec![VisitRange::SubGrain {
+                        addr: mk_addr(base),
+                        bit_start: bit0,
+                        bit_end: bit1
+                    }],
+                    "Not equal.  bit0: {bit0}, bit1: {bit1}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_end_grain_range() {
+        let g = G64BIT;
+        let base = 0x1000;
+        let ba1 = mk_ba(base + g.bytes(), 0);
+        for bit0 in 1..g.bits() {
+            let ba0 = mk_ba(base, bit0);
+            let result = break_range(g, ba0, ba1);
+            assert_eq!(
+                result,
+                vec![VisitRange::SubGrain {
+                    addr: mk_addr(base),
+                    bit_start: bit0,
+                    bit_end: g.bits()
+                }],
+                "Not equal.  bit0: {bit0}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_adjacent_grain_range() {
+        let g = G64BIT;
+        let base = 0x1000;
+        for bit0 in 1..g.bits() {
+            let ba0 = mk_ba(base, bit0);
+            for bit1 in 1..g.bits() {
+                let ba1 = mk_ba(base + g.bytes(), bit1);
+                let result = break_range(g, ba0, ba1);
+                assert_eq!(
+                    result,
+                    vec![
+                        VisitRange::SubGrain {
+                            addr: mk_addr(base),
+                            bit_start: bit0,
+                            bit_end: g.bits(),
+                        },
+                        VisitRange::SubGrain {
+                            addr: mk_addr(base + g.bytes()),
+                            bit_start: 0,
+                            bit_end: bit1,
+                        },
+                    ],
+                    "Not equal.  bit0: {bit0}, bit1: {bit1}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_left_and_whole_range() {
+        let g = G64BIT;
+        let base = 0x1000;
+        for bit0 in 1..g.bits() {
+            let ba0 = mk_ba(base, bit0);
+            for word1 in 2..8 {
+                let ba1 = mk_ba(base + word1 * g.bytes(), 0);
+                let result = break_range(g, ba0, ba1);
+                assert_eq!(
+                    result,
+                    vec![
+                        VisitRange::SubGrain {
+                            addr: mk_addr(base),
+                            bit_start: bit0,
+                            bit_end: g.bits(),
+                        },
+                        VisitRange::WholeGrain {
+                            start: mk_addr(base + g.bytes()),
+                            end: mk_addr(base + word1 * g.bytes()),
+                        },
+                    ],
+                    "Not equal.  bit0: {bit0}, word1: {word1}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_whole_and_right_range() {
+        let g = G64BIT;
+        let base = 0x1000;
+        for word0 in 1..8 {
+            let ba0 = mk_ba(base - word0 * g.bytes(), 0);
+            for bit1 in 1..g.bits() {
+                let ba1 = mk_ba(base, bit1);
+                let result = break_range(g, ba0, ba1);
+                assert_eq!(
+                    result,
+                    vec![
+                        VisitRange::WholeGrain {
+                            start: mk_addr(base - word0 * g.bytes()),
+                            end: mk_addr(base),
+                        },
+                        VisitRange::SubGrain {
+                            addr: mk_addr(base),
+                            bit_start: 0,
+                            bit_end: bit1,
+                        },
+                    ],
+                    "Not equal.  word0: {word0}, bit1: {bit1}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_whole_range() {
+        let g = G64BIT;
+        let base = 0x1000;
+        let ba0 = mk_ba(base, 0);
+        let ba1 = mk_ba(base + 42 * g.bytes(), 0);
+        let result = break_range(g, ba0, ba1);
+        assert_eq!(
+            result,
+            vec![VisitRange::WholeGrain {
+                start: mk_addr(base),
+                end: mk_addr(base + 42 * g.bytes()),
+            },],
+        );
+    }
+
+    #[test]
+    fn test_left_whole_right_range() {
+        let g = G64BIT;
+        let base0 = 0x1000;
+        let base1 = 0x2000;
+
+        for bit0 in 1..g.bits() {
+            let ba0 = mk_ba(base0 - g.bytes(), bit0);
+            for bit1 in 1..g.bits() {
+                let ba1 = mk_ba(base1, bit1);
+                let result = break_range(g, ba0, ba1);
+                assert_eq!(
+                    result,
+                    vec![
+                        VisitRange::SubGrain {
+                            addr: mk_addr(base0 - g.bytes()),
+                            bit_start: bit0,
+                            bit_end: g.bits(),
+                        },
+                        VisitRange::WholeGrain {
+                            start: mk_addr(base0),
+                            end: mk_addr(base1),
+                        },
+                        VisitRange::SubGrain {
+                            addr: mk_addr(base1),
+                            bit_start: 0,
+                            bit_end: bit1,
+                        },
+                    ],
+                    "Not equal.  bit0: {bit0}, bit1: {bit1}",
+                );
+            }
+        }
+    }
 }

--- a/src/util/metadata/side_metadata/grain.rs
+++ b/src/util/metadata/side_metadata/grain.rs
@@ -70,6 +70,10 @@ impl BitAddress {
     }
 
     pub fn normalize(&self, granularity: Granularity) -> Self {
+        if self.is_normalized(granularity) {
+            return *self;
+        }
+
         // Transfer unaligned bytes from addr to bits
         let aligned_addr = self.addr.align_down(granularity.bytes());
         let rem_bytes = self.addr - aligned_addr;

--- a/src/util/metadata/side_metadata/mod.rs
+++ b/src/util/metadata/side_metadata/mod.rs
@@ -2,7 +2,7 @@
 // For convenience, this module is public and the bindings may create and use side metadata for their purpose.
 
 mod constants;
-mod grain;
+pub mod grain;
 mod helpers;
 #[cfg(target_pointer_width = "32")]
 mod helpers_32;

--- a/src/util/metadata/side_metadata/mod.rs
+++ b/src/util/metadata/side_metadata/mod.rs
@@ -1,6 +1,7 @@
 //! This module provides an implementation of side table metadata.
 // For convenience, this module is public and the bindings may create and use side metadata for their purpose.
 
+mod grain;
 mod constants;
 mod helpers;
 #[cfg(target_pointer_width = "32")]

--- a/src/util/metadata/side_metadata/mod.rs
+++ b/src/util/metadata/side_metadata/mod.rs
@@ -1,8 +1,8 @@
 //! This module provides an implementation of side table metadata.
 // For convenience, this module is public and the bindings may create and use side metadata for their purpose.
 
-mod grain;
 mod constants;
+mod grain;
 mod helpers;
 #[cfg(target_pointer_width = "32")]
 mod helpers_32;


### PR DESCRIPTION
**DRAFT**:

-   There is still performance disadvantage over the old approach.  Find the cause.
-   (Re-)implement bulk update, VO bit searching (internal pointer) and VO bit scanning (traversal).

This PR refactors the mechanism for visiting (reading and/or updating) side metadata in bulk.  Comparing with the existing approach, the new approach

-   uses only one callback for both bit ranges an byte ranges (TODO: Try not to use callback.  Use iterator instead.)
-   allows arbitrary granularity instead of bytes-only
-   (TODO) allows breaking discontiguous metadata for a contiguous data address range into contiguous metadata sub-ranges. (Do we need it? We only need it for bulk visiting metadata for data ranges larger than 4K.)

Using one callback allows an arbitrary `FnMut` callback (instead two `Fn`s) to be used to visit things (such as valid object references via VO bits) in a metadata range.  This also removes the use of `Cell` when finding the last VO bit from an internal pointer.

Now the side metadata can be visited at any granularity, such as `usize`.  We no longer have to do it in two steps, from bits to bytes (`iterate_meta_bits`) and from bytes to words (`find_last_non_zero_bit_in_metadata_bytes`).  Now anything smaller than a grain (a `usize` for example) are treated as a "sub-grain range" and visited bit by bit (e.g. for each bit in a `usize`...).

(TODO) Make a generic mechanism to break a contiguous data address range into a single or multiple contiguous metadata ranges, so that concrete meta bit traversal mechanism can be expressed in several levels of nested `for` loops (or nested callbacks).