### PR TITLE
Extra assertions for mutators and epilogues

### DIFF
--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -65,6 +65,10 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.release(tls, true);
     }
 
+    fn end_of_gc(&mut self, _tls: VMWorkerThread) {
+        self.ms.end_of_gc();
+    }
+
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
         self.base().collection_required(self, space_full)
     }

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -9,7 +9,6 @@ use crate::policy::sft_map::SFTMap;
 use crate::policy::space::{CommonSpace, Space};
 use crate::util::alloc::allocator::AllocatorContext;
 use crate::util::constants::LOG_BYTES_IN_PAGE;
-use crate::util::copy::*;
 use crate::util::heap::chunk_map::*;
 use crate::util::heap::BlockPageResource;
 use crate::util::heap::PageResource;
@@ -19,6 +18,7 @@ use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::metadata::vo_bit;
 use crate::util::metadata::{self, MetadataSpec};
 use crate::util::object_forwarding;
+use crate::util::{copy::*, epilogue};
 use crate::util::{Address, ObjectReference};
 use crate::vm::*;
 use crate::{
@@ -976,6 +976,12 @@ impl<VM: VMBinding> FlushPageResource<VM> {
             // Now flush the BlockPageResource.
             self.space.flush_page_resource()
         }
+    }
+}
+
+impl<VM: VMBinding> Drop for FlushPageResource<VM> {
+    fn drop(&mut self) {
+        epilogue::debug_assert_counter_zero(&self.counter, "FlushPageResource::counter");
     }
 }
 

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -8,6 +8,7 @@ use crate::{
     scheduler::{GCWorkScheduler, GCWorker, WorkBucketStage},
     util::{
         copy::CopySemantics,
+        epilogue,
         heap::{BlockPageResource, PageResource},
         metadata::{self, side_metadata::SideMetadataSpec, MetadataSpec},
         ObjectReference,
@@ -373,6 +374,13 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
         self.scheduler.work_buckets[crate::scheduler::WorkBucketStage::Release].add(work_packet);
     }
 
+    pub fn end_of_gc(&mut self) {
+        epilogue::debug_assert_counter_zero(
+            &self.pending_release_packets,
+            "pending_release_packets",
+        );
+    }
+
     /// Release a block.
     pub fn release_block(&self, block: Block) {
         self.block_clear_metadata(block);
@@ -579,5 +587,11 @@ impl<VM: VMBinding> RecycleBlocks<VM> {
         if 1 == self.counter.fetch_sub(1, Ordering::SeqCst) {
             self.space.recycle_blocks()
         }
+    }
+}
+
+impl<VM: VMBinding> Drop for RecycleBlocks<VM> {
+    fn drop(&mut self) {
+        epilogue::debug_assert_counter_zero(&self.counter, "RecycleBlocks::counter");
     }
 }

--- a/src/util/epilogue.rs
+++ b/src/util/epilogue.rs
@@ -1,0 +1,13 @@
+//! Utilities for implementing epilogues.
+//!
+//! Epilogues are operations that are done when several other operations are done.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A debugging method for detecting the case when the epilogue is never executed.
+pub fn debug_assert_counter_zero(counter: &AtomicUsize, what: &'static str) {
+    let value = counter.load(Ordering::SeqCst);
+    if value != 0 {
+        panic!("{what} is still {value}.");
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -44,6 +44,7 @@ pub mod test_util;
 /// An analysis framework for collecting data and profiling in GC.
 #[cfg(feature = "analysis")]
 pub(crate) mod analysis;
+pub(crate) mod epilogue;
 /// Non-generic refs to generic types of `<VM>`.
 pub(crate) mod erase_vm;
 /// Finalization implementation.


### PR DESCRIPTION
This commit adds assertions about the number of mutators and the list of mutators returned from the VM binding.

Also asserts that epilogues are not silently dropped before they are executed.  It could happen if a buggy VM binding returns a number of mutators that does not match the actual list of mutators.

This should detect bugs like https://github.com/mmtk/mmtk-ruby/issues/84