### PR TITLE
Require ObjectReference to point inside object

### DIFF
--- a/benches/mock_bench/internal_pointer.rs
+++ b/benches/mock_bench/internal_pointer.rs
@@ -42,10 +42,7 @@ pub fn bench(c: &mut Criterion) {
             );
             let obj_end = addr + NORMAL_OBJECT_SIZE;
             _b.iter(|| {
-                memory_manager::find_object_from_internal_pointer::<MockVM>(
-                    obj_end - 1,
-                    NORMAL_OBJECT_SIZE,
-                );
+                memory_manager::find_object_from_internal_pointer(obj_end - 1, NORMAL_OBJECT_SIZE);
             })
         }
         #[cfg(not(feature = "is_mmtk_object"))]
@@ -83,10 +80,7 @@ pub fn bench(c: &mut Criterion) {
             );
             let obj_end = addr + LARGE_OBJECT_SIZE;
             _b.iter(|| {
-                memory_manager::find_object_from_internal_pointer::<MockVM>(
-                    obj_end - 1,
-                    LARGE_OBJECT_SIZE,
-                );
+                memory_manager::find_object_from_internal_pointer(obj_end - 1, LARGE_OBJECT_SIZE);
             })
         }
         #[cfg(not(feature = "is_mmtk_object"))]

--- a/benches/mock_bench/sft.rs
+++ b/benches/mock_bench/sft.rs
@@ -12,6 +12,6 @@ pub fn bench(c: &mut Criterion) {
     let obj = MockVM::object_start_to_ref(addr);
 
     c.bench_function("sft read", |b| {
-        b.iter(|| memory_manager::is_in_mmtk_spaces::<MockVM>(black_box(obj)))
+        b.iter(|| memory_manager::is_in_mmtk_spaces(black_box(obj)))
     });
 }

