### PR TITLE
Minor changes for debugging.

### DIFF
--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -526,4 +526,30 @@ impl<VM: VMBinding> MMTK<VM> {
             space.enumerate_objects(&mut enumerator);
         })
     }
+
+    /// Print VM maps.  It will print the memory ranges used by spaces as well as some attributes of
+    /// the spaces.
+    ///
+    /// -   "I": The space is immortal.  Its objects will never die.
+    /// -   "N": The space is non-movable.  Its objects will never move.
+    ///
+    /// Arguments:
+    /// *   `out`: the place to print the VM maps.
+    /// *   `space_name`: If `None`, print all spaces;
+    ///                   if `Some(n)`, only print the space whose name is `n`.
+    pub fn debug_print_vm_maps(
+        &self,
+        out: &mut impl std::fmt::Write,
+        space_name: Option<&str>,
+    ) -> Result<(), std::fmt::Error> {
+        let mut result_so_far = Ok(());
+        self.get_plan().for_each_space(&mut |space| {
+            if result_so_far.is_ok()
+                && (space_name.is_none() || space_name == Some(space.get_name()))
+            {
+                result_so_far = crate::policy::space::print_vm_map(space, out);
+            }
+        });
+        result_so_far
+    }
 }

--- a/src/util/api_util.rs
+++ b/src/util/api_util.rs
@@ -15,6 +15,7 @@ use super::{Address, ObjectReference};
 /// It is intended for passing an `Option<ObjectReference>` values to and from native programs
 /// (usually C or C++) that have null pointers.
 #[repr(transparent)]
+#[derive(Clone, Copy)]
 pub struct NullableObjectReference(usize);
 
 impl From<NullableObjectReference> for Option<ObjectReference> {
@@ -29,5 +30,17 @@ impl From<Option<ObjectReference>> for NullableObjectReference {
             .map(|obj| obj.to_raw_address().as_usize())
             .unwrap_or(0);
         Self(encoded)
+    }
+}
+
+impl std::fmt::Display for NullableObjectReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#x}", self.0)
+    }
+}
+
+impl std::fmt::Debug for NullableObjectReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
     }
 }


### PR DESCRIPTION
Added `MMTK::debug_print_vm_map` which prints the memory ranges of spaces.

`NullableObjectReference` now implements `Clone`, `Copy`, `Display` and `Debug`.  This allows the binding to print its value like `Address` and `ObjectReference`, and is useful for logging API functions that involve `NullableObjectReference` parameters.