### PR TITLE
Clear stale line mark state

### DIFF
--- a/src/policy/immix/block.rs
+++ b/src/policy/immix/block.rs
@@ -247,7 +247,11 @@ impl Block {
                     if prev_line_is_marked {
                         holes += 1;
                     }
-
+                    // We need to clear the line mark state at least twice in every 128 GC
+                    // otherwise, the line mark state of the last GC will stick around
+                    if line_mark_state > Line::MAX_MARK_STATE - 2 {
+                        line.mark(0);
+                    }
                     #[cfg(feature = "immix_zero_on_release")]
                     crate::util::memory::zero(line.start(), Line::BYTES);
 

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -298,6 +298,8 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     block.start(),
                     block.end()
                 );
+                // Bulk clear stale line mark state
+                Line::MARK_TABLE.bzero_metadata(block.start(), Block::BYTES);
                 if self.request_for_large {
                     self.large_bump_pointer.cursor = block.start();
                     self.large_bump_pointer.limit = block.end();

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -299,7 +299,8 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     block.end()
                 );
                 // Bulk clear stale line mark state
-                Line::MARK_TABLE.bzero_metadata(block.start(), Block::BYTES);
+                Line::MARK_TABLE
+                    .bzero_metadata(block.start(), crate::policy::immix::block::Block::BYTES);
                 if self.request_for_large {
                     self.large_bump_pointer.cursor = block.start();
                     self.large_bump_pointer.limit = block.end();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5ce787c6-03c0-4845-b0a9-ade68bb0f8d6)
![image](https://github.com/user-attachments/assets/605711ba-1140-42b0-9306-849d4e15e244)
![image](https://github.com/user-attachments/assets/2f1ba1d5-9ca8-4678-b75a-45eac5789990)
Overall, this fix does not incur significant overhead