### PR TITLE
Allow setting object metadata for VM space objects. Expose VO bit under a feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,8 @@ no_mmap_annotation = []
 # However, in rare cases, a binding may want to directly access and manipulate VO bit. For example, a binding cannot cooperate
 # with MMTk to identify each object for setting the VO bit. This is usually due to the limitation of the VM.
 # In such cases, a binding may use this feature and manipulate the VO bit to their needs. The binding's manipulation on VO bit
-# may violate MMTk's semantics, and may result in undefined behaviors for VO bit related APIs.
+# may violate MMTk's semantics, and may result in undefined behaviors for VO bit related APIs. This feature should
+# only be used if you understand how VO bit works internally. Use at your own risk.
 vo_bit_access = []
 
 # Do not modify the following line - ci-common.sh matches it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,15 @@ bpftrace_workaround = []
 # users can disable such annotations by enabling this Cargo feature.
 no_mmap_annotation = []
 
+# Allow the binding to access Valid Object (VO) bit.
+# MMTk uses VO bit to identify a valid object. Thus VO bit is carefully managed by MMTk in cooperation with the binding.
+# So normally this feature is not needed, and its use should be discouraged.
+# However, in rare cases, a binding may want to directly access and manipulate VO bit. For example, a binding cannot cooperate
+# with MMTk to identify each object for setting the VO bit. This is usually due to the limitation of the VM.
+# In such cases, a binding may use this feature and manipulate the VO bit to their needs. The binding's manipulation on VO bit
+# may violate MMTk's semantics, and may result in undefined behaviors for VO bit related APIs.
+vo_bit_access = []
+
 # Do not modify the following line - ci-common.sh matches it
 # -- Mutally exclusive features --
 # Only one feature from each group can be provided. Otherwise build will fail.

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -584,4 +584,16 @@ impl<VM: VMBinding> MMTK<VM> {
         });
         result_so_far
     }
+
+    /// Initialize object metadata for a VM space object.
+    /// Objects in the VM space are allocated/managed by the binding. This function provides a way for
+    /// the binding to set object metadata in MMTk for an object in the space.
+    #[cfg(feature = "vm_space")]
+    pub fn initialize_vm_space_object(&self, object: crate::util::ObjectReference) {
+        use crate::policy::sft::SFT;
+        self.get_plan()
+            .base()
+            .vm_space
+            .initialize_object_metadata(object, false)
+    }
 }

--- a/src/util/metadata/mod.rs
+++ b/src/util/metadata/mod.rs
@@ -222,11 +222,11 @@ mod global;
 pub mod header_metadata;
 mod metadata_val_traits;
 pub mod side_metadata;
+pub mod vo_bit;
 pub use metadata_val_traits::*;
 
 pub(crate) mod log_bit;
 pub(crate) mod mark_bit;
 pub(crate) mod pin_bit;
-pub(crate) mod vo_bit;
 
 pub use global::*;

--- a/src/util/metadata/side_metadata/constants.rs
+++ b/src/util/metadata/side_metadata/constants.rs
@@ -30,6 +30,7 @@ pub(crate) const GLOBAL_SIDE_METADATA_BASE_OFFSET: SideMetadataOffset =
     SideMetadataOffset::addr(GLOBAL_SIDE_METADATA_BASE_ADDRESS);
 
 /// Base address of VO bit, public to VM bindings which may need to use this.
+#[cfg(target_pointer_width = "64")]
 pub const VO_BIT_SIDE_METADATA_ADDR: Address =
     crate::util::metadata::vo_bit::VO_BIT_SIDE_METADATA_ADDR;
 

--- a/src/util/metadata/side_metadata/mod.rs
+++ b/src/util/metadata/side_metadata/mod.rs
@@ -22,9 +22,3 @@ pub(crate) use helpers::*;
 #[allow(unused_imports)]
 pub(crate) use helpers_32::*;
 pub(crate) use sanity::SideMetadataSanity;
-
-/// Side metadata spec for VO bit. This is only available when the feature "vo_bit_access" is enabled.
-/// Check the comments on "vo_bit_access" in `Cargo.toml` before use. Use at your own risk.
-#[cfg(feature = "vo_bit_access")]
-pub const VO_BIT_SIDE_METADATA_SPEC: SideMetadataSpec =
-    crate::util::metadata::side_metadata::spec_defs::VO_BIT;

--- a/src/util/metadata/side_metadata/mod.rs
+++ b/src/util/metadata/side_metadata/mod.rs
@@ -23,6 +23,8 @@ pub(crate) use helpers::*;
 pub(crate) use helpers_32::*;
 pub(crate) use sanity::SideMetadataSanity;
 
