### PR TITLE
Assert OBJECT_REF_OFFSET_LOWER_BOUND invariant

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -568,6 +568,15 @@ impl ObjectReference {
         use crate::vm::ObjectModel;
         let object_start = VM::VMObjectModel::ref_to_object_start(self);
         debug_assert!(!VM::VMObjectModel::UNIFIED_OBJECT_REFERENCE_ADDRESS || object_start == self.to_raw_address(), "The binding claims unified object reference address, but for object reference {}, ref_to_object_start() returns {}", self, object_start);
+        debug_assert!(
+            self.to_raw_address()
+                >= object_start + VM::VMObjectModel::OBJECT_REF_OFFSET_LOWER_BOUND,
+            "The invariant `object_ref >= object_start + OBJECT_REF_OFFSET_LOWER_BOUND` is violated. \
+            object_ref: {}, object_start: {}, OBJECT_REF_OFFSET_LOWER_BOUND: {}",
+            self.to_raw_address(),
+            object_start,
+            VM::VMObjectModel::OBJECT_REF_OFFSET_LOWER_BOUND,
+        );
         object_start
     }
 

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -457,6 +457,9 @@ pub trait ObjectModel<VM: VMBinding> {
     /// Return the lowest address of the storage associated with an object. This should be
     /// the address that a binding gets by an allocation call ([`crate::memory_manager::alloc`]).
     ///
+    /// Note that the return value needs to satisfy the invariant mentioned in the doc comment of
+    /// [`Self::OBJECT_REF_OFFSET_LOWER_BOUND`].
+    ///
     /// Arguments:
     /// * `object`: The object to be queried.
     fn ref_to_object_start(object: ObjectReference) -> Address;


### PR DESCRIPTION
Do a `debug_assert` on the invariant of `ObjectModel::OBJECT_REF_OFFSET_LOWER_BOUND` when calling `address.to_object_start::<VM>()`.  VM bindings may violate this invariant when changing their object models.