### PR TITLE
Minor fixes

### DIFF
--- a/docs/dummyvm/src/lib.rs
+++ b/docs/dummyvm/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate libc;
-extern crate mmtk;
-
 use std::sync::OnceLock;
 
 use mmtk::vm::VMBinding;

--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -80,7 +80,7 @@ See also:
 
 ## 0.27.0
 
-### `is_mmtk_object` returns `Option<ObjectReference>
+### `is_mmtk_object` returns `Option<ObjectReference>`
 
 ```admonish tldr
 `memory_manager::is_mmtk_object` now returns `Option<ObjectReference>` instead of `bool`.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,8 +1,3 @@
-extern crate proc_macro;
-extern crate proc_macro_error;
-extern crate quote;
-extern crate syn;
-
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 use syn::parse_macro_input;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,15 +27,10 @@
 //!   i.e. [the memory manager API](memory_manager/index.html) that allows a language's memory manager to use MMTk
 //!   and [the VMBinding trait](vm/trait.VMBinding.html) that allows MMTk to call the language implementation.
 
-extern crate libc;
-extern crate strum_macros;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate atomic_traits;
-extern crate crossbeam;
-extern crate num_cpus;
 #[macro_use]
 extern crate downcast_rs;
 #[macro_use]

--- a/src/util/reference_processor.rs
+++ b/src/util/reference_processor.rs
@@ -223,7 +223,7 @@ impl ReferenceProcessor {
 
     // These funcions call `trace_object()`, which will ensure the object and its descendents will
     // be traced.  They are only called in steps that expand the transitive closure.  That include
-    // retaining soft references, and (for MarkSweep) tracing objects for forwarding.
+    // retaining soft references, and (for MarkCompact) tracing objects for forwarding.
     // Note that finalizers also expand the transitive closure.
     // These functions are intended to make the code easier to understand.
 

--- a/src/vm/reference_glue.rs
+++ b/src/vm/reference_glue.rs
@@ -28,7 +28,7 @@ pub trait ReferenceGlue<VM: VMBinding> {
     /// Get the referent from a weak reference object.
     ///
     /// Arguments:
-    /// * `object`: Reference to the referent.  `None`` if the object currently does not point to a
+    /// * `object`: Reference to the referent.  `None` if the object currently does not point to a
     ///   referent.  This may happen if the reference has been cleared.
     fn get_referent(object: ObjectReference) -> Option<ObjectReference>;
 

--- a/tests/test_address.rs
+++ b/tests/test_address.rs
@@ -1,5 +1,3 @@
-extern crate mmtk;
-
 use mmtk::util::Address;
 
 #[test]


### PR DESCRIPTION
Fixed typos in documents and comments.

Removed redundant `extern crate` items.