### PR TITLE
Always return false for collection_required for NoGC

### DIFF
--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -46,8 +46,8 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         &NOGC_CONSTRAINTS
     }
 
-    fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
-        self.base().collection_required(self, space_full)
+    fn collection_required(&self, _space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
+        false
     }
 
     fn base(&self) -> &BasePlan<VM> {


### PR DESCRIPTION
If we use the dynamic heap with NoGC, it will trigger a GC when `space_full` is true. This will cause a Rust panic of `entered unreachable code: GC triggered in nogc` because `collection_required` returns true.