### PR TITLE
Add a feature immix_stress_copying

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,8 @@ immix_non_moving = []
 # if `immix_non_moving` is in use.
 sticky_immix_non_moving_nursery = []
 
-
+# Turn on stress copying for Immix. This is a debug feature to test copying for Immix plans.
+immix_stress_copying = []
 # Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.
 immix_smaller_block = []
 # Zero the unmarked lines after a GC cycle in immix. This helps debug untraced objects.

--- a/src/policy/immix/mod.rs
+++ b/src/policy/immix/mod.rs
@@ -17,7 +17,7 @@ pub const BLOCK_ONLY: bool = false;
 /// Do we allow Immix to do defragmentation?
 pub const DEFRAG: bool = !cfg!(feature = "immix_non_moving"); // defrag if we are allowed to move.
 
-// STRESS COPYING: Set the following options so that Immix will copy as many objects as possible.
+// STRESS COPYING: Set the feature 'immix_stress_copying' so that Immix will copy as many objects as possible.
 // Useful for debugging copying GC if you cannot use SemiSpace.
 //
 // | constant                  | when    | value   | comment                                                              |
@@ -32,15 +32,19 @@ pub const DEFRAG: bool = !cfg!(feature = "immix_non_moving"); // defrag if we ar
 // | `DEFRAG_HEADROOM_PERCENT` | stress  | `50`    | Reserve enough headroom to copy all objects.  50% is like SemiSpace. |
 
 /// Make every GC a defragment GC. (for debugging)
-pub const STRESS_DEFRAG: bool = false;
+pub const STRESS_DEFRAG: bool = cfg!(feature = "immix_stress_copying");
 
 /// Mark every allocated block as defragmentation source before GC. (for debugging)
-pub const DEFRAG_EVERY_BLOCK: bool = false;
+pub const DEFRAG_EVERY_BLOCK: bool = cfg!(feature = "immix_stress_copying");
 
 /// Percentage of heap size reserved for defragmentation.
 /// According to [this paper](https://doi.org/10.1145/1375581.1375586), Immix works well with
 /// headroom between 1% to 3% of the heap size.
-pub const DEFRAG_HEADROOM_PERCENT: usize = 2;
+pub const DEFRAG_HEADROOM_PERCENT: usize = if cfg!(feature = "immix_stress_copying") {
+    50
+} else {
+    2
+};
 
 /// If Immix is used as a nursery space, do we prefer copy?
 pub const PREFER_COPY_ON_NURSERY_GC: bool =


### PR DESCRIPTION
This PR adds a feature `immix_stress_copying`. The bindings can turn on stress copying for Immix without modifying the source code. We plan to test with stress copying for Julia in the CI.