+/// Side metadata spec for VO bit. This is only available when the feature "vo_bit_access" is enabled.
+/// Check the comments on "vo_bit_access" in `Cargo.toml` before use. Use at your own risk.
 #[cfg(feature = "vo_bit_access")]
 pub const VO_BIT_SIDE_METADATA_SPEC: SideMetadataSpec =
     crate::util::metadata::side_metadata::spec_defs::VO_BIT;

--- a/src/util/metadata/side_metadata/mod.rs
+++ b/src/util/metadata/side_metadata/mod.rs
@@ -22,3 +22,7 @@ pub(crate) use helpers::*;
 #[allow(unused_imports)]
 pub(crate) use helpers_32::*;
 pub(crate) use sanity::SideMetadataSanity;
+
+#[cfg(feature = "vo_bit_access")]
+pub const VO_BIT_SIDE_METADATA_SPEC: SideMetadataSpec =
+    crate::util::metadata::side_metadata::spec_defs::VO_BIT;

--- a/src/util/metadata/vo_bit/mod.rs
+++ b/src/util/metadata/vo_bit/mod.rs
@@ -58,6 +58,7 @@ use crate::vm::VMBinding;
 pub(crate) const VO_BIT_SIDE_METADATA_SPEC: SideMetadataSpec =
     crate::util::metadata::side_metadata::spec_defs::VO_BIT;
 
+#[cfg(target_pointer_width = "64")]
 pub const VO_BIT_SIDE_METADATA_ADDR: Address = VO_BIT_SIDE_METADATA_SPEC.get_absolute_offset();
 
 /// Atomically set the VO bit for an object.

--- a/src/util/metadata/vo_bit/mod.rs
+++ b/src/util/metadata/vo_bit/mod.rs
@@ -231,9 +231,15 @@ use crate::MMTK;
 /// Objects in the VM space are allocated/managed by the binding. This functio provides a way for
 /// the binding to set VO bit for an object in the space.
 #[cfg(feature = "vm_space")]
-pub fn set_vo_bit_for_vm_space_object<VM: VMBinding>(mmtk: &'static MMTK<VM>, object: ObjectReference) {
+pub fn set_vo_bit_for_vm_space_object<VM: VMBinding>(
+    mmtk: &'static MMTK<VM>,
+    object: ObjectReference,
+) {
     use crate::policy::space::Space;
-    debug_assert!(mmtk.get_plan().base().vm_space.in_space(object), "{} is not in VM space", object);
+    debug_assert!(
+        mmtk.get_plan().base().vm_space.in_space(object),
+        "{} is not in VM space",
+        object
+    );
     set_vo_bit(object);
 }
-

--- a/src/util/metadata/vo_bit/mod.rs
+++ b/src/util/metadata/vo_bit/mod.rs
@@ -222,3 +222,17 @@ pub fn is_internal_ptr_from_vo_bit<VM: VMBinding>(
 pub unsafe fn is_vo_addr(addr: Address) -> bool {
     VO_BIT_SIDE_METADATA_SPEC.load::<u8>(addr) != 0
 }
+
+#[cfg(feature = "vm_space")]
+use crate::MMTK;
+
+/// Set VO bit for a VM space object.
+/// Objects in the VM space are allocated/managed by the binding. This functio provides a way for
+/// the binding to set VO bit for an object in the space.
+#[cfg(feature = "vm_space")]
+pub fn set_vo_bit_for_vm_space_object<VM: VMBinding>(mmtk: &'static MMTK<VM>, object: ObjectReference) {
+    use crate::policy::space::Space;
+    debug_assert!(mmtk.get_plan().base().vm_space.in_space(object), "{} is not in VM space", object);
+    set_vo_bit(object);
+}
+


### PR DESCRIPTION
This PR changes a few things for vo bit:
1. Add a function to set object metadata for an object in the VM space: `MMTK::initialize_vm_space_object`.
2. Add a feature `vo_bit_access` to expose VO bit and a binding may use it at its own risk.
3. Mark VO bit side metadata base address only avilable for 64 bits.

The second is needed for Julia. The Julia binding uses MMTk immortal allocation or VM space for a region of memory, and pop the regions with boot image objects with no clear way to identify each object. The easist workaround is to bulk set VO bit for the region. The problem from this is that MMTk cannot identify valid objects in those regions. However, Julia binding only uses VO bit for pinning objects. Objects in the immortal space or the VM space will not be moved so failing to pinning objects in those regions is benign. Currently the Julia binding duplicates a bunch of side metadata code to bulk set VO bit only using the VO bit side metadata base address. See https://github.com/mmtk/mmtk-julia/pull/200