### PR TITLE
Fix a race between forwarding bits and VO bits.

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -252,10 +252,11 @@ impl<VM: VMBinding> CopySpace<VM> {
                 object,
                 semantics.unwrap(),
                 worker.get_copy_context_mut(),
+                |_new_object| {
+                    #[cfg(feature = "vo_bit")]
+                    crate::util::metadata::vo_bit::set_vo_bit(_new_object);
+                },
             );
-
-            #[cfg(feature = "vo_bit")]
-            crate::util::metadata::vo_bit::set_vo_bit(new_object);
 
             trace!("Forwarding pointer");
             queue.enqueue(new_object);

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -660,15 +660,15 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 // We are forwarding objects. When the copy allocator allocates the block, it should
                 // mark the block. So we do not need to explicitly mark it here.
 
-                // Clippy complains if the "vo_bit" feature is not enabled.
-                #[allow(clippy::let_and_return)]
-                let new_object =
-                    object_forwarding::forward_object::<VM>(object, semantics, copy_context);
-
-                #[cfg(feature = "vo_bit")]
-                vo_bit::helper::on_object_forwarded::<VM>(new_object);
-
-                new_object
+                object_forwarding::forward_object::<VM>(
+                    object,
+                    semantics,
+                    copy_context,
+                    |_new_object| {
+                        #[cfg(feature = "vo_bit")]
+                        vo_bit::helper::on_object_forwarded::<VM>(_new_object);
+                    },
+                )
             };
             debug_assert_eq!(
                 Block::containing(new_object).get_state(),


### PR DESCRIPTION
The current code sets the forwarding bits before setting the VO bit when copying an object.  If another GC worker is attempting to forward the same object, it may observe the forwarding bits being `FORWARDED` but the VO bit is not set.  This violates the semantics of VO bits because VO bits should be set for both from-space and to-space copies.  This will affect VM bindings that assert slots always refer to a valid object when scanning objects and may update the same slot multiple times for some reasons.

This revision provides a mechanism to ensure that all necessary metadata are set before setting forwarding bits to `FORWARDED`.  Currently it affects the VO bits and the mark bits (which are used to update the VO bits in Immix-based plans).  It may be used for other metadata introduced in the future.