### PR TITLE
Collect live bytes per space, and report by space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,9 +172,6 @@ work_packet_stats = []
 # Count the malloc'd memory into the heap size
 malloc_counted_size = []
 
-# Count the size of all live objects in GC
-count_live_bytes_in_gc = []
-
 # Workaround a problem where bpftrace scripts (see tools/tracing/timeline/capture.bt) cannot
 # capture the type names of work packets.
 bpftrace_workaround = []

--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -30,6 +30,26 @@ Notes for the mmtk-core developers:
 
 <!-- Insert new versions here -->
 
+## 0.30.0
+
+### `live_bytes_in_last_gc` returns a map for live bytes in each space
+
+```admonish tldr
+The feature `count_live_bytes_in_gc` now collects live bytes statistics per space.
+Correspondingly, `memory_manager::live_bytes_in_last_gc` now returns a map for
+live bytes in each space.
+```
+
+API changes:
+
+-   module `memory_manager`
+    +   `live_bytes_in_last_gc` now returns a `HashMap<&'static str, LiveBytesStats>`. The keys are
+        strings for space names, and the values are statistics for live bytes in the space.
+
+See also:
+
+-   PR: <https://github.com/mmtk/mmtk-core/pull/1238>
+
 ## 0.28.0
 
 ### `handle_user_collection_request` returns `bool`

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -1,5 +1,4 @@
 use atomic_refcell::AtomicRefCell;
-#[cfg(feature = "count_live_bytes_in_gc")]
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
@@ -47,7 +46,6 @@ pub struct GlobalState {
     #[cfg(feature = "malloc_counted_size")]
     pub(crate) malloc_bytes: AtomicUsize,
     /// This stores the live bytes and the used bytes (by pages) for each space in last GC. This counter is only updated in the GC release phase.
-    #[cfg(feature = "count_live_bytes_in_gc")]
     pub(crate) live_bytes_in_last_gc: AtomicRefCell<HashMap<&'static str, LiveBytesStats>>,
 }
 
@@ -204,7 +202,6 @@ impl Default for GlobalState {
             allocation_bytes: AtomicUsize::new(0),
             #[cfg(feature = "malloc_counted_size")]
             malloc_bytes: AtomicUsize::new(0),
-            #[cfg(feature = "count_live_bytes_in_gc")]
             live_bytes_in_last_gc: AtomicRefCell::new(HashMap::new()),
         }
     }
