### PR TITLE
Panic message and outdated comments

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -522,7 +522,7 @@ impl ObjectReference {
     pub fn from_raw_address(addr: Address) -> Option<ObjectReference> {
         debug_assert!(
             addr.is_aligned_to(Self::ALIGNMENT),
-            "ObjectReference is required to be word aligned"
+            "ObjectReference is required to be word aligned.  addr: {addr}"
         );
         NonZeroUsize::new(addr.0).map(ObjectReference)
     }
@@ -539,7 +539,7 @@ impl ObjectReference {
         debug_assert!(!addr.is_zero());
         debug_assert!(
             addr.is_aligned_to(Self::ALIGNMENT),
-            "ObjectReference is required to be word aligned"
+            "ObjectReference is required to be word aligned.  addr: {addr}"
         );
         ObjectReference(NonZeroUsize::new_unchecked(addr.0))
     }
@@ -582,7 +582,7 @@ impl ObjectReference {
         debug_assert!(!VM::VMObjectModel::UNIFIED_OBJECT_REFERENCE_ADDRESS || addr == obj.to_raw_address(), "The binding claims unified object reference address, but for address {}, the object reference is {}", addr, obj);
         debug_assert!(
             obj.to_raw_address().is_aligned_to(Self::ALIGNMENT),
-            "ObjectReference is required to be word aligned"
+            "ObjectReference is required to be word aligned.  addr: {addr}, obj: {obj}"
         );
         obj
     }

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1071,8 +1071,6 @@ impl SideMetadataSpec {
         let end_meta_addr = address_to_contiguous_meta_address(self, end_addr);
         let end_meta_shift = meta_byte_lshift(self, end_addr);
 
-        // The result will be set by one of the following closures.
-        // Use Cell so it doesn't need to be mutably borrowed by the two closures which Rust will complain.
         let mut res = None;
 
         let mut visitor = |range: BitByteRange| {


### PR DESCRIPTION
This commit contains some minor fixes.

-   Added the actual address to the panic message when the assertions
    about ObjectReference alignment fails.
-   Removed an outdated comment about the use of Cell.