### PR TITLE
Add misc debugging helpers and feature to poison dead memory

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -188,6 +188,11 @@ impl<VM: VMBinding> CopySpace<VM> {
     }
 
     pub fn release(&self) {
+        #[cfg(feature = "poison_on_release")]
+        for (start, size) in self.pr.iterate_allocated_regions() {
+            crate::util::memory::set(start, 0xbc, size);
+        }
+
         for (start, size) in self.pr.iterate_allocated_regions() {
             // Clear the forwarding bits if it is on the side.
             if let MetadataSpec::OnSide(side_forwarding_status_table) =

--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -248,8 +248,8 @@ impl Block {
                         holes += 1;
                     }
 
-                    #[cfg(feature = "immix_zero_on_release")]
-                    crate::util::memory::zero(line.start(), Line::BYTES);
+                    #[cfg(feature = "poison_on_release")]
+                    crate::util::memory::set_pattern(line.start(), (0xdeadbeef ^ line.start().as_usize()) & !0xff, Line::BYTES);
 
                     // We need to clear the pin bit if it is on the side, as this line can be reused
                     #[cfg(feature = "object_pinning")]

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -288,8 +288,15 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
         let sweep = |object: ObjectReference| {
             #[cfg(feature = "vo_bit")]
             crate::util::metadata::vo_bit::unset_vo_bit(object);
+            if self.common.needs_log_bit {
+                VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
+                    .clear::<VM>(object, Ordering::SeqCst);
+            }
+            let start = object.to_object_start::<VM>();
+            #[cfg(feature = "poison_on_release")]
+            crate::util::memory::set(start, 0xed, VM::VMObjectModel::get_current_size(object));
             self.pr
-                .release_pages(get_super_page(object.to_object_start::<VM>()));
+                .release_pages(get_super_page(start));
         };
         if sweep_nursery {
             for object in self.treadmill.collect_nursery() {


### PR DESCRIPTION
We add some misc debugging helpers to help binding implementers in debugging tricky memory corruption bugs. We now can also poison dead memory in each space's `release` method. This feature supersedes "immix_zero_on_release".