@@ -219,7 +216,6 @@ pub enum GcStatus {
 
 /// Statistics for the live bytes in the last GC. The statistics is per space.
 #[derive(Copy, Clone, Debug)]
-#[cfg(feature = "count_live_bytes_in_gc")]
 pub struct LiveBytesStats {
     /// Total accumulated bytes of live objects in the space.
     pub live_bytes: usize,

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -46,9 +46,9 @@ pub struct GlobalState {
     /// A counteer that keeps tracks of the number of bytes allocated by malloc
     #[cfg(feature = "malloc_counted_size")]
     pub(crate) malloc_bytes: AtomicUsize,
-    /// This stores the size in bytes for all the live objects in last GC. This counter is only updated in the GC release phase.
+    /// This stores the live bytes and the used bytes (by pages) for each space in last GC. This counter is only updated in the GC release phase.
     #[cfg(feature = "count_live_bytes_in_gc")]
-    pub(crate) live_bytes_in_last_gc: AtomicRefCell<HashMap<&'static str, usize>>,
+    pub(crate) live_bytes_in_last_gc: AtomicRefCell<HashMap<&'static str, LiveBytesStats>>,
 }
 
 impl GlobalState {
@@ -215,4 +215,17 @@ pub enum GcStatus {
     NotInGC,
     GcPrepare,
     GcProper,
+}
+
+/// Statistics for the live bytes in the last GC. The statistics is per space.
+#[derive(Copy, Clone, Debug)]
+#[cfg(feature = "count_live_bytes_in_gc")]
+pub struct LiveBytesStats {
+    /// Total accumulated bytes of live objects in the space.
+    pub live_bytes: usize,
+    /// Total pages used by the space.
+    pub used_pages: usize,
+    /// Total bytes used by the space, computed from `used_pages`.
+    /// The ratio of live_bytes and used_bytes reflects the utilization of the memory in the space.
+    pub used_bytes: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub(crate) use mmtk::MMAPPER;
 pub use mmtk::MMTK;
 
 mod global_state;
+#[cfg(feature = "count_live_bytes_in_gc")]
+pub use crate::global_state::LiveBytesStats;
 
 mod policy;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ pub(crate) use mmtk::MMAPPER;
 pub use mmtk::MMTK;
 
 mod global_state;
-#[cfg(feature = "count_live_bytes_in_gc")]
 pub use crate::global_state::LiveBytesStats;
 
 mod policy;

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -26,7 +26,6 @@ use crate::vm::slot::MemorySlice;
 use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 
-#[cfg(feature = "count_live_bytes_in_gc")]
 use std::collections::HashMap;
 
 /// Initialize an MMTk instance. A VM should call this method after creating an [`crate::MMTK`]
@@ -542,7 +541,6 @@ pub fn free_bytes<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
 /// the space is fragmented.
 /// The value returned by this method is only updated when we finish tracing in a GC. A recommended timing
 /// to call this method is at the end of a GC (e.g. when the runtime is about to resume threads).
-#[cfg(feature = "count_live_bytes_in_gc")]
 pub fn live_bytes_in_last_gc<VM: VMBinding>(
     mmtk: &MMTK<VM>,
 ) -> HashMap<&'static str, crate::LiveBytesStats> {

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -26,6 +26,9 @@ use crate::vm::slot::MemorySlice;
 use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 
+#[cfg(feature = "count_live_bytes_in_gc")]
+use std::collections::HashMap;
+
 /// Initialize an MMTk instance. A VM should call this method after creating an [`crate::MMTK`]
 /// instance but before using any of the methods provided in MMTk (except `process()` and `process_bulk()`).
 ///
@@ -538,9 +541,8 @@ pub fn free_bytes<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
 /// The value returned by this method is only updated when we finish tracing in a GC. A recommended timing
 /// to call this method is at the end of a GC (e.g. when the runtime is about to resume threads).
 #[cfg(feature = "count_live_bytes_in_gc")]
-pub fn live_bytes_in_last_gc<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
-    use std::sync::atomic::Ordering;
-    mmtk.state.live_bytes_in_last_gc.load(Ordering::SeqCst)
+pub fn live_bytes_in_last_gc<VM: VMBinding>(mmtk: &MMTK<VM>) -> HashMap<&'static str, usize> {
+    mmtk.state.live_bytes_in_last_gc.borrow().clone()
 }
 
 /// Return the starting address of the heap. *Note that currently MMTk uses

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -534,14 +534,18 @@ pub fn free_bytes<VM: VMBinding>(mmtk: &MMTK<VM>) -> usize {
     mmtk.get_plan().get_free_pages() << LOG_BYTES_IN_PAGE
 }
 
-/// Return the size of all the live objects in bytes in the last GC. MMTk usually accounts for memory in pages.
+/// Return a hash map for live bytes statistics in the last GC for each space.
+///
+/// MMTk usually accounts for memory in pages by each space.
 /// This is a special method that we count the size of every live object in a GC, and sum up the total bytes.
-/// We provide this method so users can compare with `used_bytes` (which does page accounting), and know if
-/// the heap is fragmented.
+/// We provide this method so users can use [`crate::LiveBytesStats`] to know if
+/// the space is fragmented.
 /// The value returned by this method is only updated when we finish tracing in a GC. A recommended timing
 /// to call this method is at the end of a GC (e.g. when the runtime is about to resume threads).
 #[cfg(feature = "count_live_bytes_in_gc")]
-pub fn live_bytes_in_last_gc<VM: VMBinding>(mmtk: &MMTK<VM>) -> HashMap<&'static str, usize> {
+pub fn live_bytes_in_last_gc<VM: VMBinding>(
+    mmtk: &MMTK<VM>,
+) -> HashMap<&'static str, crate::LiveBytesStats> {
     mmtk.state.live_bytes_in_last_gc.borrow().clone()
 }
 

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -12,7 +12,6 @@ use crate::util::address::ObjectReference;
 use crate::util::analysis::AnalysisManager;
 use crate::util::finalizable_processor::FinalizableProcessor;
 use crate::util::heap::gc_trigger::GCTrigger;
-#[cfg(feature = "count_live_bytes_in_gc")]
 use crate::util::heap::layout::heap_parameters::MAX_SPACES;
 use crate::util::heap::layout::vm_layout::VMLayout;
 use crate::util::heap::layout::{self, Mmapper, VMMap};
@@ -28,7 +27,6 @@ use crate::util::statistics::stats::Stats;
 use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 use std::cell::UnsafeCell;
-#[cfg(feature = "count_live_bytes_in_gc")]
 use std::collections::HashMap;
 use std::default::Default;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -531,7 +529,6 @@ impl<VM: VMBinding> MMTK<VM> {
         })
     }
 