--- a/docs/dummyvm/src/api.rs
+++ b/docs/dummyvm/src/api.rs
@@ -142,23 +142,23 @@ pub extern "C" fn mmtk_total_bytes() -> usize {
 
 #[no_mangle]
 pub extern "C" fn mmtk_is_live_object(object: ObjectReference) -> bool {
-    memory_manager::is_live_object::<DummyVM>(object)
+    memory_manager::is_live_object(object)
 }
 
 #[no_mangle]
 pub extern "C" fn mmtk_will_never_move(object: ObjectReference) -> bool {
-    !object.is_movable::<DummyVM>()
+    !object.is_movable()
 }
 
 #[cfg(feature = "is_mmtk_object")]
 #[no_mangle]
 pub extern "C" fn mmtk_is_mmtk_object(addr: Address) -> bool {
-    memory_manager::is_mmtk_object(addr)
+    memory_manager::is_mmtk_object(addr).is_some()
 }
 
 #[no_mangle]
 pub extern "C" fn mmtk_is_in_mmtk_spaces(object: ObjectReference) -> bool {
-    memory_manager::is_in_mmtk_spaces::<DummyVM>(object)
+    memory_manager::is_in_mmtk_spaces(object)
 }
 
 #[no_mangle]

--- a/docs/dummyvm/src/object_model.rs
+++ b/docs/dummyvm/src/object_model.rs
@@ -6,14 +6,9 @@ use mmtk::vm::*;
 pub struct VMObjectModel {}
 
 /// This is the offset from the allocation result to the object reference for the object.
-/// For bindings that this offset is not a constant, you can implement the calculation in the method `ref_to_object_start``, and
+/// For bindings that this offset is not a constant, you can implement the calculation in the method `ref_to_object_start`, and
 /// remove this constant.
 pub const OBJECT_REF_OFFSET: usize = 0;
-
-/// This is the offset from the object reference to an in-object address. The binding needs
-/// to guarantee the in-object address is inside the storage associated with the object.
-/// It has to be a constant offset. See `ObjectModel::IN_OBJECT_ADDRESS_OFFSET`.
-pub const IN_OBJECT_ADDRESS_OFFSET: isize = 0;
 
 // This is the offset from the object reference to the object header.
 // This value is used in `ref_to_header` where MMTk loads header metadata from.
@@ -85,8 +80,6 @@ impl ObjectModel<DummyVM> for VMObjectModel {
     fn ref_to_header(object: ObjectReference) -> Address {
         object.to_raw_address().sub(OBJECT_HEADER_OFFSET)
     }
-
-    const IN_OBJECT_ADDRESS_OFFSET: isize = IN_OBJECT_ADDRESS_OFFSET;
 
     fn dump_object(_object: ObjectReference) {
         unimplemented!()

--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -55,6 +55,9 @@ API changes:
         *   `is_movable`
         *   `is_reachable`
 -   module `memory_manager`
+    +   `is_mmtk_object`: It now requires the address parameter to be non-zero and word-aligned.
+        *   Otherwise it will not be a legal `ObjectReference` in the first place.  The user should
+            filter out such illegal values.
     +   The following functions no longer have the `<VM>` type argument.
         *   `find_object_from_internal_pointer`
         *   `is_in_mmtk_space`
@@ -67,6 +70,13 @@ API changes:
         *   `containing`
 -   trait `ObjectModel`
     +   `IN_OBJECT_ADDRESS_OFFSET`: removed because it is no longer needed.
+
+See also:
+
+-   PR: <https://github.com/mmtk/mmtk-core/issues/1170>
+-   Examples:
+    +   https://github.com/mmtk/mmtk-openjdk/pull/286: a simple case
+    +   https://github.com/mmtk/mmtk-jikesrvm/issues/178: a VM that needs much change for this
 
 ## 0.27.0
 

--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -30,6 +30,44 @@ Notes for the mmtk-core developers:
 
 <!-- Insert new versions here -->
 
+## 0.28.0
+
+### `ObjectReference` must point inside an object
+
+```admonish tldr
+`ObjectReference` is now required to be an address within an object.  The concept of "in-object
+address" and related methods are removed.  Some methods which used to depend on the "in-object
+address" no longer need the `<VM>` type argument.
+```
+
+API changes:
+
+-   struct `ObjectReference`
+    +   Its "raw address" must be within an object now.
+    +   The following methods which were used to access the in-object address are removed.
+        *   `from_address`
+        *   `to_address`
+        *   When accessing side metadata, the "raw address" should be used, instead.
+    +   The following methods no longer have the `<VM>` type argument.
+        *   `get_forwarded_object`
+        *   `is_in_any_space`
+        *   `is_live`
+        *   `is_movable`
+        *   `is_reachable`
+-   module `memory_manager`
+    +   The following functions no longer have the `<VM>` type argument.
+        *   `find_object_from_internal_pointer`
+        *   `is_in_mmtk_space`
+        *   `is_live_object`
+        *   `is_pinned`
+        *   `pin_object`
+        *   `unpin_object`
+-   struct `Region`
+    +   The following methods no longer have the `<VM>` type argument.
+        *   `containing`
+-   trait `ObjectModel`
+    +   `IN_OBJECT_ADDRESS_OFFSET`: removed because it is no longer needed.
+
 ## 0.27.0
 
 ### `is_mmtk_object` returns `Option<ObjectReference>

--- a/docs/userguide/src/portingguide/howto/nogc.md
+++ b/docs/userguide/src/portingguide/howto/nogc.md
@@ -98,9 +98,12 @@ We recommend going through the [list of metadata specifications](https://docs.mm
 A key principle in MMTk is the distinction between [`ObjectReference`](https://docs.mmtk.io/api/mmtk/util/address/struct.ObjectReference.html) and [`Address`](https://docs.mmtk.io/api/mmtk/util/address/struct.Address.html). The idea is that very few operations are allowed on an `ObjectReference`. For example, MMTk does not allow address arithmetic on `ObjectReference`s. This allows us to preserve memory-safety, only performing unsafe operations when required, and gives us a cleaner and more flexible abstraction to work with as it can allow object handles or offsets etc. `Address`, on the other hand, represents an arbitrary machine address. You might be interested in reading the [*Demystifying Magic: High-level Low-level Programming*][FBC09] paper which describes the above in more detail.
 
 In MMTk, `ObjectReference` is a special address that represents an object.  It is required to be
-with the address range of the object it refers to, and must be word-aligned.  This address is used
+within the address range of the object it refers to, and must be word-aligned.  This address is used
 by MMTk to access side metadata, and find the space or regions (chunk, block, line, etc.) that
-contains the object.
+contains the object.  It must also be efficient to locate the object header (where in-header MMTk
+metadata are held) and the object's VM-specific metadata, such as type information, from a given
+`ObjectReference`.  MMTk will need to access those information, either directly or indirectly via
+traits implemented by the binding, during tracing, which is performance-critical.
 
 The address used as `ObjectReference` is nominated by the VM binding when an object is allocated (or
 moved by a moving GC, which we can ignore for now when supporting NoGC).  VMs usually have their own

--- a/docs/userguide/src/portingguide/howto/nogc.md
+++ b/docs/userguide/src/portingguide/howto/nogc.md
@@ -95,13 +95,36 @@ We recommend going through the [list of metadata specifications](https://docs.mm
 
 #### `ObjectReference` vs `Address`
 
-A key principle in MMTk is the distinction between [`ObjectReference`](https://docs.mmtk.io/api/mmtk/util/address/struct.ObjectReference.html) and [`Address`](https://docs.mmtk.io/api/mmtk/util/address/struct.Address.html). The idea is that very few operations are allowed on an `ObjectReference`. For example, MMTk does not allow address arithmetic on `ObjectReference`s. This allows us to preserve memory-safety, only performing unsafe operations when required, and gives us a cleaner and more flexible abstraction to work with as it can allow object handles or offsets etc. `Address`, on the other hand, represents an arbitrary machine address. You might be interested in reading the *Demystifying Magic: High-level Low-level Programming* paper[^3] which describes the above in more detail.
+A key principle in MMTk is the distinction between [`ObjectReference`](https://docs.mmtk.io/api/mmtk/util/address/struct.ObjectReference.html) and [`Address`](https://docs.mmtk.io/api/mmtk/util/address/struct.Address.html). The idea is that very few operations are allowed on an `ObjectReference`. For example, MMTk does not allow address arithmetic on `ObjectReference`s. This allows us to preserve memory-safety, only performing unsafe operations when required, and gives us a cleaner and more flexible abstraction to work with as it can allow object handles or offsets etc. `Address`, on the other hand, represents an arbitrary machine address. You might be interested in reading the [*Demystifying Magic: High-level Low-level Programming*][FBC09] paper which describes the above in more detail.
 
-In MMTk, `ObjectReference` is a special address that represents an object. A binding may use tagged references, compressed pointers, etc.
-They need to deal with the encoding and the decoding in their [`Slot`](https://docs.mmtk.io/api/mmtk/vm/slot/trait.Slot.html) implementation,
-and always present plain `ObjectReference`s to MMTk. See [this test](https://github.com/mmtk/mmtk-core/blob/master/src/vm/tests/mock_tests/mock_test_slots.rs) for some `Slot` implementation examples.
+In MMTk, `ObjectReference` is a special address that represents an object.  It is required to be
+with the address range of the object it refers to, and must be word-aligned.  This address is used
+by MMTk to access side metadata, and find the space or regions (chunk, block, line, etc.) that
+contains the object.
 
-[^3]: https://users.cecs.anu.edu.au/~steveb/pubs/papers/vmmagic-vee-2009.pdf
+The address used as `ObjectReference` is nominated by the VM binding when an object is allocated (or
+moved by a moving GC, which we can ignore for now when supporting NoGC).  VMs usually have their own
+concepts of "object reference" which refer to objects.  Some of them, including OpenJDK and CRuby,
+uses addresses to the object (the starting address or at an offset within the object) to refer to an
+object.  Such VMs can directly use their "object reference" for the address of MMTk's
+`ObjectReference`.
+
+Some VMs, such as JikesRVM, refers to an object by an address at a constant offset after the header,
+and can be outside the object.  This does not satisfy the requirement of MMTk's `ObjectReference`,
+and the VM binding needs to make a clear distinction between the VM-level object reference and
+MMTk's `ObjectReference` type.  A detailed example for supporting such a VM can be found
+[here][jikesrvm-objref].
+
+Other VMs may use tagged references, compressed pointers, etc.  They need to convert them to plain
+addresses to be used as MMTk's `ObjectReference`.  Specifically, if the VM use such representations
+in object fields, the VM binding can deal with the encoding and the decoding in its
+[`Slot`][slot-trait] implementation, and always present plain `ObjectReference`s to MMTk. See [this
+test] for some `Slot` implementation examples.
+
+[FBC09]: https://users.cecs.anu.edu.au/~steveb/pubs/papers/vmmagic-vee-2009.pdf
+[jikesrvm-objref]: https://github.com/mmtk/mmtk-jikesrvm/issues/178
+[slot-trait]: https://docs.mmtk.io/api/mmtk/vm/slot/trait.Slot.html
+[slot-test]: https://github.com/mmtk/mmtk-core/blob/master/src/vm/tests/mock_tests/mock_test_slots.rs
 
 #### Miscellaneous configuration options
 
@@ -261,7 +284,7 @@ void *mmtk_alloc(MmtkMutator mutator, size_t size, size_t align,
  * Set relevant object metadata
  *
  * @param mutator the mutator instance that is requesting the allocation
- * @param object the returned address of the allocated object
+ * @param object the ObjectReference address chosen by the VM binding
  * @param size the size of the allocated object
  * @param allocator the allocation semantics to use for the allocation
  */
@@ -274,13 +297,21 @@ In order to perform allocations, you will need to know what object alignment the
 
 Now that MMTk is aware of each mutator thread, you have to change the runtime's allocation functions to call into MMTk to allocate using `mmtk_alloc` and set object metadata using `mmtk_post_alloc`. Note that there may be multiple allocation functions in the runtime so make sure that you edit them all!
 
-You should use the saved `Mutator` pointer as the first parameter, the requested object size as the next parameter, and any alignment requirements the runtimes has as the third parameter.
+When calling `mmtk_alloc`, you should use the saved `Mutator` pointer as the first parameter, the requested object size as the next parameter, and any alignment requirements the runtimes has as the third parameter.
 
 If your runtime requires a non-zero allocation offset (i.e. the alignment requirements are for the offset address, not the returned address) then you have to provide the required value as the fourth parameter. Note that you ***must*** also update the [`USE_ALLOCATION_OFFSET`](https://docs.mmtk.io/api/mmtk/vm/trait.VMBinding.html#associatedconstant.USE_ALLOCATION_OFFSET) constant in the `VMBinding` implementation if your runtime requires a non-zero allocation offset.
 
 For the time-being, you can ignore the `allocator` parameter in both these functions and always pass a value of `0` which means MMTk will pick the default allocator for your collector (a bump pointer allocator in the case of NoGC).
 
-Finally, you need to call `mmtk_post_alloc` with the object address returned from the previous `mmtk_alloc` call in order to initialize object metadata.
+The return value of `mmtk_alloc` is the starting address of the allocated object.
+
+Then you should nominate a word-aligned address within the allocated bytes to be the
+`ObjectReference` used to refer to that object from now on.  It doesn't have to be the starting
+address.
+
+Finally, you need to call `mmtk_post_alloc` with your chosen `ObjectReference` in order to
+initialize MMTk-level object metadata, such as logging bits, valid-object (VO) bits, etc.  As a VM
+binding developer, you can ignore the details for now.
 
 **Note:** Currently MMTk assumes object sizes are multiples of the `MIN_ALIGNMENT`. If you encounter errors with alignment, a simple workaround would be to align the requested object size up to the `MIN_ALIGNMENT`. See [here](https://github.com/mmtk/mmtk-core/issues/730) for the tracking issue to fix this bug.
 

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -579,8 +579,8 @@ pub fn handle_user_collection_request<VM: VMBinding>(mmtk: &MMTK<VM>, tls: VMMut
 ///
 /// Arguments:
 /// * `object`: The object reference to query.
-pub fn is_live_object<VM: VMBinding>(object: ObjectReference) -> bool {
-    object.is_live::<VM>()
+pub fn is_live_object(object: ObjectReference) -> bool {
+    object.is_live()
 }
 
 /// Check if `addr` is the address of an object reference to an MMTk object.
@@ -633,7 +633,7 @@ pub fn is_mmtk_object(addr: Address) -> Option<ObjectReference> {
 /// * `internal_ptr`: The address to start searching. We search backwards from this address (including this address) to find the base reference.
 /// * `max_search_bytes`: The maximum number of bytes we may search for an object with VO bit set. `internal_ptr - max_search_bytes` is not included.
 #[cfg(feature = "is_mmtk_object")]
-pub fn find_object_from_internal_pointer<VM: VMBinding>(
+pub fn find_object_from_internal_pointer(
     internal_ptr: Address,
     max_search_bytes: usize,
 ) -> Option<ObjectReference> {
@@ -669,10 +669,10 @@ pub fn find_object_from_internal_pointer<VM: VMBinding>(
 ///
 /// Arguments:
 /// * `object`: The object reference to query.
-pub fn is_in_mmtk_spaces<VM: VMBinding>(object: ObjectReference) -> bool {
+pub fn is_in_mmtk_spaces(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
     SFT_MAP
-        .get_checked(object.to_address::<VM>())
+        .get_checked(object.to_raw_address())
         .is_in_space(object)
 }
 
@@ -766,10 +766,10 @@ pub fn add_finalizer<VM: VMBinding>(
 /// Arguments:
 /// * `object`: The object to be pinned
 #[cfg(feature = "object_pinning")]
-pub fn pin_object<VM: VMBinding>(object: ObjectReference) -> bool {
+pub fn pin_object(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
     SFT_MAP
-        .get_checked(object.to_address::<VM>())
+        .get_checked(object.to_raw_address())
         .pin_object(object)
 }
 
@@ -780,10 +780,10 @@ pub fn pin_object<VM: VMBinding>(object: ObjectReference) -> bool {
 /// Arguments:
 /// * `object`: The object to be pinned
 #[cfg(feature = "object_pinning")]
-pub fn unpin_object<VM: VMBinding>(object: ObjectReference) -> bool {
+pub fn unpin_object(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
     SFT_MAP
-        .get_checked(object.to_address::<VM>())
+        .get_checked(object.to_raw_address())
         .unpin_object(object)
 }
 
@@ -792,10 +792,10 @@ pub fn unpin_object<VM: VMBinding>(object: ObjectReference) -> bool {
 /// Arguments:
 /// * `object`: The object to be checked
 #[cfg(feature = "object_pinning")]
-pub fn is_pinned<VM: VMBinding>(object: ObjectReference) -> bool {
+pub fn is_pinned(object: ObjectReference) -> bool {
     use crate::mmtk::SFT_MAP;
     SFT_MAP
-        .get_checked(object.to_address::<VM>())
+        .get_checked(object.to_raw_address())
         .is_object_pinned(object)
 }
 

--- a/src/plan/barriers.rs
+++ b/src/plan/barriers.rs
@@ -182,7 +182,7 @@ impl<S: BarrierSemantics> ObjectBarrier<S> {
     fn log_object(&self, object: ObjectReference) -> bool {
         #[cfg(all(feature = "vo_bit", feature = "extreme_assertions"))]
         debug_assert!(
-            crate::util::metadata::vo_bit::is_vo_bit_set::<S::VM>(object),
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
             "object bit is unset"
         );
         loop {

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -59,7 +59,7 @@ impl<VM: VMBinding> SFT for CopySpace<VM> {
 
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
         #[cfg(feature = "vo_bit")]
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(_object);
+        crate::util::metadata::vo_bit::set_vo_bit(_object);
     }
 
     fn get_forwarded_object(&self, object: ObjectReference) -> Option<ObjectReference> {
@@ -76,7 +76,7 @@ impl<VM: VMBinding> SFT for CopySpace<VM> {
 
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
 
     #[cfg(feature = "is_mmtk_object")]
@@ -231,7 +231,7 @@ impl<VM: VMBinding> CopySpace<VM> {
 
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::metadata::vo_bit::is_vo_bit_set::<VM>(object),
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
             "{:x}: VO bit not set",
             object
         );
@@ -255,7 +255,7 @@ impl<VM: VMBinding> CopySpace<VM> {
             );
 
             #[cfg(feature = "vo_bit")]
-            crate::util::metadata::vo_bit::set_vo_bit::<VM>(new_object);
+            crate::util::metadata::vo_bit::set_vo_bit(new_object);
 
             trace!("Forwarding pointer");
             queue.enqueue(new_object);

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -139,11 +139,11 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
     }
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
         #[cfg(feature = "vo_bit")]
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(_object);
+        crate::util::metadata::vo_bit::set_vo_bit(_object);
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
     #[cfg(feature = "is_mmtk_object")]
     fn find_object_from_internal_pointer(
@@ -207,7 +207,7 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for ImmixSpace
         if KIND == TRACE_KIND_TRANSITIVE_PIN {
             self.trace_object_without_moving(queue, object)
         } else if KIND == TRACE_KIND_DEFRAG {
-            if Block::containing::<VM>(object).is_defrag_source() {
+            if Block::containing(object).is_defrag_source() {
                 debug_assert!(self.in_defrag());
                 debug_assert!(
                     !crate::plan::is_nursery_gc(worker.mmtk.get_plan()),
@@ -576,7 +576,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                     self.mark_lines(object);
                 }
             } else {
-                Block::containing::<VM>(object).set_state(BlockState::Marked);
+                Block::containing(object).set_state(BlockState::Marked);
             }
 
             #[cfg(feature = "vo_bit")]
@@ -625,9 +625,9 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 } else {
                     // new_object != object
                     debug_assert!(
-                        !Block::containing::<VM>(new_object).is_defrag_source(),
+                        !Block::containing(new_object).is_defrag_source(),
                         "Block {:?} containing forwarded object {} should not be a defragmentation source",
-                        Block::containing::<VM>(new_object),
+                        Block::containing(new_object),
                         new_object,
                     );
                 }
@@ -646,7 +646,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             {
                 self.attempt_mark(object, self.mark_state);
                 object_forwarding::clear_forwarding_bits::<VM>(object);
-                Block::containing::<VM>(object).set_state(BlockState::Marked);
+                Block::containing(object).set_state(BlockState::Marked);
 
                 #[cfg(feature = "vo_bit")]
                 vo_bit::helper::on_object_marked::<VM>(object);
@@ -671,12 +671,12 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 new_object
             };
             debug_assert_eq!(
-                Block::containing::<VM>(new_object).get_state(),
+                Block::containing(new_object).get_state(),
                 BlockState::Marked
             );
 
             queue.enqueue(new_object);
-            debug_assert!(new_object.is_live::<VM>());
+            debug_assert!(new_object.is_live());
             self.unlog_object_if_needed(new_object);
             new_object
         }

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -62,11 +62,11 @@ impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
         #[cfg(feature = "vo_bit")]
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(object);
+        crate::util::metadata::vo_bit::set_vo_bit(object);
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
     #[cfg(feature = "is_mmtk_object")]
     fn find_object_from_internal_pointer(
@@ -208,7 +208,7 @@ impl<VM: VMBinding> ImmortalSpace<VM> {
     ) -> ObjectReference {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::metadata::vo_bit::is_vo_bit_set::<VM>(object),
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
             "{:x}: VO bit not set",
             object
         );

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -80,11 +80,11 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
         }
 
         #[cfg(feature = "vo_bit")]
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(object);
+        crate::util::metadata::vo_bit::set_vo_bit(object);
         #[cfg(all(feature = "is_mmtk_object", debug_assertions))]
         {
             use crate::util::constants::LOG_BYTES_IN_PAGE;
-            let vo_addr = object.to_address::<VM>();
+            let vo_addr = object.to_raw_address();
             let offset_from_page_start = vo_addr & ((1 << LOG_BYTES_IN_PAGE) - 1) as usize;
             debug_assert!(
                 offset_from_page_start < crate::util::metadata::vo_bit::VO_BIT_WORD_TO_REGION,
@@ -96,7 +96,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
     #[cfg(feature = "is_mmtk_object")]
     fn find_object_from_internal_pointer(
@@ -257,7 +257,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
     ) -> ObjectReference {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::metadata::vo_bit::is_vo_bit_set::<VM>(object),
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
             "{:x}: VO bit not set",
             object
         );
@@ -292,7 +292,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
     fn sweep_large_pages(&mut self, sweep_nursery: bool) {
         let sweep = |object: ObjectReference| {
             #[cfg(feature = "vo_bit")]
-            crate::util::metadata::vo_bit::unset_vo_bit::<VM>(object);
+            crate::util::metadata::vo_bit::unset_vo_bit(object);
             self.pr
                 .release_pages(get_super_page(object.to_object_start::<VM>()));
         };

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -124,12 +124,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
                 for offset in 0..vo_bit::VO_BIT_WORD_TO_REGION {
                     let addr = cur_page + offset;
                     if unsafe { vo_bit::is_vo_addr(addr) } {
-                        let obj = vo_bit::is_internal_ptr_from_vo_bit::<VM>(addr, ptr);
-                        if obj.is_some() {
-                            return obj;
-                        } else {
-                            return None;
-                        }
+                        return vo_bit::is_internal_ptr_from_vo_bit::<VM>(addr, ptr);
                     }
                 }
                 unreachable!(

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -88,7 +88,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
             let offset_from_page_start = vo_addr & ((1 << LOG_BYTES_IN_PAGE) - 1) as usize;
             debug_assert!(
                 offset_from_page_start < crate::util::metadata::vo_bit::VO_BIT_WORD_TO_REGION,
-                "The in-object address is not in the first 512 bytes of a page. The internal pointer searching for LOS won't work."
+                "The raw address of ObjectReference is not in the first 512 bytes of a page. The internal pointer searching for LOS won't work."
             );
         }
 
@@ -117,7 +117,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
             }
             // For performance, we only check the first word which maps to the first 512 bytes in the page.
             // In almost all the cases, it should be sufficient.
-            // However, if the in-object address is not in the first 512 bytes, this won't work.
+            // However, if the raw address of ObjectReference is not in the first 512 bytes, this won't work.
             // We assert this when we set VO bit for LOS.
             if vo_bit::get_raw_vo_bit_word(cur_page) != 0 {
                 // Find the exact address that has vo bit set

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -72,11 +72,11 @@ impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
     }
     fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
         #[cfg(feature = "vo_bit")]
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(_object);
+        crate::util::metadata::vo_bit::set_vo_bit(_object);
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
     #[cfg(feature = "is_mmtk_object")]
     fn find_object_from_internal_pointer(

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -67,7 +67,7 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
     }
 
     fn initialize_object_metadata(&self, object: ObjectReference, _alloc: bool) {
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(object);
+        crate::util::metadata::vo_bit::set_vo_bit(object);
     }
 
     #[cfg(feature = "sanity")]
@@ -77,7 +77,7 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
 
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
 
     #[cfg(feature = "is_mmtk_object")]
@@ -241,7 +241,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         object: ObjectReference,
     ) -> ObjectReference {
         debug_assert!(
-            crate::util::metadata::vo_bit::is_vo_bit_set::<VM>(object),
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
             "{:x}: VO bit not set",
             object
         );
@@ -257,7 +257,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         object: ObjectReference,
     ) -> ObjectReference {
         debug_assert!(
-            crate::util::metadata::vo_bit::is_vo_bit_set::<VM>(object),
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
             "{:x}: VO bit not set",
             object
         );
@@ -403,7 +403,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             for obj in self.linear_scan_objects(from_start..from_end) {
                 let copied_size = VM::VMObjectModel::get_size_when_copied(obj);
                 // clear the VO bit
-                vo_bit::unset_vo_bit::<VM>(obj);
+                vo_bit::unset_vo_bit(obj);
 
                 let maybe_forwarding_pointer = Self::get_header_forwarding_pointer(obj);
                 if let Some(forwarding_pointer) = maybe_forwarding_pointer {
@@ -416,7 +416,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
                     let end_of_new_object =
                         VM::VMObjectModel::copy_to(obj, new_object, Address::ZERO);
                     // update VO bit,
-                    vo_bit::set_vo_bit::<VM>(new_object);
+                    vo_bit::set_vo_bit(new_object);
                     to = new_object.to_object_start::<VM>() + copied_size;
                     debug_assert_eq!(end_of_new_object, to);
                 } else {

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -98,7 +98,7 @@ impl<VM: VMBinding> SFT for MallocSpace<VM> {
 
     // For malloc space, we need to further check the VO bit.
     fn is_in_space(&self, object: ObjectReference) -> bool {
-        is_alloced_by_malloc::<VM>(object)
+        is_alloced_by_malloc(object)
     }
 
     /// For malloc space, we just use the side metadata.
@@ -107,7 +107,7 @@ impl<VM: VMBinding> SFT for MallocSpace<VM> {
         debug_assert!(!addr.is_zero());
         // `addr` cannot be mapped by us. It should be mapped by the malloc library.
         debug_assert!(!addr.is_mapped());
-        has_object_alloced_by_malloc::<VM>(addr)
+        has_object_alloced_by_malloc(addr)
     }
 
     #[cfg(feature = "is_mmtk_object")]
@@ -124,7 +124,7 @@ impl<VM: VMBinding> SFT for MallocSpace<VM> {
 
     fn initialize_object_metadata(&self, object: ObjectReference, _alloc: bool) {
         trace!("initialize_object_metadata for object {}", object);
-        set_vo_bit::<VM>(object);
+        set_vo_bit(object);
     }
 
     fn sft_trace_object(
@@ -173,7 +173,7 @@ impl<VM: VMBinding> Space<VM> for MallocSpace<VM> {
     // We have assertions in a debug build. We allow this pattern for the release build.
     #[allow(clippy::let_and_return)]
     fn in_space(&self, object: ObjectReference) -> bool {
-        let ret = is_alloced_by_malloc::<VM>(object);
+        let ret = is_alloced_by_malloc(object);
 
         #[cfg(debug_assertions)]
         if ASSERT_ALLOCATION {
@@ -556,7 +556,7 @@ impl<VM: VMBinding> MallocSpace<VM> {
             // Free object
             self.free_internal(obj_start, bytes, offset_malloc);
             trace!("free object {}", object);
-            unsafe { unset_vo_bit_unsafe::<VM>(object) };
+            unsafe { unset_vo_bit_unsafe(object) };
 
             true
         } else {

--- a/src/policy/marksweepspace/malloc_ms/metadata.rs
+++ b/src/policy/marksweepspace/malloc_ms/metadata.rs
@@ -153,9 +153,8 @@ pub(super) fn map_meta_space(metadata: &SideMetadataContext, addr: Address, size
 }
 
 /// Check if a given object was allocated by malloc
-pub fn is_alloced_by_malloc<VM: VMBinding>(object: ObjectReference) -> bool {
-    is_meta_space_mapped_for_address(object.to_address::<VM>())
-        && vo_bit::is_vo_bit_set::<VM>(object)
+pub fn is_alloced_by_malloc(object: ObjectReference) -> bool {
+    is_meta_space_mapped_for_address(object.to_raw_address()) && vo_bit::is_vo_bit_set(object)
 }
 
 /// Check if there is an object allocated by malloc at the address.
@@ -163,11 +162,11 @@ pub fn is_alloced_by_malloc<VM: VMBinding>(object: ObjectReference) -> bool {
 /// This function doesn't check if `addr` is aligned.
 /// If not, it will try to load the VO bit for the address rounded down to the metadata's granularity.
 #[cfg(feature = "is_mmtk_object")]
-pub fn has_object_alloced_by_malloc<VM: VMBinding>(addr: Address) -> Option<ObjectReference> {
+pub fn has_object_alloced_by_malloc(addr: Address) -> Option<ObjectReference> {
     if !is_meta_space_mapped_for_address(addr) {
         return None;
     }
-    vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+    vo_bit::is_vo_bit_set_for_addr(addr)
 }
 
 pub fn is_marked<VM: VMBinding>(object: ObjectReference, ordering: Ordering) -> bool {
@@ -218,8 +217,8 @@ pub unsafe fn is_chunk_marked_unsafe(chunk_start: Address) -> bool {
     ACTIVE_CHUNK_METADATA_SPEC.load::<u8>(chunk_start) == 1
 }
 
-pub fn set_vo_bit<VM: VMBinding>(object: ObjectReference) {
-    vo_bit::set_vo_bit::<VM>(object);
+pub fn set_vo_bit(object: ObjectReference) {
+    vo_bit::set_vo_bit(object);
 }
 
 pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Ordering) {
@@ -227,8 +226,8 @@ pub fn set_mark_bit<VM: VMBinding>(object: ObjectReference, ordering: Ordering) 
 }
 
 #[allow(unused)]
-pub fn unset_vo_bit<VM: VMBinding>(object: ObjectReference) {
-    vo_bit::unset_vo_bit::<VM>(object);
+pub fn unset_vo_bit(object: ObjectReference) {
+    vo_bit::unset_vo_bit(object);
 }
 
 #[allow(unused)]
@@ -255,8 +254,8 @@ pub(super) unsafe fn unset_offset_malloc_bit_unsafe(address: Address) {
     OFFSET_MALLOC_METADATA_SPEC.store::<u8>(address, 0);
 }
 
-pub unsafe fn unset_vo_bit_unsafe<VM: VMBinding>(object: ObjectReference) {
-    vo_bit::unset_vo_bit_unsafe::<VM>(object);
+pub unsafe fn unset_vo_bit_unsafe(object: ObjectReference) {
+    vo_bit::unset_vo_bit_unsafe(object);
 }
 
 #[allow(unused)]

--- a/src/policy/marksweepspace/native_ms/block.rs
+++ b/src/policy/marksweepspace/native_ms/block.rs
@@ -300,7 +300,7 @@ impl Block {
                 // clear VO bit if it is ever set. It is possible that the VO bit is never set for this cell (i.e. there was no object in this cell before this GC),
                 // we unset the bit anyway.
                 #[cfg(feature = "vo_bit")]
-                crate::util::metadata::vo_bit::unset_vo_bit_nocheck::<VM>(potential_object);
+                crate::util::metadata::vo_bit::unset_vo_bit_nocheck(potential_object);
                 unsafe {
                     cell.store::<Address>(last);
                 }

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -191,12 +191,12 @@ impl<VM: VMBinding> SFT for MarkSweepSpace<VM> {
 
     fn initialize_object_metadata(&self, _object: crate::util::ObjectReference, _alloc: bool) {
         #[cfg(feature = "vo_bit")]
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(_object);
+        crate::util::metadata::vo_bit::set_vo_bit(_object);
     }
 
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
 
     #[cfg(feature = "is_mmtk_object")]
@@ -341,7 +341,7 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
         );
         if !VM::VMObjectModel::LOCAL_MARK_BIT_SPEC.is_marked::<VM>(object, Ordering::SeqCst) {
             VM::VMObjectModel::LOCAL_MARK_BIT_SPEC.mark::<VM>(object, Ordering::SeqCst);
-            let block = Block::containing::<VM>(object);
+            let block = Block::containing(object);
             block.set_state(BlockState::Marked);
             queue.enqueue(object);
         }

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -242,7 +242,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
     }
 
     fn in_space(&self, object: ObjectReference) -> bool {
-        self.address_in_space(object.to_address::<VM>())
+        self.address_in_space(object.to_raw_address())
     }
 
     /**

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -64,11 +64,11 @@ impl<VM: VMBinding> SFT for VMSpace<VM> {
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
         #[cfg(feature = "vo_bit")]
-        crate::util::metadata::vo_bit::set_vo_bit::<VM>(object);
+        crate::util::metadata::vo_bit::set_vo_bit(object);
     }
     #[cfg(feature = "is_mmtk_object")]
     fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
-        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr::<VM>(addr)
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
     }
     #[cfg(feature = "is_mmtk_object")]
     fn find_object_from_internal_pointer(
@@ -277,7 +277,7 @@ impl<VM: VMBinding> VMSpace<VM> {
     ) -> ObjectReference {
         #[cfg(feature = "vo_bit")]
         debug_assert!(
-            crate::util::metadata::vo_bit::is_vo_bit_set::<VM>(object),
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
             "{:x}: VO bit not set",
             object
         );

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -697,7 +697,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SFTProcessEdges<VM> {
         let worker = GCWorkerMutRef::new(self.worker());
 
         // Invoke trace object on sft
-        let sft = unsafe { crate::mmtk::SFT_MAP.get_unchecked(object.to_address::<VM>()) };
+        let sft = unsafe { crate::mmtk::SFT_MAP.get_unchecked(object.to_raw_address()) };
         sft.sft_trace_object(&mut self.base.nodes, object, worker)
     }
 

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -544,22 +544,14 @@ impl ObjectReference {
     /// you will see an assertion failure in the debug build when constructing an object reference instance.
     pub const ALIGNMENT: usize = crate::util::constants::BYTES_IN_ADDRESS;
 
-    /// Cast the object reference to its raw address. This method is mostly for the convinience of a binding.
-    ///
-    /// MMTk should not make any assumption on the actual location of the address with the object reference.
-    /// MMTk should not assume the address returned by this method is in our allocation. For the purposes of
-    /// setting object metadata, MMTk should use [`crate::util::ObjectReference::to_address`] or [`crate::util::ObjectReference::to_header`].
+    /// Cast the object reference to its raw address.
     pub fn to_raw_address(self) -> Address {
         Address(self.0.get())
     }
 
-    /// Cast a raw address to an object reference. This method is mostly for the convinience of a binding.
-    /// This is how a binding creates `ObjectReference` instances.
+    /// Cast a raw address to an object reference.
     ///
     /// If `addr` is 0, the result is `None`.
-    ///
-    /// MMTk should not assume an arbitrary address can be turned into an object reference. MMTk can use [`crate::util::ObjectReference::from_address`]
-    /// to turn addresses that are from [`crate::util::ObjectReference::to_address`] back to object.
     pub fn from_raw_address(addr: Address) -> Option<ObjectReference> {
         debug_assert!(
             addr.is_aligned_to(Self::ALIGNMENT),

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -477,17 +477,17 @@ use crate::vm::VMBinding;
 ///
 /// -   When the address is in one of MMTk's spaces, it refers to an object allocated in that space.
 ///     In this case, the address must satisfy the following requirements.
-///     -   The address must be within the address range of the object it refers to. *(Note 1)*
+///     -   The address must be within the address range of the object it refers to.  But it is not
+///         necessarily the starting address.
 ///     -   The address must be word-aligned.
-///     -   For each object, the same address shall be used for all `ObjectReference` instances
-///         referring to that object, until the object is moved by the GC. *(Note 2)*
 /// -   When the address is outside any MMTk space, its semantics is VM-defined.
 ///
-/// *Note 1*: The address is not necessarily the starting address of the object.
-///
-/// *Note 2*: When an object is moved, the VM binding shall choose another address to use for the
-/// `ObjectReference` of the new copy (in [`crate::vm::ObjectModel::copy`] or
-/// [`crate::vm::ObjectModel::get_reference_when_copied_to`]).
+/// The address used as the `ObjectReference` is nominated by the VM binding when an object is
+/// allocated in the MMTk heap (i.e. the argument of [`crate::memory_manager::post_alloc`]).  The
+/// same address is used by all `ObjectReference`s that refer to that object until the object is
+/// moved, at which time the VM binding shall choose another address to use as the `ObjectReference`
+/// of the new copy (in [`crate::vm::ObjectModel::copy`] or
+/// [`crate::vm::ObjectModel::get_reference_when_copied_to`]) until it is moved again.
 ///
 /// The address value held inside an `ObjectReference` instance is its **raw address**.  When
 /// accessing side metadata, MMTk uses the raw address to locate the side metadata bits.

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -479,15 +479,13 @@ use crate::vm::VMBinding;
 ///     In this case, the address must satisfy the following requirements.
 ///     -   The address must be within the address range of the object it refers to. *(Note 1)*
 ///     -   The address must be word-aligned.
-///     -   After an object is allocated, the same address is used for all `ObjectReference`
-///         instances referring that object, until the object is moved by the (moving) GC.
-///         *(Note 2)*
+///     -   For each object, the same address shall be used for all `ObjectReference` instances
+///         referring to that object, until the object is moved by the GC. *(Note 2)*
 /// -   When the address is outside any MMTk space, its semantics is VM-defined.
 ///
 /// *Note 1*: The address is not necessarily the starting address of the object.
 ///
-/// *Note 2*: When an object is moved, the GC performs another allocation
-/// (`CopyContext::alloc_copy`), and the VM binding shall choose another address to use for the
+/// *Note 2*: When an object is moved, the VM binding shall choose another address to use for the
 /// `ObjectReference` of the new copy (in [`crate::vm::ObjectModel::copy`] or
 /// [`crate::vm::ObjectModel::get_reference_when_copied_to`]).
 ///

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -476,11 +476,20 @@ use crate::vm::VMBinding;
 /// or not.
 ///
 /// -   When the address is in one of MMTk's spaces, it refers to an object allocated in that space.
-///     In this case, the address
-///     -   must be within the address range of the object it refers to, and
-///     -   must be word-aligned, but
-///     -   is not necessarily the starting address of the object.
+///     In this case, the address must satisfy the following requirements.
+///     -   The address must be within the address range of the object it refers to. *(Note 1)*
+///     -   The address must be word-aligned.
+///     -   After an object is allocated, the same address is used for all `ObjectReference`
+///         instances referring that object, until the object is moved by the (moving) GC.
+///         *(Note 2)*
 /// -   When the address is outside any MMTk space, its semantics is VM-defined.
+///
+/// *Note 1*: The address is not necessarily the starting address of the object.
+///
+/// *Note 2*: When an object is moved, the GC performs another allocation
+/// (`CopyContext::alloc_copy`), and the VM binding shall choose another address to use for the
+/// `ObjectReference` of the new copy (in [`crate::vm::ObjectModel::copy`] or
+/// [`crate::vm::ObjectModel::get_reference_when_copied_to`]).
 ///
 /// The address value held inside an `ObjectReference` instance is its **raw address**.  When
 /// accessing side metadata, MMTk uses the raw address to locate the side metadata bits.

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -406,7 +406,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
         // unset allocation bit
         // Note: We cannot use `unset_vo_bit_unsafe` because two threads may attempt to free
         // objects at adjacent addresses, and they may share the same byte in the VO bit metadata.
-        crate::util::metadata::vo_bit::unset_vo_bit::<VM>(unsafe {
+        crate::util::metadata::vo_bit::unset_vo_bit(unsafe {
             ObjectReference::from_raw_address_unchecked(addr)
         })
     }

--- a/src/util/finalizable_processor.rs
+++ b/src/util/finalizable_processor.rs
@@ -54,7 +54,7 @@ impl<F: Finalizable> FinalizableProcessor<F> {
         for mut f in self.candidates.drain(start..).collect::<Vec<F>>() {
             let reff = f.get_reference();
             trace!("Pop {:?} for finalization", reff);
-            if reff.is_live::<E::VM>() {
+            if reff.is_live() {
                 FinalizableProcessor::<F>::forward_finalizable_reference(e, &mut f);
                 trace!("{:?} is live, push {:?} back to candidates", reff, f);
                 self.candidates.push(f);

--- a/src/util/is_mmtk_object.rs
+++ b/src/util/is_mmtk_object.rs
@@ -7,6 +7,11 @@ use crate::util::{Address, ObjectReference};
 
 pub(crate) fn check_object_reference(addr: Address) -> Option<ObjectReference> {
     use crate::mmtk::SFT_MAP;
+    debug_assert_ne!(addr, Address::ZERO, "Address is zero");
+    debug_assert!(
+        addr.is_aligned_to(ObjectReference::ALIGNMENT),
+        "Address is not aligned to word size: {addr}"
+    );
     SFT_MAP.get_checked(addr).is_mmtk_object(addr)
 }
 

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -125,7 +125,7 @@ pub trait Region: Copy + PartialEq + PartialOrd {
         debug_assert!(self.start().as_usize() < usize::MAX - (n << Self::LOG_BYTES));
         Self::from_aligned_address(self.start() + (n << Self::LOG_BYTES))
     }
-    /// Return the region that contains the object (by its cell address).
+    /// Return the region that contains the object.
     fn containing(object: ObjectReference) -> Self {
         Self::from_unaligned_address(object.to_raw_address())
     }

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -27,6 +27,14 @@ impl<VM: VMBinding, S: LinearScanObjectSize, const ATOMIC_LOAD_VO_BIT: bool>
     /// that the VO bit metadata is mapped for the address range.
     pub fn new(start: Address, end: Address) -> Self {
         debug_assert!(start < end);
+        debug_assert!(
+            start.is_aligned_to(ObjectReference::ALIGNMENT),
+            "start is not word-aligned: {start}"
+        );
+        debug_assert!(
+            end.is_aligned_to(ObjectReference::ALIGNMENT),
+            "end is not word-aligned: {end}"
+        );
         ObjectIterator {
             start,
             end,

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -44,9 +44,9 @@ impl<VM: VMBinding, S: LinearScanObjectSize, const ATOMIC_LOAD_VO_BIT: bool> std
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         while self.cursor < self.end {
             let is_object = if ATOMIC_LOAD_VO_BIT {
-                vo_bit::is_vo_bit_set_for_addr::<VM>(self.cursor)
+                vo_bit::is_vo_bit_set_for_addr(self.cursor)
             } else {
-                unsafe { vo_bit::is_vo_bit_set_unsafe::<VM>(self.cursor) }
+                unsafe { vo_bit::is_vo_bit_set_unsafe(self.cursor) }
             };
 
             if let Some(object) = is_object {
@@ -118,8 +118,8 @@ pub trait Region: Copy + PartialEq + PartialOrd {
         Self::from_aligned_address(self.start() + (n << Self::LOG_BYTES))
     }
     /// Return the region that contains the object (by its cell address).
-    fn containing<VM: VMBinding>(object: ObjectReference) -> Self {
-        Self::from_unaligned_address(object.to_address::<VM>())
+    fn containing(object: ObjectReference) -> Self {
+        Self::from_unaligned_address(object.to_raw_address())
     }
     /// Check if the given address is in the region.
     fn includes_address(&self, addr: Address) -> bool {

--- a/src/util/metadata/global.rs
+++ b/src/util/metadata/global.rs
@@ -55,7 +55,7 @@ impl MetadataSpec {
         mask: Option<T>,
     ) -> T {
         match self {
-            MetadataSpec::OnSide(metadata_spec) => metadata_spec.load(object.to_address::<VM>()),
+            MetadataSpec::OnSide(metadata_spec) => metadata_spec.load(object.to_raw_address()),
             MetadataSpec::InHeader(metadata_spec) => {
                 VM::VMObjectModel::load_metadata::<T>(metadata_spec, object, mask)
             }
@@ -79,7 +79,7 @@ impl MetadataSpec {
     ) -> T {
         match self {
             MetadataSpec::OnSide(metadata_spec) => {
-                metadata_spec.load_atomic(object.to_address::<VM>(), ordering)
+                metadata_spec.load_atomic(object.to_raw_address(), ordering)
             }
             MetadataSpec::InHeader(metadata_spec) => {
                 VM::VMObjectModel::load_metadata_atomic::<T>(metadata_spec, object, mask, ordering)
@@ -105,7 +105,7 @@ impl MetadataSpec {
     ) {
         match self {
             MetadataSpec::OnSide(metadata_spec) => {
-                metadata_spec.store(object.to_address::<VM>(), val);
+                metadata_spec.store(object.to_raw_address(), val);
             }
             MetadataSpec::InHeader(metadata_spec) => {
                 VM::VMObjectModel::store_metadata::<T>(metadata_spec, object, val, mask)
@@ -130,7 +130,7 @@ impl MetadataSpec {
     ) {
         match self {
             MetadataSpec::OnSide(metadata_spec) => {
-                metadata_spec.store_atomic(object.to_address::<VM>(), val, ordering);
+                metadata_spec.store_atomic(object.to_raw_address(), val, ordering);
             }
             MetadataSpec::InHeader(metadata_spec) => VM::VMObjectModel::store_metadata_atomic::<T>(
                 metadata_spec,
@@ -165,7 +165,7 @@ impl MetadataSpec {
     ) -> std::result::Result<T, T> {
         match self {
             MetadataSpec::OnSide(metadata_spec) => metadata_spec.compare_exchange_atomic(
-                object.to_address::<VM>(),
+                object.to_raw_address(),
                 old_val,
                 new_val,
                 success_order,
@@ -202,7 +202,7 @@ impl MetadataSpec {
     ) -> T {
         match self {
             MetadataSpec::OnSide(metadata_spec) => {
-                metadata_spec.fetch_add_atomic(object.to_address::<VM>(), val, order)
+                metadata_spec.fetch_add_atomic(object.to_raw_address(), val, order)
             }
             MetadataSpec::InHeader(metadata_spec) => {
                 VM::VMObjectModel::fetch_add_metadata::<T>(metadata_spec, object, val, order)
@@ -227,7 +227,7 @@ impl MetadataSpec {
     ) -> T {
         match self {
             MetadataSpec::OnSide(metadata_spec) => {
-                metadata_spec.fetch_sub_atomic(object.to_address::<VM>(), val, order)
+                metadata_spec.fetch_sub_atomic(object.to_raw_address(), val, order)
             }
             MetadataSpec::InHeader(metadata_spec) => {
                 VM::VMObjectModel::fetch_sub_metadata::<T>(metadata_spec, object, val, order)
@@ -252,7 +252,7 @@ impl MetadataSpec {
     ) -> T {
         match self {
             MetadataSpec::OnSide(metadata_spec) => {
-                metadata_spec.fetch_and_atomic(object.to_address::<VM>(), val, order)
+                metadata_spec.fetch_and_atomic(object.to_raw_address(), val, order)
             }
             MetadataSpec::InHeader(metadata_spec) => {
                 VM::VMObjectModel::fetch_and_metadata::<T>(metadata_spec, object, val, order)
@@ -277,7 +277,7 @@ impl MetadataSpec {
     ) -> T {
         match self {
             MetadataSpec::OnSide(metadata_spec) => {
-                metadata_spec.fetch_or_atomic(object.to_address::<VM>(), val, order)
+                metadata_spec.fetch_or_atomic(object.to_raw_address(), val, order)
             }
             MetadataSpec::InHeader(metadata_spec) => {
                 VM::VMObjectModel::fetch_or_metadata::<T>(metadata_spec, object, val, order)
@@ -308,7 +308,7 @@ impl MetadataSpec {
     ) -> std::result::Result<T, T> {
         match self {
             MetadataSpec::OnSide(metadata_spec) => metadata_spec.fetch_update_atomic(
-                object.to_address::<VM>(),
+                object.to_raw_address(),
                 set_order,
                 fetch_order,
                 f,

--- a/src/util/metadata/log_bit.rs
+++ b/src/util/metadata/log_bit.rs
@@ -23,7 +23,7 @@ impl VMGlobalLogBitSpec {
             // know we are setting log bit for mature space, and every object in the space should have log
             // bit as 1.
             MetadataSpec::OnSide(spec) => unsafe {
-                spec.set_raw_byte_atomic(object.to_address::<VM>(), order)
+                spec.set_raw_byte_atomic(object.to_raw_address(), order)
             },
         }
     }

--- a/src/util/metadata/vo_bit/helper.rs
+++ b/src/util/metadata/vo_bit/helper.rs
@@ -142,7 +142,7 @@ pub(crate) fn on_trace_object<VM: VMBinding>(object: ObjectReference) {
         // If the VO bits are available during tracing,
         // we validate the objects we trace using the VO bits.
         debug_assert!(
-            vo_bit::is_vo_bit_set::<VM>(object),
+            vo_bit::is_vo_bit_set(object),
             "{:x}: VO bit not set",
             object
         );
@@ -153,7 +153,7 @@ pub(crate) fn on_object_marked<VM: VMBinding>(object: ObjectReference) {
     match strategy::<VM>() {
         VOBitUpdateStrategy::ClearAndReconstruct => {
             // In this strategy, we set the VO bit when an object is marked.
-            vo_bit::set_vo_bit::<VM>(object);
+            vo_bit::set_vo_bit(object);
         }
         VOBitUpdateStrategy::CopyFromMarkBits => {
             // VO bit was not cleared before tracing in this strategy.  Do nothing.
@@ -165,7 +165,7 @@ pub(crate) fn on_object_forwarded<VM: VMBinding>(new_object: ObjectReference) {
     match strategy::<VM>() {
         VOBitUpdateStrategy::ClearAndReconstruct => {
             // In this strategy, we set the VO bit of the to-space object when forwarded.
-            vo_bit::set_vo_bit::<VM>(new_object);
+            vo_bit::set_vo_bit(new_object);
         }
         VOBitUpdateStrategy::CopyFromMarkBits => {
             // In this strategy, we will copy mark bits to VO bits.
@@ -178,7 +178,7 @@ pub(crate) fn on_object_forwarded<VM: VMBinding>(new_object: ObjectReference) {
             );
 
             // We set the VO bit for the to-space object eagerly.
-            vo_bit::set_vo_bit::<VM>(new_object);
+            vo_bit::set_vo_bit(new_object);
         }
     }
 }

--- a/src/util/metadata/vo_bit/mod.rs
+++ b/src/util/metadata/vo_bit/mod.rs
@@ -95,17 +95,17 @@ pub fn is_vo_bit_set(object: ObjectReference) -> bool {
 
 /// Check if an address can be turned directly into an object reference using the VO bit.
 /// If so, return `Some(object)`. Otherwise return `None`.
+///
+/// The `address` must be word-aligned.
 pub fn is_vo_bit_set_for_addr(address: Address) -> Option<ObjectReference> {
-    // if the address is not aligned, it cannot be an object reference.
-    if !address.is_aligned_to(ObjectReference::ALIGNMENT) {
-        return None;
-    }
     is_vo_bit_set_inner::<true>(address)
 }
 
 /// Check if an address can be turned directly into an object reference using the VO bit.
 /// If so, return `Some(object)`. Otherwise return `None`. The caller needs to ensure the side
 /// metadata for the VO bit for the object is accessed by only one thread.
+///
+/// The `address` must be word-aligned.
 ///
 /// # Safety
 ///
@@ -115,6 +115,11 @@ pub unsafe fn is_vo_bit_set_unsafe(address: Address) -> Option<ObjectReference> 
 }
 
 fn is_vo_bit_set_inner<const ATOMIC: bool>(address: Address) -> Option<ObjectReference> {
+    debug_assert!(
+        address.is_aligned_to(ObjectReference::ALIGNMENT),
+        "Address is not word-aligned: {address}"
+    );
+
     let addr = get_in_object_address_for_potential_object(address);
 
     // If we haven't mapped VO bit for the address, it cannot be an object

--- a/src/util/metadata/vo_bit/mod.rs
+++ b/src/util/metadata/vo_bit/mod.rs
@@ -61,24 +61,20 @@ pub(crate) const VO_BIT_SIDE_METADATA_SPEC: SideMetadataSpec =
 pub const VO_BIT_SIDE_METADATA_ADDR: Address = VO_BIT_SIDE_METADATA_SPEC.get_absolute_offset();
 
 /// Atomically set the VO bit for an object.
-pub fn set_vo_bit<VM: VMBinding>(object: ObjectReference) {
-    debug_assert!(
-        !is_vo_bit_set::<VM>(object),
-        "{:x}: VO bit already set",
-        object
-    );
-    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_address::<VM>(), 1, Ordering::SeqCst);
+pub fn set_vo_bit(object: ObjectReference) {
+    debug_assert!(!is_vo_bit_set(object), "{:x}: VO bit already set", object);
+    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_raw_address(), 1, Ordering::SeqCst);
 }
 
 /// Atomically unset the VO bit for an object.
-pub fn unset_vo_bit<VM: VMBinding>(object: ObjectReference) {
-    debug_assert!(is_vo_bit_set::<VM>(object), "{:x}: VO bit not set", object);
-    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_address::<VM>(), 0, Ordering::SeqCst);
+pub fn unset_vo_bit(object: ObjectReference) {
+    debug_assert!(is_vo_bit_set(object), "{:x}: VO bit not set", object);
+    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_raw_address(), 0, Ordering::SeqCst);
 }
 
 /// Atomically unset the VO bit for an object, regardless whether the bit is set or not.
-pub fn unset_vo_bit_nocheck<VM: VMBinding>(object: ObjectReference) {
-    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_address::<VM>(), 0, Ordering::SeqCst);
+pub fn unset_vo_bit_nocheck(object: ObjectReference) {
+    VO_BIT_SIDE_METADATA_SPEC.store_atomic::<u8>(object.to_raw_address(), 0, Ordering::SeqCst);
 }
 
 /// Non-atomically unset the VO bit for an object. The caller needs to ensure the side
@@ -87,24 +83,24 @@ pub fn unset_vo_bit_nocheck<VM: VMBinding>(object: ObjectReference) {
 /// # Safety
 ///
 /// This is unsafe: check the comment on `side_metadata::store`
-pub unsafe fn unset_vo_bit_unsafe<VM: VMBinding>(object: ObjectReference) {
-    debug_assert!(is_vo_bit_set::<VM>(object), "{:x}: VO bit not set", object);
-    VO_BIT_SIDE_METADATA_SPEC.store::<u8>(object.to_address::<VM>(), 0);
+pub unsafe fn unset_vo_bit_unsafe(object: ObjectReference) {
+    debug_assert!(is_vo_bit_set(object), "{:x}: VO bit not set", object);
+    VO_BIT_SIDE_METADATA_SPEC.store::<u8>(object.to_raw_address(), 0);
 }
 
 /// Check if the VO bit is set for an object.
-pub fn is_vo_bit_set<VM: VMBinding>(object: ObjectReference) -> bool {
-    VO_BIT_SIDE_METADATA_SPEC.load_atomic::<u8>(object.to_address::<VM>(), Ordering::SeqCst) == 1
+pub fn is_vo_bit_set(object: ObjectReference) -> bool {
+    VO_BIT_SIDE_METADATA_SPEC.load_atomic::<u8>(object.to_raw_address(), Ordering::SeqCst) == 1
 }
 
 /// Check if an address can be turned directly into an object reference using the VO bit.
 /// If so, return `Some(object)`. Otherwise return `None`.
-pub fn is_vo_bit_set_for_addr<VM: VMBinding>(address: Address) -> Option<ObjectReference> {
+pub fn is_vo_bit_set_for_addr(address: Address) -> Option<ObjectReference> {
     // if the address is not aligned, it cannot be an object reference.
     if !address.is_aligned_to(ObjectReference::ALIGNMENT) {
         return None;
     }
-    is_vo_bit_set_inner::<true, VM>(address)
+    is_vo_bit_set_inner::<true>(address)
 }
 
 /// Check if an address can be turned directly into an object reference using the VO bit.
@@ -114,14 +110,12 @@ pub fn is_vo_bit_set_for_addr<VM: VMBinding>(address: Address) -> Option<ObjectR
 /// # Safety
 ///
 /// This is unsafe: check the comment on `side_metadata::load`
-pub unsafe fn is_vo_bit_set_unsafe<VM: VMBinding>(address: Address) -> Option<ObjectReference> {
-    is_vo_bit_set_inner::<false, VM>(address)
+pub unsafe fn is_vo_bit_set_unsafe(address: Address) -> Option<ObjectReference> {
+    is_vo_bit_set_inner::<false>(address)
 }
 
-fn is_vo_bit_set_inner<const ATOMIC: bool, VM: VMBinding>(
-    address: Address,
-) -> Option<ObjectReference> {
-    let addr = get_in_object_address_for_potential_object::<VM>(address);
+fn is_vo_bit_set_inner<const ATOMIC: bool>(address: Address) -> Option<ObjectReference> {
+    let addr = get_in_object_address_for_potential_object(address);
 
     // If we haven't mapped VO bit for the address, it cannot be an object
     if !VO_BIT_SIDE_METADATA_SPEC.is_mapped(addr) {
@@ -135,7 +129,7 @@ fn is_vo_bit_set_inner<const ATOMIC: bool, VM: VMBinding>(
     };
 
     if vo_bit == 1 {
-        let obj = get_object_ref_for_vo_addr::<VM>(addr);
+        let obj = get_object_ref_for_vo_addr(addr);
         Some(obj)
     } else {
         None
@@ -196,13 +190,13 @@ pub fn find_object_from_internal_pointer<VM: VMBinding>(
 }
 
 /// Turning a potential object reference into its in-object address (the ref_to_address address) where the metadata is set for.
-fn get_in_object_address_for_potential_object<VM: VMBinding>(potential_obj: Address) -> Address {
-    potential_obj.offset(VM::VMObjectModel::IN_OBJECT_ADDRESS_OFFSET)
+fn get_in_object_address_for_potential_object(potential_obj: Address) -> Address {
+    potential_obj
 }
 
 /// Get the object reference from an aligned address where VO bit is set.
-pub(crate) fn get_object_ref_for_vo_addr<VM: VMBinding>(vo_addr: Address) -> ObjectReference {
-    let addr = vo_addr.offset(-VM::VMObjectModel::IN_OBJECT_ADDRESS_OFFSET);
+pub(crate) fn get_object_ref_for_vo_addr(vo_addr: Address) -> ObjectReference {
+    let addr = vo_addr;
     let aligned = addr.align_up(ObjectReference::ALIGNMENT);
     unsafe { ObjectReference::from_raw_address_unchecked(aligned) }
 }
@@ -222,7 +216,7 @@ pub fn is_internal_ptr_from_vo_bit<VM: VMBinding>(
     // VO bit should be set on the address.
     debug_assert!(unsafe { is_vo_addr(vo_addr) });
 
-    let obj = get_object_ref_for_vo_addr::<VM>(vo_addr);
+    let obj = get_object_ref_for_vo_addr(vo_addr);
     if is_internal_ptr::<VM>(obj, internal_ptr) {
         Some(obj)
     } else {

--- a/src/util/object_enum.rs
+++ b/src/util/object_enum.rs
@@ -58,7 +58,7 @@ where
 
     fn visit_address_range(&mut self, start: Address, end: Address) {
         VO_BIT.scan_non_zero_values::<u8>(start, end, &mut |address| {
-            let object = vo_bit::get_object_ref_for_vo_addr::<VM>(address);
+            let object = vo_bit::get_object_ref_for_vo_addr(address);
             (self.object_callback)(object);
         })
     }

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -192,7 +192,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SanityGCProcessEdges<VM> {
         let mut sanity_checker = self.mmtk().sanity_checker.lock().unwrap();
         if !sanity_checker.refs.contains(&object) {
             // FIXME steveb consider VM-specific integrity check on reference.
-            assert!(object.is_sane::<VM>(), "Invalid reference {:?}", object);
+            assert!(object.is_sane(), "Invalid reference {:?}", object);
 
             // Let plan check object
             assert!(
@@ -217,7 +217,7 @@ impl<VM: VMBinding> ProcessEdgesWork for SanityGCProcessEdges<VM> {
         // If the valid object (VO) bit metadata is enabled, all live objects should have the VO
         // bit set when sanity GC starts.
         #[cfg(feature = "vo_bit")]
-        if !crate::util::metadata::vo_bit::is_vo_bit_set::<VM>(object) {
+        if !crate::util::metadata::vo_bit::is_vo_bit_set(object) {
             panic!("VO bit is not set: {}", object);
         }
 

--- a/src/util/test_util/mock_vm.rs
+++ b/src/util/test_util/mock_vm.rs
@@ -523,9 +523,6 @@ impl crate::vm::ObjectModel<MockVM> for MockVM {
         mock!(ref_to_header(object))
     }
 
-    // TODO: This is not mocked. We need a way to deal with it.
-    const IN_OBJECT_ADDRESS_OFFSET: isize = -(DEFAULT_OBJECT_REF_OFFSET as isize);
-
     fn dump_object(object: ObjectReference) {
         mock!(dump_object(object))
     }

--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -44,6 +44,8 @@ pub trait ActivePlan<VM: VMBinding> {
     ///
     /// The method should return the new object reference if the method moves the object, otherwise return the original object reference.
     ///
+    /// Note: **This is an experimental feature**, and may not interact well with other parts of MMTk.  Use with caution.
+    ///
     /// Arguments:
     /// * `queue`: The object queue. If an object is encountered for the first time in this GC, we expect the implementation to call `queue.enqueue()`
     ///            for the object. If the object is moved during the tracing, the new object reference (after copying) should be enqueued instead.

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -425,7 +425,7 @@ pub trait ObjectModel<VM: VMBinding> {
     /// mature space for generational plans.
     const VM_WORST_CASE_COPY_EXPANSION: f64 = 1.5;
 
-    /// If this is true, the binding guarantees that the object reference's raw addressand the
+    /// If this is true, the binding guarantees that the object reference's raw address and the
     /// object start are always the same address.  In other words, an object reference's raw
     /// address is always equal to the return value of the `ref_to_object_start` method,
     ///

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -64,24 +64,17 @@ use crate::vm::VMBinding;
 /// Instead, MMTk only uses the following addresses for an object. If you find the MMTk's approach does not work for your language in practice, you are welcome to submit an issue
 /// or engage with MMTk team on Zulip to disucss further.
 ///
-/// ## Object Reference
+/// ## (Raw) Object Reference
 ///
-/// See [`crate::util::address::ObjectReference`]. This is a special address that represents the object.
-/// MMTk refers to an object by its object reference. An object reference cannot be NULL, and has to be
-/// word aligned ([`crate::util::address::ObjectReference::ALIGNMENT`]). It is allowed that an object
-/// reference is not in the allocated memory for the object.
+/// See [`crate::util::address::ObjectReference`]. This is a special address that represents the
+/// object. MMTk refers to an object by its object reference. An object reference cannot be NULL,
+/// must be inside the address range of the object, and must be word aligned
+/// ([`crate::util::address::ObjectReference::ALIGNMENT`]).
 ///
 /// ## Object Start Address
 ///
 /// This address is returned by an allocation call [`crate::memory_manager::alloc`]. This is the start of the address range of the allocation.
 /// [`ObjectModel::ref_to_object_start`] should return this address for a given object.
-///
-/// ## In-object Address
-///
-/// As the object reference address may be outside the allocated memory, and calculating the object start address may
-/// be complex, MMTk requires a fixed and efficient in-object address for each object. The in-object address must be a constant
-/// offset from the object reference address, and must be inside the allocated memory. MMTk requires the binding to
-/// specify the offset from the object reference to the in-object address by [`ObjectModel::IN_OBJECT_ADDRESS_OFFSET`].
 ///
 /// ## Object header address
 ///
@@ -432,10 +425,9 @@ pub trait ObjectModel<VM: VMBinding> {
     /// mature space for generational plans.
     const VM_WORST_CASE_COPY_EXPANSION: f64 = 1.5;
 
-    /// If this is true, the binding guarantees that the object reference's raw address,
-    /// the in-object address, and the object start are always the same address. To be precise,
-    /// 1. an object reference's raw address is always equal to the return value of the `ref_to_object_start` method,
-    /// 2. `IN_OBJECT_ADDRESS_OFFSET` is 0.
+    /// If this is true, the binding guarantees that the object reference's raw addressand the
+    /// object start are always the same address.  In other words, an object reference's raw
+    /// address is always equal to the return value of the `ref_to_object_start` method,
     ///
     /// This is a very strong guarantee, but it is also helpful for MMTk to
     /// make some assumptions and optimize for this case.
@@ -472,11 +464,6 @@ pub trait ObjectModel<VM: VMBinding> {
     /// Arguments:
     /// * `object`: The object to be queried.
     fn ref_to_header(object: ObjectReference) -> Address;
-
-    /// The offset from the object reference to an in-object address.
-    /// The binding needs to guarantee that obj_ref.to_raw_address() + IN_OBJECT_ADDRESS_OFFSET
-    /// is inside the storage associated with the object.
-    const IN_OBJECT_ADDRESS_OFFSET: isize;
 
     /// Dump debugging information for an object.
     ///

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_before_object_ref.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_before_object_ref.rs
@@ -30,11 +30,10 @@ pub fn interior_pointer_before_object_ref() {
 
             let obj = MockVM::object_start_to_ref(addr);
             println!(
-                "start = {}, end = {}, obj = {}, in-obj addr = {}",
+                "start = {}, end = {}, obj = {}",
                 addr,
                 addr + OBJECT_SIZE,
                 obj,
-                obj.to_address::<MockVM>()
             );
             memory_manager::post_alloc(
                 &mut fixture.mutator,
@@ -42,21 +41,6 @@ pub fn interior_pointer_before_object_ref() {
                 OBJECT_SIZE,
                 AllocationSemantics::Default,
             );
-
-            // Forge a pointer that points before the object reference, but after in-object address. MMTk should still find the base reference properly.
-
-            let before_obj_ref = addr;
-            assert!(before_obj_ref < obj.to_raw_address());
-            assert!(before_obj_ref >= obj.to_address::<MockVM>());
-
-            println!("Check {:?}", before_obj_ref);
-            let base_ref = crate::memory_manager::find_object_from_internal_pointer::<MockVM>(
-                before_obj_ref,
-                usize::MAX,
-            );
-            println!("base_ref {:?}", base_ref);
-            assert!(base_ref.is_some());
-            assert_eq!(base_ref.unwrap(), obj);
         },
         no_cleanup,
     )

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_invalid.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_invalid.rs
@@ -15,10 +15,8 @@ pub fn interior_pointer_invalid() {
             let _ = MutatorFixture::create_with_heapsize(10 * MB);
 
             let assert_no_object = |addr: Address| {
-                let base_ref = crate::memory_manager::find_object_from_internal_pointer::<MockVM>(
-                    addr,
-                    usize::MAX,
-                );
+                let base_ref =
+                    crate::memory_manager::find_object_from_internal_pointer(addr, usize::MAX);
                 assert!(base_ref.is_none());
             };
 

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_multi_page.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_multi_page.rs
@@ -33,11 +33,10 @@ pub fn interior_pointer_in_large_object() {
 
             let obj = MockVM::object_start_to_ref(addr);
             println!(
-                "start = {}, end = {}, obj = {}, in-obj addr = {}",
+                "start = {}, end = {}, obj = {}",
                 addr,
                 addr + OBJECT_SIZE,
                 obj,
-                obj.to_address::<MockVM>()
             );
 
             memory_manager::post_alloc(
@@ -47,25 +46,22 @@ pub fn interior_pointer_in_large_object() {
                 AllocationSemantics::Los,
             );
 
-            let test_internal_ptr =
-                |ptr: Address| {
-                    println!("ptr = {}", ptr);
-                    if ptr > addr + OBJECT_SIZE {
-                        // not internal pointer
-                        let base_ref = crate::memory_manager::find_object_from_internal_pointer::<
-                            MockVM,
-                        >(ptr, usize::MAX);
-                        println!("{:?}", base_ref);
-                        assert!(base_ref.is_none());
-                    } else {
-                        // is internal pointer
-                        let base_ref = crate::memory_manager::find_object_from_internal_pointer::<
-                            MockVM,
-                        >(ptr, usize::MAX);
-                        assert!(base_ref.is_some());
-                        assert_eq!(base_ref.unwrap(), obj);
-                    }
-                };
+            let test_internal_ptr = |ptr: Address| {
+                println!("ptr = {}", ptr);
+                if ptr > addr + OBJECT_SIZE {
+                    // not internal pointer
+                    let base_ref =
+                        crate::memory_manager::find_object_from_internal_pointer(ptr, usize::MAX);
+                    println!("{:?}", base_ref);
+                    assert!(base_ref.is_none());
+                } else {
+                    // is internal pointer
+                    let base_ref =
+                        crate::memory_manager::find_object_from_internal_pointer(ptr, usize::MAX);
+                    assert!(base_ref.is_some());
+                    assert_eq!(base_ref.unwrap(), obj);
+                }
+            };
 
             // Test with the first 1024 bytes as offset in the object
             for offset in 0..1024usize {

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_same_page.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_same_page.rs
@@ -34,11 +34,10 @@ pub fn interior_pointer_in_large_object_same_page() {
 
             let obj = MockVM::object_start_to_ref(addr);
             println!(
-                "start = {}, end = {}, obj = {}, in-obj addr = {}",
+                "start = {}, end = {}, obj = {}",
                 addr,
                 addr + OBJECT_SIZE,
                 obj,
-                obj.to_address::<MockVM>()
             );
 
             memory_manager::post_alloc(
@@ -49,27 +48,21 @@ pub fn interior_pointer_in_large_object_same_page() {
             );
 
             let ptr = obj.to_raw_address();
-            let base_ref = crate::memory_manager::find_object_from_internal_pointer::<MockVM>(
-                ptr,
-                OBJECT_SIZE,
-            );
+            let base_ref =
+                crate::memory_manager::find_object_from_internal_pointer(ptr, OBJECT_SIZE);
             println!("{:?}", base_ref);
             assert!(base_ref.is_some());
             assert_eq!(base_ref.unwrap(), obj);
 
             let ptr = obj.to_raw_address() + OBJECT_SIZE / 2;
-            let base_ref = crate::memory_manager::find_object_from_internal_pointer::<MockVM>(
-                ptr,
-                OBJECT_SIZE,
-            );
+            let base_ref =
+                crate::memory_manager::find_object_from_internal_pointer(ptr, OBJECT_SIZE);
             assert!(base_ref.is_some());
             assert_eq!(base_ref.unwrap(), obj);
 
             let ptr = obj.to_raw_address() + OBJECT_SIZE;
-            let base_ref = crate::memory_manager::find_object_from_internal_pointer::<MockVM>(
-                ptr,
-                OBJECT_SIZE,
-            );
+            let base_ref =
+                crate::memory_manager::find_object_from_internal_pointer(ptr, OBJECT_SIZE);
             assert!(base_ref.is_none());
         },
         no_cleanup,

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_normal_object.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_normal_object.rs
@@ -32,11 +32,10 @@ pub fn interior_pointer_in_normal_object() {
 
                 let obj = MockVM::object_start_to_ref(addr);
                 println!(
-                    "start = {}, end = {}, obj = {}, in-obj addr = {}",
+                    "start = {}, end = {}, obj = {}",
                     addr,
                     addr + OBJECT_SIZE,
                     obj,
-                    obj.to_address::<MockVM>()
                 );
                 memory_manager::post_alloc(
                     &mut fixture.mutator,
@@ -49,23 +48,25 @@ pub fn interior_pointer_in_normal_object() {
                     if ptr >= addr + OBJECT_SIZE {
                         println!("ptr = {}, not internal pointer", ptr);
                         // not internal pointer
-                        let base_ref = crate::memory_manager::find_object_from_internal_pointer::<
-                            MockVM,
-                        >(ptr, usize::MAX);
+                        let base_ref = crate::memory_manager::find_object_from_internal_pointer(
+                            ptr,
+                            usize::MAX,
+                        );
                         println!("{:?}", base_ref);
                         assert!(base_ref.is_none());
                     } else {
                         println!("ptr = {}, internal pointer", ptr);
                         // is internal pointer
-                        let base_ref = crate::memory_manager::find_object_from_internal_pointer::<
-                            MockVM,
-                        >(ptr, usize::MAX);
+                        let base_ref = crate::memory_manager::find_object_from_internal_pointer(
+                            ptr,
+                            usize::MAX,
+                        );
                         assert!(base_ref.is_some());
                         assert_eq!(base_ref.unwrap(), obj);
                     }
                 };
 
-                let base_ref = crate::memory_manager::find_object_from_internal_pointer::<MockVM>(
+                let base_ref = crate::memory_manager::find_object_from_internal_pointer(
                     obj.to_raw_address(),
                     OBJECT_SIZE,
                 );

--- a/src/vm/tests/mock_tests/mock_test_is_in_mmtk_spaces.rs
+++ b/src/vm/tests/mock_tests/mock_test_is_in_mmtk_spaces.rs
@@ -19,7 +19,7 @@ pub fn near_zero() {
                 // and decide if we need to test calling `is_in_mmtk_space` with 0 as an argument.
                 let addr = unsafe { Address::from_usize(DEFAULT_OBJECT_REF_OFFSET) };
                 assert!(
-                    !memory_manager::is_in_mmtk_spaces::<MockVM>(
+                    !memory_manager::is_in_mmtk_spaces(
                         ObjectReference::from_raw_address(addr).unwrap()
                     ),
                     "A very low address {addr} should not be in any MMTk spaces."
@@ -37,7 +37,7 @@ pub fn max() {
         || {
             SINGLE_OBJECT.with_fixture(|_fixture| {
                 assert!(
-                    !memory_manager::is_in_mmtk_spaces::<MockVM>(
+                    !memory_manager::is_in_mmtk_spaces(
                         ObjectReference::from_raw_address(
                             Address::MAX.align_down(crate::util::constants::BYTES_IN_ADDRESS)
                         )
@@ -58,7 +58,7 @@ pub fn direct_hit() {
         || {
             SINGLE_OBJECT.with_fixture(|fixture| {
                 assert!(
-                    memory_manager::is_in_mmtk_spaces::<MockVM>(fixture.objref),
+                    memory_manager::is_in_mmtk_spaces(fixture.objref),
                     "The address of the allocated object should be in the space"
                 );
             });
@@ -86,7 +86,7 @@ pub fn large_offsets_aligned() {
                     };
                     // It's just a smoke test.  It is hard to predict if the addr is still in any space,
                     // but it must not crash.
-                    let _ = memory_manager::is_in_mmtk_spaces::<MockVM>(
+                    let _ = memory_manager::is_in_mmtk_spaces(
                         ObjectReference::from_raw_address(addr).unwrap(),
                     );
                 }
@@ -115,7 +115,7 @@ pub fn negative_offsets() {
                     };
                     // It's just a smoke test.  It is hard to predict if the addr is still in any space,
                     // but it must not crash.
-                    let _ = memory_manager::is_in_mmtk_spaces::<MockVM>(
+                    let _ = memory_manager::is_in_mmtk_spaces(
                         ObjectReference::from_raw_address(
                             addr.align_down(crate::util::constants::BYTES_IN_ADDRESS),
                         )

--- a/src/vm/tests/mock_tests/mock_test_vm_layout_default.rs
+++ b/src/vm/tests/mock_tests/mock_test_vm_layout_default.rs
@@ -24,7 +24,7 @@ pub fn test_with_vm_layout(layout: Option<VMLayout>) {
     let addr = memory_manager::alloc(&mut fixture.mutator, 8, 8, 0, AllocationSemantics::Default);
     let obj = MockVM::object_start_to_ref(addr);
     // Test SFT
-    assert!(memory_manager::is_in_mmtk_spaces::<MockVM>(obj));
+    assert!(memory_manager::is_in_mmtk_spaces(obj));
     // Test mmapper
     assert!(memory_manager::is_mapped_address(addr));
 }


### PR DESCRIPTION
Require the raw address of `ObjectReference` to be within the address range of the object it refers to.  The raw address is now used directly for side metadata access and SFT dispatching.  This makes "in-object address" unnecessary, and we removed the concept of "in-object address" and related constants and methods.

Methods which use the "in-object address" for SFT dispatching or side-metadata access used to have a `<VM: VMBinding>` type parameter.  This PR removes that type parameter.

Because `ObjectReference` is now both within an object an word-aligned, the algorithm for searching for VO bits from internal pointers is slightly simplified.  The method `is_mmtk_object` now has undefined behavior for arguments that are zero or misaligned because they are obviously illegal addresses for `ObjectReference`, and the user should have filtered them out in the first place.

Fixes: https://github.com/mmtk/mmtk-core/issues/1170