### PR TITLE
Fix auto merge branches

### DIFF
--- a/.github/workflows/auto-merge-inner.yml
+++ b/.github/workflows/auto-merge-inner.yml
@@ -15,6 +15,10 @@ on:
       ref:
         required: true
         type: string
+      # The upstream branch where the binding PR is targeting, such as master, dev
+      base_ref:
+        required: true
+        type: string
       # The core commit hash that the binding should be using.
       core_commit:
         required: true
@@ -35,7 +39,7 @@ jobs:
       - name: Check input conditions
         id: check-input
         run: |
-          if [[ "${{ inputs.repo }}" == ${{ inputs.base_repo }} ]] && [[ "${{ inputs.ref }}" == "master" ]]; then
+          if [[ "${{ inputs.repo }}" == ${{ inputs.base_repo }} ]] && [[ "${{ inputs.ref }}" == "${{ inputs.base_ref }}" ]]; then
             echo "Conditions not met"
             echo "skip=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,8 +36,9 @@ jobs:
     needs: [get-merged-pr, binding-refs]
     with:
       repo: ${{ needs.binding-refs.outputs.openjdk_binding_repo }}
-      base_repo: mmtk/mmtk-openjdk
+      base_repo: ${{ needs.binding-refs.outputs.openjdk_binding_repo_default }}
       ref: ${{ needs.binding-refs.outputs.openjdk_binding_ref }}
+      base_ref: ${{ needs.binding-refs.outputs.openjdk_binding_ref_default }}
       core_commit: ${{ needs.get-merged-pr.outputs.commit }}
       update_lockfile: cargo build
     secrets: inherit
@@ -47,8 +48,9 @@ jobs:
     needs: [get-merged-pr, binding-refs]
     with:
       repo: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo }}
-      base_repo: mmtk/mmtk-jikesrvm
+      base_repo: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo_default }}
       ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
+      base_ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref_default }}
       core_commit: ${{ needs.get-merged-pr.outputs.commit }}
       # `cargo generate-lockfile` will update other dependencies. We avoid using it for the bindings.
       # But we do not have a good option for JikesRVM. The Rust project in JikesRVM needs some source files
@@ -62,8 +64,9 @@ jobs:
     needs: [get-merged-pr, binding-refs]
     with:
       repo: ${{ needs.binding-refs.outputs.v8_binding_repo }}
-      base_repo: mmtk/mmtk-v8
+      base_repo: ${{ needs.binding-refs.outputs.v8_binding_repo_default }}
       ref: ${{ needs.binding-refs.outputs.v8_binding_ref }}
+      base_ref: ${{ needs.binding-refs.outputs.v8_binding_ref_default }}
       core_commit: ${{ needs.get-merged-pr.outputs.commit }}
       update_lockfile: cargo build --features nogc
     secrets: inherit
@@ -73,10 +76,14 @@ jobs:
     needs: [get-merged-pr, binding-refs]
     with:
       repo: ${{ needs.binding-refs.outputs.julia_binding_repo }}
-      base_repo: mmtk/mmtk-julia
+      base_repo: ${{ needs.binding-refs.outputs.julia_binding_repo_default }}
       ref: ${{ needs.binding-refs.outputs.julia_binding_ref }}
+      base_ref: ${{ needs.binding-refs.outputs.julia_binding_ref_default }}
       core_commit: ${{ needs.get-merged-pr.outputs.commit }}
-      update_lockfile: cargo build --features immix
+      # `cargo generate-lockfile` will update other dependencies. We avoid using it for the bindings.
+      # mmtk-julia uses bindgen during building and requires the Julia repo. This is a similar situation
+      # as mmtk-jikesrvm. To make thigns simpler, we just use `cargo generate-lockfile`.
+      update_lockfile: cargo generate-lockfile
     secrets: inherit
 
   check-merge-ruby-pr:
@@ -84,8 +91,9 @@ jobs:
     needs: [get-merged-pr, binding-refs]
     with:
       repo: ${{ needs.binding-refs.outputs.ruby_binding_repo }}
-      base_repo: mmtk/mmtk-ruby
+      base_repo: ${{ needs.binding-refs.outputs.ruby_binding_repo_default }}
       ref: ${{ needs.binding-refs.outputs.ruby_binding_ref }}
+      base_ref: ${{ needs.binding-refs.outputs.ruby_binding_ref_default }}
       core_commit: ${{ needs.get-merged-pr.outputs.commit }}
       update_lockfile: cargo build
     secrets: inherit

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
     - master
+  # Just for testing
+  pull_request:
+    branches:
+    - master
 
 jobs:
   # Figure out the PR that is merged.

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,10 +6,6 @@ on:
   push:
     branches:
     - master
-  # Just for testing
-  pull_request:
-    branches:
-    - master
 
 jobs:
   # Figure out the PR that is merged.

--- a/.github/workflows/pr-binding-refs.yml
+++ b/.github/workflows/pr-binding-refs.yml
@@ -38,33 +38,67 @@ on:
       openjdk_binding_repo:
         description: "The repository of OpenJDK binding, such as {user}/{repo}"
         value: ${{ jobs.binding-refs.outputs.openjdk_binding_repo}}
+      openjdk_binding_repo_default:
+        description: "The default repository of OpenJDK binding, such as {user}/{repo}"
+        value: ${{ jobs.binding-refs.outputs.openjdk_binding_repo_default }}
       openjdk_binding_ref:
         description: "The git ref of OpenJDK binding, such as sha and branch name"
         value: ${{ jobs.binding-refs.outputs.openjdk_binding_ref}}