-    #[cfg(feature = "count_live_bytes_in_gc")]
     /// Aggregate a hash map of live bytes per space with the space stats to produce
     /// a map of live bytes stats for the spaces.
     pub(crate) fn aggregate_live_bytes_in_last_gc(

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -542,7 +542,7 @@ impl<VM: VMBinding> MMTK<VM> {
             let space_idx = space.get_descriptor().get_index();
             let used_pages = space.reserved_pages();
             if used_pages != 0 {
-                let used_bytes = used_pages << crate::util::constants::LOG_BYTES_IN_PAGE;
+                let used_bytes = crate::util::conversions::pages_to_bytes(used_pages);
                 let live_bytes = live_bytes_per_space[space_idx];
                 debug_assert!(
                     live_bytes <= used_bytes,

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -529,9 +529,9 @@ impl<VM: VMBinding> MMTK<VM> {
         })
     }
 
-    /// Aggregate a hash map of live bytes per space with the space stats to produce
-    /// a map of [`crate::liveByteStats`] for the spaces.
     #[cfg(feature = "count_live_bytes_in_gc")]
+    /// Aggregate a hash map of live bytes per space with the space stats to produce
+    /// a map of live bytes stats for the spaces.
     pub(crate) fn aggregate_live_bytes_in_last_gc(
         &self,
         live_bytes_per_space: HashMap<&'static str, usize>,
@@ -556,6 +556,6 @@ impl<VM: VMBinding> MMTK<VM> {
                 });
             }
         });
-        return ret;
+        ret
     }
 }

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -51,7 +51,6 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         mmtk.slot_logger.reset();
 
         // We do two passes of transitive closures. We clear the live bytes from the first pass.
-        #[cfg(feature = "count_live_bytes_in_gc")]
         mmtk.scheduler
             .worker_group
             .get_and_clear_worker_live_bytes();

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -25,7 +25,7 @@ pub struct CopySpace<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> SFT for CopySpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.get_name()
     }
 

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -86,7 +86,7 @@ pub struct ImmixSpaceArgs {
 unsafe impl<VM: VMBinding> Sync for ImmixSpace<VM> {}
 
 impl<VM: VMBinding> SFT for ImmixSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.get_name()
     }
 

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -27,7 +27,7 @@ pub struct ImmortalSpace<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.get_name()
     }
     fn is_live(&self, _object: ObjectReference) -> bool {

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -32,7 +32,7 @@ pub struct LargeObjectSpace<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.get_name()
     }
     fn is_live(&self, object: ObjectReference) -> bool {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -45,7 +45,7 @@ pub struct LockFreeImmortalSpace<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.get_name()
     }
     fn is_live(&self, _object: ObjectReference) -> bool {

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -33,7 +33,7 @@ pub const GC_EXTRA_HEADER_WORD: usize = 1;
 const GC_EXTRA_HEADER_BYTES: usize = GC_EXTRA_HEADER_WORD << LOG_BYTES_IN_WORD;
 
 impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.get_name()
     }
 

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -64,7 +64,7 @@ pub struct MallocSpace<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> SFT for MallocSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.get_name()
     }
 

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -157,7 +157,7 @@ impl AbandonedBlockLists {
 }
 
 impl<VM: VMBinding> SFT for MarkSweepSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.common.name
     }
 

