### PR TITLE
Use macos-15 for style check

### DIFF
--- a/.github/workflows/minimal-tests-core.yml
+++ b/.github/workflows/minimal-tests-core.yml
@@ -87,7 +87,7 @@ jobs:
         target:
           - { os: ubuntu-22.04, triple: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, triple: i686-unknown-linux-gnu }
-          - { os: macos-12, triple: x86_64-apple-darwin }
+          - { os: macos-15, triple: x86_64-apple-darwin }
         rust: ${{ fromJson(needs.setup-test-matrix.outputs.rust )}}
 
     name: style-check/${{ matrix.target.triple }}/${{ matrix.rust }}


### PR DESCRIPTION
https://github.com/mmtk/mmtk-core/pull/1216 updated the test runner image from `macos-12` to `macos-15`, but I forgot to update the image for style checks. This PR updates the runner for style checks as well.