+      openjdk_binding_ref_default:
+        description: "The default git ref of OpenJDK binding, such as sha and branch name"
+        value: ${{ jobs.binding-refs.outputs.openjdk_binding_ref_default }}
+
       jikesrvm_binding_repo:
         description: "The repository of JikesRVM binding, such as {user}/{repo}"
         value: ${{ jobs.binding-refs.outputs.jikesrvm_binding_repo}}
+      jikesrvm_binding_repo_default:
+        description: "The default repository of JikesRVM binding, such as {user}/{repo}"
+        value: ${{ jobs.binding-refs.outputs.jikesrvm_binding_repo_default }}
       jikesrvm_binding_ref:
         description: "The git ref of JikesRVM binding, such as sha and branch name"
         value: ${{ jobs.binding-refs.outputs.jikesrvm_binding_ref}}
+      jikesrvm_binding_ref_default:
+        description: "The default git ref of JikesRVM binding, such as sha and branch name"
+        value: ${{ jobs.binding-refs.outputs.jikesrvm_binding_ref_default }}
+
       v8_binding_repo:
         description: "The repository of V8 binding, such as {user}/{repo}"
         value: ${{ jobs.binding-refs.outputs.v8_binding_repo}}
+      v8_binding_repo_default:
+        description: "The default repository of V8 binding, such as {user}/{repo}"
+        value: ${{ jobs.binding-refs.outputs.v8_binding_repo_default }}
       v8_binding_ref:
         description: "The git ref of V8 binding, such as sha and branch name"
         value: ${{ jobs.binding-refs.outputs.v8_binding_ref}}
+      v8_binding_ref_default:
+        description: "The default git ref of V8 binding, such as sha and branch name"
+        value: ${{ jobs.binding-refs.outputs.v8_binding_ref_default }}
+
       julia_binding_repo:
         description: "The repository of Julia binding, such as {user}/{repo}"
         value: ${{ jobs.binding-refs.outputs.julia_binding_repo}}
+      julia_binding_repo_default:
+        description: "The default repository of Julia binding, such as {user}/{repo}"
+        value: ${{ jobs.binding-refs.outputs.julia_binding_repo_default }}
       julia_binding_ref:
         description: "The git ref of Julia binding, such as sha and branch name"
         value: ${{ jobs.binding-refs.outputs.julia_binding_ref}}
+      julia_binding_ref_default:
+        description: "The default git ref of Julia binding, such as sha and branch name"
+        value: ${{ jobs.binding-refs.outputs.julia_binding_ref_default }}
+
       ruby_binding_repo:
         description: "The repository of Ruby binding, such as {user}/{repo}"
         value: ${{ jobs.binding-refs.outputs.ruby_binding_repo}}
+      ruby_binding_repo_default:
+        description: "The default repository of Ruby binding, such as {user}/{repo}"
+        value: ${{ jobs.binding-refs.outputs.ruby_binding_repo_default }}
       ruby_binding_ref:
         description: "The git ref of Ruby binding, such as sha and branch name"
         value: ${{ jobs.binding-refs.outputs.ruby_binding_ref}}
+      ruby_binding_ref_default:
+        description: "The default git ref of Ruby binding, such as sha and branch name"
+        value: ${{ jobs.binding-refs.outputs.ruby_binding_ref_default }}
 
 jobs:
   binding-refs:
@@ -82,15 +116,25 @@ jobs:
       RUBY_BINDING_REF_DEFAULT: master
     outputs:
         openjdk_binding_repo: ${{ steps.print.outputs.openjdk_binding_repo }}
+        openjdk_binding_repo_default: ${{ env.OPENJDK_BINDING_REPO_DEFAULT }}
         openjdk_binding_ref: ${{ steps.print.outputs.openjdk_binding_ref }}
+        openjdk_binding_ref_default: ${{ env.OPENJDK_BINDING_REF_DEFAULT }}
         jikesrvm_binding_repo: ${{ steps.print.outputs.jikesrvm_binding_repo }}
+        jikesrvm_binding_repo_default: ${{ env.JIKESRVM_BINDING_REPO_DEFAULT }}
         jikesrvm_binding_ref: ${{ steps.print.outputs.jikesrvm_binding_ref }}
+        jikesrvm_binding_ref_default: ${{ env.JIKESRVM_BINDING_REF_DEFAULT }}
         v8_binding_repo: ${{ steps.print.outputs.v8_binding_repo }}
+        v8_binding_repo_default: ${{ env.V8_BINDING_REPO_DEFAULT }}
         v8_binding_ref: ${{ steps.print.outputs.v8_binding_ref }}
+        v8_binding_ref_default: ${{ env.V8_BINDING_REF_DEFAULT }}
         julia_binding_repo: ${{ steps.print.outputs.julia_binding_repo }}
+        julia_binding_repo_default: ${{ env.JULIA_BINDING_REPO_DEFAULT }}
         julia_binding_ref: ${{ steps.print.outputs.julia_binding_ref }}
+        julia_binding_ref_default: ${{ env.JULIA_BINDING_REF_DEFAULT }}
         ruby_binding_repo: ${{ steps.print.outputs.ruby_binding_repo }}
+        ruby_binding_repo_default: ${{ env.RUBY_BINDING_REPO_DEFAULT }}
         ruby_binding_ref: ${{ steps.print.outputs.ruby_binding_ref }}
+        ruby_binding_ref_default: ${{ env.RUBY_BINDING_REF_DEFAULT }}
     steps:
         - name: Check binding revisions
           uses: qinsoon/comment-env-vars@1.1.0


### PR DESCRIPTION
This PR changes the auto merge workflow. For each binding, the workflow now allows inputs for base repo and base ref. This change is mostly for the Julia binding which uses `dev` instead of `master` as the default branch. https://github.com/mmtk/mmtk-core/pull/1221 only changed for the correctness testing, this PR made corresponding changes for auto merge.