### PR TITLE
Fix clippy warnings for Rust 1.83

### DIFF
--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -390,7 +390,7 @@ pub struct CreateSpecificPlanArgs<'a, VM: VMBinding> {
     pub global_side_metadata_specs: Vec<SideMetadataSpec>,
 }
 
-impl<'a, VM: VMBinding> CreateSpecificPlanArgs<'a, VM> {
+impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
     /// Get a PlanCreateSpaceArgs that can be used to create a space
     pub fn get_space_args(
         &mut self,

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -81,7 +81,6 @@ impl<VM: VMBinding> std::fmt::Debug for MutatorConfig<VM> {
 /// A mutator is a per-thread data structure that manages allocations and barriers. It is usually highly coupled with the language VM.
 /// It is recommended for MMTk users 1) to have a mutator struct of the same layout in the thread local storage that can be accessed efficiently,
 /// and 2) to implement fastpath allocation and barriers for the mutator in the VM side.
-
 // We are trying to make this struct fixed-sized so that VM bindings can easily define a type to have the exact same layout as this struct.
 // Currently Mutator is fixed sized, and we should try keep this invariant:
 // - Allocators are fixed-length arrays of allocators.
@@ -256,7 +255,6 @@ impl<VM: VMBinding> Mutator<VM> {
 
 /// Each GC plan should provide their implementation of a MutatorContext. *Note that this trait is no longer needed as we removed
 /// per-plan mutator implementation and we will remove this trait as well in the future.*
-
 // TODO: We should be able to remove this trait, as we removed per-plan mutator implementation, and there is no other type that implements this trait.
 // The Mutator struct above is the only type that implements this trait. We should be able to merge them.
 pub trait MutatorContext<VM: VMBinding>: Send + 'static {

--- a/src/plan/tracing.rs
+++ b/src/plan/tracing.rs
@@ -111,7 +111,7 @@ impl<'a, E: ProcessEdgesWork> ObjectsClosure<'a, E> {
     }
 }
 
-impl<'a, E: ProcessEdgesWork> SlotVisitor<SlotOf<E>> for ObjectsClosure<'a, E> {
+impl<E: ProcessEdgesWork> SlotVisitor<SlotOf<E>> for ObjectsClosure<'_, E> {
     fn visit_slot(&mut self, slot: SlotOf<E>) {
         #[cfg(debug_assertions)]
         {
@@ -129,7 +129,7 @@ impl<'a, E: ProcessEdgesWork> SlotVisitor<SlotOf<E>> for ObjectsClosure<'a, E> {
     }
 }
 
-impl<'a, E: ProcessEdgesWork> Drop for ObjectsClosure<'a, E> {
+impl<E: ProcessEdgesWork> Drop for ObjectsClosure<'_, E> {
     fn drop(&mut self) {
         self.flush();
     }

--- a/src/util/test_util/mock_vm.rs
+++ b/src/util/test_util/mock_vm.rs
@@ -180,7 +180,6 @@ pub fn no_cleanup() {}
 ///
 /// These are not supported at the moment. As those will change the `MockVM` type, we will have
 /// to use macros to generate a new `MockVM` type when we custimize constants or associated types.
-
 // The current implementation is not perfect, but at least it works, and it is easy enough to debug with.
 // I have tried different third-party libraries for mocking, and each has its own limitation. And
 // none of the libraries I tried can mock `VMBinding` and the associated traits out of box. Even after I attempted


### PR DESCRIPTION
Clippy 1.83 produces some new warnings:

-   `needless_lifetimes` is extended to suggest eliding `impl` lifetimes.
-   `empty_line_after_doc_comments` is added to the `suspicious` group.