### PR TITLE
Make GC triggering and heap resizing consistent

### DIFF
--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -129,10 +129,14 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
         unsafe { sft_map.eager_initialize(self.as_sft(), self.start, self.total_bytes) };
     }
 
+    fn estimate_side_meta_pages(&self, data_pages: usize) -> usize {
+        self.metadata.calculate_reserved_pages(data_pages)
+    }
+
     fn reserved_pages(&self) -> usize {
         let cursor = self.cursor.load(Ordering::Relaxed);
         let data_pages = conversions::bytes_to_pages_up(self.limit - cursor);
-        let meta_pages = self.metadata.calculate_reserved_pages(data_pages);
+        let meta_pages = self.estimate_side_meta_pages(data_pages);
         data_pages + meta_pages
     }
 

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -215,6 +215,10 @@ impl<VM: VMBinding> Space<VM> for MallocSpace<VM> {
         "MallocSpace"
     }
 
+    fn estimate_side_meta_pages(&self, data_pages: usize) -> usize {
+        self.metadata.calculate_reserved_pages(data_pages)
+    }
+
     #[allow(clippy::assertions_on_constants)]
     fn reserved_pages(&self) -> usize {
         use crate::util::constants::LOG_BYTES_IN_PAGE;
@@ -222,7 +226,7 @@ impl<VM: VMBinding> Space<VM> for MallocSpace<VM> {
         debug_assert!(LOG_BYTES_IN_MALLOC_PAGE >= LOG_BYTES_IN_PAGE);
         let data_pages = self.active_pages.load(Ordering::SeqCst)
             << (LOG_BYTES_IN_MALLOC_PAGE - LOG_BYTES_IN_PAGE);
-        let meta_pages = self.metadata.calculate_reserved_pages(data_pages);
+        let meta_pages = self.estimate_side_meta_pages(data_pages);
         data_pages + meta_pages
     }
 

--- a/src/util/conversions.rs
+++ b/src/util/conversions.rs
@@ -94,9 +94,8 @@ pub fn bytes_to_formatted_string(bytes: usize) -> String {
     format!("{}{}", num, UNITS.last().unwrap())
 }
 
-/// Shift `num` by `bits` to the right.  Add 1 to the result if any bits are shifted out to the
-/// right.  This is equivalent to dividing `num` by 2 to the power of `bits`, rounding towards
-/// infinity.
+/// Shift `num` by `bits` to the right.  Add 1 to the result if any `1` bits are shifted out to the
+/// right.  This is equivalent to dividing `num` by 2 to the power of `bits`, rounding up.
 ///
 /// This function has undefined behavior if `bits` is greater or equal to the number of bits in
 /// `usize`.

--- a/src/util/conversions.rs
+++ b/src/util/conversions.rs
@@ -94,6 +94,16 @@ pub fn bytes_to_formatted_string(bytes: usize) -> String {
     format!("{}{}", num, UNITS.last().unwrap())
 }
 
+/// Shift `num` by `bits` to the right.  Add 1 to the result if any bits are shifted out to the
+/// right.  This is equivalent to dividing `num` by 2 to the power of `bits`, rounding towards
+/// infinity.
+///
+/// This function has undefined behavior if `bits` is greater or equal to the number of bits in
+/// `usize`.
+pub const fn rshift_align_up(num: usize, bits: usize) -> usize {
+    (num + ((1 << bits) - 1)) >> bits
+}
+
 #[cfg(test)]
 mod tests {
     use crate::util::conversions::*;

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1362,12 +1362,10 @@ impl SideMetadataContext {
     pub fn calculate_reserved_pages(&self, data_pages: usize) -> usize {
         let mut total = 0;
         for spec in self.global.iter() {
-            let rshift = addr_rshift(spec);
-            total += (data_pages + ((1 << rshift) - 1)) >> rshift;
+            total += data_to_meta_size_round_up(spec, data_pages);
         }
         for spec in self.local.iter() {
-            let rshift = addr_rshift(spec);
-            total += (data_pages + ((1 << rshift) - 1)) >> rshift;
+            total += data_to_meta_size_round_up(spec, data_pages);
         }
         total
     }

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1362,6 +1362,9 @@ impl SideMetadataContext {
     pub fn calculate_reserved_pages(&self, data_pages: usize) -> usize {
         let mut total = 0;
         for spec in self.global.iter() {
+            // This rounds up.  No matter how small `data_pages` is, the side metadata size will be
+            // at least one page.  This behavior is *intended*.  The over-estimated amount is used
+            // for triggering GC and resizing the heap.
             total += data_to_meta_size_round_up(spec, data_pages);
         }
         for spec in self.local.iter() {

--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1363,7 +1363,7 @@ impl SideMetadataContext {
         let mut total = 0;
         for spec in self.global.iter() {
             // This rounds up.  No matter how small `data_pages` is, the side metadata size will be
-            // at least one page.  This behavior is *intended*.  The over-estimated amount is used
+            // at least one page.  This behavior is *intended*.  This over-estimated amount is used
             // for triggering GC and resizing the heap.
             total += data_to_meta_size_round_up(spec, data_pages);
         }


### PR DESCRIPTION
This PR fixes a bug where the MemBalancer did not increase the heap size enough to accommodate the amount of side metadata needed by the pending allocation.  It manifested as looping infinitely between triggering GC and (not actually) resizing the heap size after a GC when the minimum heap size is too small.

Now it always includes the side metadata amount when increasing heap size.

This PR also refactors the calculation of "shifting right and rounding up" which is used in multiple places.  We also replace `alloc_rshift` with `log_data_meta_ratio` for two reasons.  (1) The previous implementation would cause unsigned overflow before converting the result to `i32`. (2) `log_data_meta_ratio` has clearer semantics.