--- a/src/policy/sft.rs
+++ b/src/policy/sft.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 /// table of SFT rather than Space.
 pub trait SFT {
     /// The space name
-    fn name(&self) -> &str;
+    fn name(&self) -> &'static str;
 
     /// Get forwarding pointer if the object is forwarded.
     fn get_forwarded_object(&self, _object: ObjectReference) -> Option<ObjectReference> {
@@ -120,7 +120,7 @@ pub const EMPTY_SFT_NAME: &str = "empty";
 pub const EMPTY_SPACE_SFT: EmptySpaceSFT = EmptySpaceSFT {};
 
 impl SFT for EmptySpaceSFT {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         EMPTY_SFT_NAME
     }
     fn is_live(&self, object: ObjectReference) -> bool {

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -323,6 +323,10 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         self.common().name
     }
 
+    fn get_descriptor(&self) -> SpaceDescriptor {
+        self.common().descriptor
+    }
+
     fn common(&self) -> &CommonSpace<VM>;
     fn get_gc_trigger(&self) -> &GCTrigger<VM> {
         self.common().gc_trigger.as_ref()

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -29,7 +29,7 @@ pub struct VMSpace<VM: VMBinding> {
 }
 
 impl<VM: VMBinding> SFT for VMSpace<VM> {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         self.common.name
     }
     fn is_live(&self, _object: ObjectReference) -> bool {

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -154,15 +154,12 @@ impl<C: GCWorkContext + 'static> GCWork<C::VM> for Release<C> {
             debug_assert!(result.is_ok());
         }
 
-        #[cfg(feature = "count_live_bytes_in_gc")]
-        {
-            let live_bytes = mmtk
-                .scheduler
-                .worker_group
-                .get_and_clear_worker_live_bytes();
-            *mmtk.state.live_bytes_in_last_gc.borrow_mut() =
-                mmtk.aggregate_live_bytes_in_last_gc(live_bytes);
-        }
+        let live_bytes = mmtk
+            .scheduler
+            .worker_group
+            .get_and_clear_worker_live_bytes();
+        *mmtk.state.live_bytes_in_last_gc.borrow_mut() =
+            mmtk.aggregate_live_bytes_in_last_gc(live_bytes);
     }
 }
 
@@ -821,7 +818,7 @@ pub trait ScanObjectsWork<VM: VMBinding>: GCWork<VM> + Sized {
         &self,
         buffer: &[ObjectReference],
         worker: &mut GCWorker<<Self::E as ProcessEdgesWork>::VM>,
-        _mmtk: &'static MMTK<<Self::E as ProcessEdgesWork>::VM>,
+        mmtk: &'static MMTK<<Self::E as ProcessEdgesWork>::VM>,
     ) {
         let tls = worker.tls;
 
@@ -833,8 +830,9 @@ pub trait ScanObjectsWork<VM: VMBinding>: GCWork<VM> + Sized {
             let mut closure = ObjectsClosure::<Self::E>::new(worker, self.get_bucket());
             for object in objects_to_scan.iter().copied() {
                 // For any object we need to scan, we count its liv bytes
-                #[cfg(feature = "count_live_bytes_in_gc")]
-                closure.worker.shared.increase_live_bytes(object);
+                if *mmtk.get_options().count_live_bytes_in_gc {
+                    closure.worker.shared.increase_live_bytes(object);
+                }
 
                 if <VM as VMBinding>::VMScanning::support_slot_enqueuing(tls, object) {
                     trace!("Scan object (slot) {}", object);

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -160,7 +160,8 @@ impl<C: GCWorkContext + 'static> GCWork<C::VM> for Release<C> {
                 .scheduler
                 .worker_group
                 .get_and_clear_worker_live_bytes();
-            *mmtk.state.live_bytes_in_last_gc.borrow_mut() = live_bytes;
+            *mmtk.state.live_bytes_in_last_gc.borrow_mut() =
+                mmtk.aggregate_live_bytes_in_last_gc(live_bytes);
         }
     }
 }

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -831,7 +831,7 @@ pub trait ScanObjectsWork<VM: VMBinding>: GCWork<VM> + Sized {
 
             // For any object we need to scan, we count its live bytes.
             // Check the option outside the loop for better performance.
-            if *mmtk.get_options().count_live_bytes_in_gc {
+            if crate::util::rust_util::unlikely(*mmtk.get_options().count_live_bytes_in_gc) {
                 // Borrow before the loop.
                 let mut live_bytes_stats = closure.worker.shared.live_bytes_per_space.borrow_mut();
                 for object in objects_to_scan.iter().copied() {

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -554,14 +554,12 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         probe!(mmtk, gc_end);
 
         if *mmtk.get_options().count_live_bytes_in_gc {
-            info!("Live bytes in spaces:");
             for (space_name, &stats) in mmtk.state.live_bytes_in_last_gc.borrow().iter() {
                 info!(
-                    "{} = {:.1}% ({} bytes) of {} used pages",
+                    "{} = {} pages ({:.1}% live)",
                     space_name,
-                    stats.live_bytes as f64 * 100.0 / stats.used_bytes as f64,
-                    stats.live_bytes,
                     stats.used_pages,
+                    stats.live_bytes as f64 * 100.0 / stats.used_bytes as f64,
                 );
             }
         }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -561,7 +561,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                     space_name,
                     stats.live_bytes,
                     stats.live_bytes as f64 * 100.0 / stats.used_bytes as f64,
-                    stats.used_bytes,
+                    stats.used_pages,
                 );
             }
         }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -554,12 +554,13 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         probe!(mmtk, gc_end);
 
         if *mmtk.get_options().count_live_bytes_in_gc {
+            info!("Live bytes in spaces:");
             for (space_name, &stats) in mmtk.state.live_bytes_in_last_gc.borrow().iter() {
                 info!(
-                    "{} = {} bytes ({:.1}% of {} used pages)",
+                    "{} = {:.1}% ({} bytes) of {} used pages",
                     space_name,
-                    stats.live_bytes,
                     stats.live_bytes as f64 * 100.0 / stats.used_bytes as f64,
+                    stats.live_bytes,
                     stats.used_pages,
                 );
             }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -555,20 +555,26 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
 
         #[cfg(feature = "count_live_bytes_in_gc")]
         {
-            let live_bytes = mmtk.state.get_live_bytes_in_last_gc();
-            let used_bytes =
-                mmtk.get_plan().get_used_pages() << crate::util::constants::LOG_BYTES_IN_PAGE;
-            debug_assert!(
-                live_bytes <= used_bytes,
-                "Live bytes of all live objects ({} bytes) is larger than used pages ({} bytes), something is wrong.",
-                live_bytes, used_bytes
-            );
-            info!(
-                "Live objects = {} bytes ({:04.1}% of {} used pages)",
-                live_bytes,
-                live_bytes as f64 * 100.0 / used_bytes as f64,
-                mmtk.get_plan().get_used_pages()
-            );
+            use crate::policy::space::Space;
+            let live_bytes_per_space = mmtk.state.live_bytes_in_last_gc.borrow();
+            mmtk.get_plan().for_each_space(&mut |space: &dyn Space<VM>| {
+                let space_name = space.get_name();
+                let used_pages = space.reserved_pages();
+                let used_bytes = space.reserved_pages() << crate::util::constants::LOG_BYTES_IN_PAGE;
+                let live_bytes = *live_bytes_per_space.get(space_name).unwrap_or(&0);
+                debug_assert!(
+                    live_bytes <= used_bytes,
+                    "Live bytes of objects in {} ({} bytes) is larger than used pages ({} bytes), something is wrong.",
+                    space_name, live_bytes, used_bytes
+                );
+                info!(
+                    "{} = {} bytes ({:04.1}% of {} used pages)",
+                    space_name,
+                    live_bytes,
+                    live_bytes as f64 * 100.0 / used_bytes as f64,
+                    used_pages
+                );
+            })
         }
 
         #[cfg(feature = "extreme_assertions")]

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -560,20 +560,22 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             mmtk.get_plan().for_each_space(&mut |space: &dyn Space<VM>| {
                 let space_name = space.get_name();
                 let used_pages = space.reserved_pages();
-                let used_bytes = space.reserved_pages() << crate::util::constants::LOG_BYTES_IN_PAGE;
-                let live_bytes = *live_bytes_per_space.get(space_name).unwrap_or(&0);
-                debug_assert!(
-                    live_bytes <= used_bytes,
-                    "Live bytes of objects in {} ({} bytes) is larger than used pages ({} bytes), something is wrong.",
-                    space_name, live_bytes, used_bytes
-                );
-                info!(
-                    "{} = {} bytes ({:04.1}% of {} used pages)",
-                    space_name,
-                    live_bytes,
-                    live_bytes as f64 * 100.0 / used_bytes as f64,
-                    used_pages
-                );
+                if used_pages != 0 {
+                    let used_bytes = space.reserved_pages() << crate::util::constants::LOG_BYTES_IN_PAGE;
+                    let live_bytes = *live_bytes_per_space.get(space_name).unwrap_or(&0);
+                    debug_assert!(
+                        live_bytes <= used_bytes,
+                        "Live bytes of objects in {} ({} bytes) is larger than used pages ({} bytes), something is wrong.",
+                        space_name, live_bytes, used_bytes
+                    );
+                    info!(
+                        "{} = {} bytes ({:.1}% of {} used pages)",
+                        space_name,
+                        live_bytes,
+                        live_bytes as f64 * 100.0 / used_bytes as f64,
+                        used_pages
+                    );
+                }
             })
         }
 

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -553,8 +553,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         // USDT tracepoint for the end of GC.
         probe!(mmtk, gc_end);
 
-        #[cfg(feature = "count_live_bytes_in_gc")]
-        {
+        if *mmtk.get_options().count_live_bytes_in_gc {
             for (space_name, &stats) in mmtk.state.live_bytes_in_last_gc.borrow().iter() {
                 info!(
                     "{} = {} bytes ({:.1}% of {} used pages)",

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -67,7 +67,7 @@ impl<VM: VMBinding> GCWorkerShared<VM> {
         use crate::mmtk::VM_MAP;
         use crate::vm::object_model::ObjectModel;
 
-        // The live bytes ofr the object
+        // The live bytes of the object
         let bytes = VM::VMObjectModel::get_current_size(object);
         // Get the space index from descriptor
         let space_descriptor = VM_MAP.get_descriptor_for_address(object.to_raw_address());
@@ -79,7 +79,7 @@ impl<VM: VMBinding> GCWorkerShared<VM> {
             MAX_SPACES
         );
         // Accumulate the live bytes for the index
-        live_bytes_per_space[space_descriptor.get_index()] += bytes;
+        live_bytes_per_space[space_index] += bytes;
     }
 }
 

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -460,6 +460,6 @@ impl<VM: VMBinding> WorkerGroup<VM> {
             }
             live_bytes_per_space.clear();
         });
-        return ret;
+        ret
     }
 }

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -864,7 +864,9 @@ options! {
     gc_trigger:             GCTriggerSelector    [env_var: true, command_line: true] [|v: &GCTriggerSelector| v.validate()] = GCTriggerSelector::FixedHeapSize((crate::util::memory::get_system_total_memory() as f64 * 0.5f64) as usize),
     /// Enable transparent hugepage support for MMTk spaces via madvise (only Linux is supported)
     /// This only affects the memory for MMTk spaces.
-    transparent_hugepages: bool                  [env_var: true, command_line: true]  [|v: &bool| !v || cfg!(target_os = "linux")] = false
+    transparent_hugepages: bool                  [env_var: true, command_line: true]  [|v: &bool| !v || cfg!(target_os = "linux")] = false,
+    /// Count live bytes for objects in each space during a GC.
+    count_live_bytes_in_gc: bool                 [env_var: true, command_line: true] [always_valid] = false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The current `count_live_bytes_in_gc` feature adds the size of all live objects and compare with the used pages reported by the plan. There are two issues with the feature: 
1. VM space is not included in the used pages reported by the plan, but the live objects include objects in the VM space. So the reported fragmentation/utilization is wrong when the VM space is in use.
2. Spaces/policies have very different fragmentation ratio. Reporting the fragmentation for the entire heap is not useful.

This PR refactors the current `count_live_bytes_in_gc` feature so we collect live bytes per space, and report by space.