### PR TITLE
Fix find_last_non_zero_bit, and align metadata address before converting to data address.

### DIFF
--- a/src/util/metadata/metadata_val_traits.rs
+++ b/src/util/metadata/metadata_val_traits.rs
@@ -10,30 +10,12 @@ pub trait Bits {
     const BITS: u32;
     /// The size (in log2) of this atomic type in bits.
     const LOG2: u32;
-
-    fn leading_zeros(self) -> u32;
-    fn trailing_zeros(self) -> u32;
-    fn leading_ones(self) -> u32;
-    fn trailing_ones(self) -> u32;
 }
 macro_rules! impl_bits_trait {
     ($t: ty) => {
         impl Bits for $t {
             const BITS: u32 = <$t>::BITS;
             const LOG2: u32 = Self::BITS.trailing_zeros();
-
-            fn leading_zeros(self) -> u32 {
-                <$t>::leading_zeros(self)
-            }
-            fn trailing_zeros(self) -> u32 {
-                <$t>::trailing_zeros(self)
-            }
-            fn leading_ones(self) -> u32 {
-                <$t>::leading_ones(self)
-            }
-            fn trailing_ones(self) -> u32 {
-                <$t>::trailing_ones(self)
-            }
         }
     };
 }

--- a/src/util/metadata/metadata_val_traits.rs
+++ b/src/util/metadata/metadata_val_traits.rs
@@ -10,12 +10,30 @@ pub trait Bits {
     const BITS: u32;
     /// The size (in log2) of this atomic type in bits.
     const LOG2: u32;
+
+    fn leading_zeros(self) -> u32;
+    fn trailing_zeros(self) -> u32;
+    fn leading_ones(self) -> u32;
+    fn trailing_ones(self) -> u32;
 }
 macro_rules! impl_bits_trait {
     ($t: ty) => {
         impl Bits for $t {
             const BITS: u32 = <$t>::BITS;
             const LOG2: u32 = Self::BITS.trailing_zeros();
+
+            fn leading_zeros(self) -> u32 {
+                <$t>::leading_zeros(self)
+            }
+            fn trailing_zeros(self) -> u32 {
+                <$t>::trailing_zeros(self)
+            }
+            fn leading_ones(self) -> u32 {
+                <$t>::leading_ones(self)
+            }
+            fn trailing_ones(self) -> u32 {
+                <$t>::trailing_ones(self)
+            }
         }
     };
 }

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1027,12 +1027,10 @@ impl SideMetadataSpec {
         let region_bytes = 1 << self.log_bytes_in_region;
         // Figure out the range that we need to search.
         let start_addr = data_addr.align_down(region_bytes);
-        let end_addr = data_addr
-            .saturating_sub(search_limit_bytes)
-            .align_down(region_bytes);
+        let end_addr = data_addr.saturating_sub(search_limit_bytes) + 1usize;
 
         let mut cursor = start_addr;
-        while cursor > end_addr {
+        while cursor >= end_addr {
             // We encounter an unmapped address. Just return None.
             if !cursor.is_mapped() {
                 return None;

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -991,6 +991,7 @@ impl SideMetadataSpec {
     ///
     /// This function uses non-atomic load for the side metadata. The user needs to make sure
     /// that there is no other thread that is mutating the side metadata.
+    #[allow(clippy::let_and_return)]
     pub unsafe fn find_prev_non_zero_value<T: MetadataValue>(
         &self,
         data_addr: Address,
@@ -1000,7 +1001,15 @@ impl SideMetadataSpec {
 
         if self.uses_contiguous_side_metadata() {
             // Contiguous side metadata
-            self.find_prev_non_zero_value_fast::<T>(data_addr, search_limit_bytes)
+            let result = self.find_prev_non_zero_value_fast::<T>(data_addr, search_limit_bytes);
+            #[cfg(debug_assertions)]
+            {
+                // Double check if the implementation is correct
+                let result2 =
+                    self.find_prev_non_zero_value_simple::<T>(data_addr, search_limit_bytes);
+                assert_eq!(result, result2, "find_prev_non_zero_value_fast returned a diffrent result from the naive implementation.");
+            }
+            result
         } else {
             // TODO: We should be able to optimize further for this case. However, we need to be careful that the side metadata
             // is not contiguous, and we need to skip to the next chunk's side metadata when we search to a different chunk.
@@ -1073,6 +1082,7 @@ impl SideMetadataSpec {
                 BitByteRange::Bytes { start, end } => {
                     match helpers::find_last_non_zero_bit_in_metadata_bytes(start, end) {
                         helpers::FindMetaBitResult::Found { addr, bit } => {
+                            let (addr, bit) = align_metadata_address(self, addr, bit);
                             res = Some(contiguous_meta_address_to_address(self, addr, bit));
                             // Return true to abort the search. We found the bit.
                             true
@@ -1091,6 +1101,7 @@ impl SideMetadataSpec {
                     match helpers::find_last_non_zero_bit_in_metadata_bits(addr, bit_start, bit_end)
                     {
                         helpers::FindMetaBitResult::Found { addr, bit } => {
+                            let (addr, bit) = align_metadata_address(self, addr, bit);
                             res = Some(contiguous_meta_address_to_address(self, addr, bit));
                             // Return true to abort the search. We found the bit.
                             true

--- a/src/util/metadata/side_metadata/helpers.rs
+++ b/src/util/metadata/side_metadata/helpers.rs
@@ -287,24 +287,35 @@ pub fn find_last_non_zero_bit_in_metadata_bits(
     FindMetaBitResult::NotFound
 }
 
+macro_rules! impl_find_last_non_zero_bit {
+    ($int_ty: ty, $value: expr, $start: expr, $end: expr) => {{
+        let mask = match (1 as $int_ty).checked_shl(($end - $start) as u32) {
+            Some(shl) => (shl - 1) << $start,
+            None => <$int_ty>::MAX << $start,
+        };
+        let leading_zeroes = ($value & mask).leading_zeros();
+        if leading_zeroes >= <$int_ty>::BITS {
+            None
+        } else {
+            Some(<$int_ty>::BITS as u8 - leading_zeroes as u8 - 1)
+        }
+    }};
+}
+
 fn find_last_non_zero_bit_u8(value: u8, start: u8, end: u8) -> Option<u8> {
-    let mask: u8 = ((1 << (end - start + 1)) - 1) << start;
-    let leading_zeroes = (value & mask).leading_zeros();
-    if leading_zeroes >= u8::BITS {
-        None
-    } else {
-        Some(u8::BITS as u8 - leading_zeroes as u8)
-    }
+    // TODO: Ideally we implement the function as a generic function.
+    // However Rust does not have a generic trait for integers yet. We can use
+    // third party traits or our own trait (such as MetadataValue), but it is cumbersome,
+    // and does not worth the efforts.
+    impl_find_last_non_zero_bit!(u8, value, start, end)
 }
 
 fn find_last_non_zero_bit_usize(value: usize, start: u8, end: u8) -> Option<u8> {
-    let mask: usize = ((1 << (end - start + 1)) - 1) << start;
-    let leading_zeroes = (value & mask).leading_zeros();
-    if leading_zeroes >= usize::BITS {
-        None
-    } else {
-        Some(usize::BITS as u8 - leading_zeroes as u8)
-    }
+    // TODO: Ideally we implement the function as a generic function.
+    // However Rust does not have a generic trait for integers yet. We can use
+    // third party traits or our own trait (such as MetadataValue), but it is cumbersome,
+    // and does not worth the efforts.
+    impl_find_last_non_zero_bit!(usize, value, start, end)
 }
 
 pub fn scan_non_zero_bits_in_metadata_bytes(
@@ -491,6 +502,9 @@ mod tests {
 
         let bit = find_last_non_zero_bit_u8(0b100101, 0, 8);
         assert_eq!(bit, Some(5));
+
+        let bit = find_last_non_zero_bit_u8(0b0, 0, 1);
+        assert_eq!(bit, None);
     }
 
     #[test]

--- a/src/util/metadata/side_metadata/helpers.rs
+++ b/src/util/metadata/side_metadata/helpers.rs
@@ -228,15 +228,21 @@ pub fn find_last_non_zero_bit_in_metadata_bytes(
     let mut mapped_chunk = Address::MAX;
     while cur > meta_start {
         // If we can check the whole word, set step to word size. Otherwise, the step is 1 (byte) and we check byte.
-        let step = if cur.is_aligned_to(BYTES_IN_ADDRESS)
-            && cur.align_down(BYTES_IN_ADDRESS) >= meta_start
-        {
+        let step = if cur.is_aligned_to(BYTES_IN_ADDRESS) && cur - BYTES_IN_ADDRESS >= meta_start {
             BYTES_IN_ADDRESS
         } else {
             1
         };
         // Move to the address so we can load from it
         cur -= step;
+        // The value we check has to be in the range.
+        debug_assert!(
+            cur >= meta_start && cur < meta_end,
+            "Check metadata value at meta address {}, which is not in the range of [{}, {})",
+            cur,
+            meta_start,
+            meta_end
+        );
 
         // If we are looking at an address that is not in a mapped chunk, we need to check if the chunk if mapped.
         if cur < mapped_chunk {

--- a/src/util/metadata/side_metadata/helpers.rs
+++ b/src/util/metadata/side_metadata/helpers.rs
@@ -6,7 +6,6 @@ use crate::util::heap::layout::vm_layout::VMLayout;
 use crate::util::memory::MmapStrategy;
 #[cfg(target_pointer_width = "32")]
 use crate::util::metadata::side_metadata::address_to_chunked_meta_address;
-use crate::util::metadata::MetadataValue;
 use crate::util::Address;
 use crate::MMAPPER;
 use std::io::Result;
@@ -253,7 +252,7 @@ pub fn find_last_non_zero_bit_in_metadata_bytes(
             // Load and check a usize word
             let value = unsafe { cur.load::<usize>() };
             if value != 0 {
-                let bit = find_last_non_zero_bit(value, 0, usize::BITS as u8).unwrap();
+                let bit = find_last_non_zero_bit_usize(value, 0, usize::BITS as u8).unwrap();
                 let byte_offset = bit >> LOG_BITS_IN_BYTE;
                 let bit_offset = bit - ((byte_offset) << LOG_BITS_IN_BYTE);
                 return FindMetaBitResult::Found {
@@ -264,7 +263,7 @@ pub fn find_last_non_zero_bit_in_metadata_bytes(
         } else {
             // Load and check a byte
             let value = unsafe { cur.load::<u8>() };
-            if let Some(bit) = find_last_non_zero_bit::<u8>(value, 0, 8) {
+            if let Some(bit) = find_last_non_zero_bit_u8(value, 0, 8) {
                 return FindMetaBitResult::Found { addr: cur, bit };
             }
         }
@@ -282,23 +281,30 @@ pub fn find_last_non_zero_bit_in_metadata_bits(
         return FindMetaBitResult::UnmappedMetadata;
     }
     let byte = unsafe { addr.load::<u8>() };
-    if let Some(bit) = find_last_non_zero_bit::<u8>(byte, start_bit, end_bit) {
+    if let Some(bit) = find_last_non_zero_bit_u8(byte, start_bit, end_bit) {
         return FindMetaBitResult::Found { addr, bit };
     }
     FindMetaBitResult::NotFound
 }
 
-fn find_last_non_zero_bit<T: MetadataValue>(value: T, start: u8, end: u8) -> Option<u8> {
-    for cur_bit in (start..end).rev() {
-        assert!(cur_bit < T::BITS as u8);
-        if !value
-            .bitand(T::from_usize(1usize << cur_bit).unwrap())
-            .is_zero()
-        {
-            return Some(cur_bit);
-        }
+fn find_last_non_zero_bit_u8(value: u8, start: u8, end: u8) -> Option<u8> {
+    let mask: u8 = ((1 << (end - start + 1)) - 1) << start;
+    let leading_zeroes = (value & mask).leading_zeros();
+    if leading_zeroes >= u8::BITS {
+        None
+    } else {
+        Some(u8::BITS as u8 - leading_zeroes as u8)
     }
-    None
+}
+
+fn find_last_non_zero_bit_usize(value: usize, start: u8, end: u8) -> Option<u8> {
+    let mask: usize = ((1 << (end - start + 1)) - 1) << start;
+    let leading_zeroes = (value & mask).leading_zeros();
+    if leading_zeroes >= usize::BITS {
+        None
+    } else {
+        Some(usize::BITS as u8 - leading_zeroes as u8)
+    }
 }
 
 pub fn scan_non_zero_bits_in_metadata_bytes(
@@ -476,14 +482,14 @@ mod tests {
 
     #[test]
     fn test_find_last_non_zero_bit_in_u8() {
-        use super::find_last_non_zero_bit;
-        let bit = find_last_non_zero_bit::<u8>(0b100101, 0, 1);
+        use super::find_last_non_zero_bit_u8;
+        let bit = find_last_non_zero_bit_u8(0b100101, 0, 1);
         assert_eq!(bit, Some(0));
 
-        let bit = find_last_non_zero_bit::<u8>(0b100101, 0, 3);
+        let bit = find_last_non_zero_bit_u8(0b100101, 0, 3);
         assert_eq!(bit, Some(2));
 
-        let bit = find_last_non_zero_bit::<u8>(0b100101, 0, 8);
+        let bit = find_last_non_zero_bit_u8(0b100101, 0, 8);
         assert_eq!(bit, Some(5));
     }
 

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_multi_page.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_multi_page.rs
@@ -1,5 +1,7 @@
-// GITHUB-CI: MMTK_PLAN=all
+// GITHUB-CI: MMTK_PLAN=Immix,GenImmix,StickyImmix,MarkSweep,MarkCompact
 // GITHUB-CI: FEATURES=is_mmtk_object
+
+// Only test this with plans that use LOS. NoGC does not use large object space.
 
 use super::mock_test_prelude::*;
 

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_same_page.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_same_page.rs
@@ -1,5 +1,7 @@
-// GITHUB-CI: MMTK_PLAN=all
+// GITHUB-CI: MMTK_PLAN=Immix,GenImmix,StickyImmix,MarkSweep,MarkCompact
 // GITHUB-CI: FEATURES=is_mmtk_object
+
+// Only test this with plans that use LOS. NoGC does not use large object space.
 
 use super::mock_test_prelude::*;
 


### PR DESCRIPTION
This PR fixes some bugs in finding base references for internal references. Prominently two bugs:
1. The way we find the last non zero bit was wrong. We used to to use `trailing_zeroes` and compare the result with the given range of the starting and ending bits. This was simply wrong. Now we do a mask first to extract the value between the starting and the ending bits, and then use `leading_zeroes`. Performance-wise, the new code has similar performnace.
2. When we convert a metadata bit (address + bit offset) back to the data address, the metadata bit needs to be the start of the metadata value. If it is the middle of the metadata value, then the computed data address will be incorrect. This PR adds `align_metadata_address`.

This PR skips some tests for LOS in plans that do not use LOS.