### PR TITLE
Install cargo-msrv using stable toolchain.

### DIFF
--- a/.github/workflows/cargo-msrv.yml
+++ b/.github/workflows/cargo-msrv.yml
@@ -24,7 +24,8 @@ jobs:
       - run: cargo --version
 
       - name: Install cargo-msrv
-        run: cargo install cargo-msrv
+        # The cargo-msrv tool sometimes requires a higher Rust version than our current rust-toolchain.
+        run: cargo +stable install cargo-msrv
       # Verify the MSRV defined in Cargo.toml
       - name: Verify MSRV
         run: cargo msrv verify


### PR DESCRIPTION
When running the CI check "msrv", we install the cargo-msrv command using the stable Rust toolchain because it sometimes requires a higher Rust version than our chosen version in the file `rust-toolchain`.