### PR TITLE
Fix warnings for lifetime in MmapAnnotation impl

### DIFF
--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -143,7 +143,7 @@ macro_rules! mmap_anno_test {
 // Export this to external crates
 pub use mmap_anno_test;
 
-impl<'a> std::fmt::Display for MmapAnnotation<'a> {
+impl std::fmt::Display for MmapAnnotation<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MmapAnnotation::Space { name } => write!(f, "mmtk:space:{name}"),


### PR DESCRIPTION
https://github.com/mmtk/mmtk-core/pull/1242 fixed most similar issues in the repo, but https://github.com/mmtk/mmtk-core/pull/1236 introduced `MmapAnnotation` and introduced a new warning.