### PR TITLE
Fix julia extended tests

### DIFF
--- a/.github/workflows/extended-tests-bindings.yml
+++ b/.github/workflows/extended-tests-bindings.yml
@@ -19,86 +19,86 @@ jobs:
     with:
       pull_request: ${{ github.event.pull_request.number }}
 
-  extended-tests-v8:
-    runs-on: ubuntu-20.04
-    needs: binding-refs
-    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-    steps:
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v4
-        with:
-          path: mmtk-core
-      - name: Checkout V8 Binding
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.binding-refs.outputs.v8_binding_repo }}
-          path: mmtk-v8
-          ref: ${{ needs.binding-refs.outputs.v8_binding_ref }}
-      - name: Use mmtk-core Rust toolchain for bindings
-        run: |
-          cp mmtk-core/rust-toolchain mmtk-v8/mmtk
-      - name: Overwrite MMTk core in V8 binding
-        run: |
-          rm -rf mmtk-v8/repos/*
-          mkdir -p mmtk-v8/repos/mmtk-core
-          cp -r mmtk-core/* mmtk-v8/repos/mmtk-core
-      - name: Setup
-        run: |
-          cd mmtk-v8
-          ./.github/scripts/ci-setup.sh
-          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
-          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
-      - name: Test
-        run: |
-          cd mmtk-v8
-          export RUST_BACKTRACE=1
-          export V8_ROOT=$GITHUB_WORKSPACE/v8_deps
-          .github/scripts/ci-test.sh
-          .github/scripts/ci-style.sh
+  # extended-tests-v8:
+  #   runs-on: ubuntu-20.04
+  #   needs: binding-refs
+  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+  #   steps:
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v4
+  #       with:
+  #         path: mmtk-core
+  #     - name: Checkout V8 Binding
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: ${{ needs.binding-refs.outputs.v8_binding_repo }}
+  #         path: mmtk-v8
+  #         ref: ${{ needs.binding-refs.outputs.v8_binding_ref }}
+  #     - name: Use mmtk-core Rust toolchain for bindings
+  #       run: |
+  #         cp mmtk-core/rust-toolchain mmtk-v8/mmtk
+  #     - name: Overwrite MMTk core in V8 binding
+  #       run: |
+  #         rm -rf mmtk-v8/repos/*
+  #         mkdir -p mmtk-v8/repos/mmtk-core
+  #         cp -r mmtk-core/* mmtk-v8/repos/mmtk-core
+  #     - name: Setup
+  #       run: |
+  #         cd mmtk-v8
+  #         ./.github/scripts/ci-setup.sh
+  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
+  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
+  #     - name: Test
+  #       run: |
+  #         cd mmtk-v8
+  #         export RUST_BACKTRACE=1
+  #         export V8_ROOT=$GITHUB_WORKSPACE/v8_deps
+  #         .github/scripts/ci-test.sh
+  #         .github/scripts/ci-style.sh
 
-  extended-tests-openjdk:
-    needs: binding-refs
-    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-    uses: ./.github/workflows/binding-tests-openjdk.yml
-    with:
-      repo: ${{ needs.binding-refs.outputs.openjdk_binding_repo }}
-      ref: ${{ needs.binding-refs.outputs.openjdk_binding_ref }}
-      test-script: ci-test-extended.sh
+  # extended-tests-openjdk:
+  #   needs: binding-refs
+  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+  #   uses: ./.github/workflows/binding-tests-openjdk.yml
+  #   with:
+  #     repo: ${{ needs.binding-refs.outputs.openjdk_binding_repo }}
+  #     ref: ${{ needs.binding-refs.outputs.openjdk_binding_ref }}
+  #     test-script: ci-test-extended.sh
 
-  extended-tests-jikesrvm:
-    runs-on: ubuntu-22.04
-    needs: binding-refs
-    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-    steps:
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v4
-        with:
-          path: mmtk-core
-      - name: Checkout JikesRVM Binding
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo }}
-          path: mmtk-jikesrvm
-          ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
-      - name: Use mmtk-core Rust toolchain for bindings
-        run: |
-          cp mmtk-core/rust-toolchain mmtk-jikesrvm/mmtk
-      - name: Setup
-        run: |
-          cd mmtk-jikesrvm
-          ./.github/scripts/ci-checkout.sh
-          ./.github/scripts/ci-setup.sh
-          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
-          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
-      - name: Overwrite MMTk core in JikesRVM binding
-        run: |
-          cp -r mmtk-core mmtk-jikesrvm/repos
-      - name: Test
-        run: |
-          cd mmtk-jikesrvm
-          export RUST_BACKTRACE=1
-          ./.github/scripts/ci-test.sh
-          ./.github/scripts/ci-style.sh
+  # extended-tests-jikesrvm:
+  #   runs-on: ubuntu-22.04
+  #   needs: binding-refs
+  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+  #   steps:
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v4
+  #       with:
+  #         path: mmtk-core
+  #     - name: Checkout JikesRVM Binding
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo }}
+  #         path: mmtk-jikesrvm
+  #         ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
+  #     - name: Use mmtk-core Rust toolchain for bindings
+  #       run: |
+  #         cp mmtk-core/rust-toolchain mmtk-jikesrvm/mmtk
+  #     - name: Setup
+  #       run: |
+  #         cd mmtk-jikesrvm
+  #         ./.github/scripts/ci-checkout.sh
+  #         ./.github/scripts/ci-setup.sh
+  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
+  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
+  #     - name: Overwrite MMTk core in JikesRVM binding
+  #       run: |
+  #         cp -r mmtk-core mmtk-jikesrvm/repos
+  #     - name: Test
+  #       run: |
+  #         cd mmtk-jikesrvm
+  #         export RUST_BACKTRACE=1
+  #         ./.github/scripts/ci-test.sh
+  #         ./.github/scripts/ci-style.sh
 
   extended-tests-julia:
     runs-on: ubuntu-22.04
@@ -147,61 +147,61 @@ jobs:
           ./.github/scripts/ci-test.sh
           ./.github/scripts/ci-style.sh
 
-  extended-tests-ruby:
-    runs-on: ubuntu-22.04
-    needs: binding-refs
-    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-    strategy:
-      fail-fast: true
-      matrix:
-        debug-level: ["debug", "release"]
-    env:
-      DEBUG_LEVEL: ${{ matrix.debug-level }}
-    steps:
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v4
-        with:
-          path: mmtk-core
+  # extended-tests-ruby:
+  #   runs-on: ubuntu-22.04
+  #   needs: binding-refs
+  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       debug-level: ["debug", "release"]
+  #   env:
+  #     DEBUG_LEVEL: ${{ matrix.debug-level }}
+  #   steps:
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v4
+  #       with:
+  #         path: mmtk-core
 
-      - name: Checkout MMTk Ruby binding
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.binding-refs.outputs.ruby_binding_repo }}
-          path: mmtk-ruby
-          ref: ${{ needs.binding-refs.outputs.ruby_binding_ref }}
+  #     - name: Checkout MMTk Ruby binding
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: ${{ needs.binding-refs.outputs.ruby_binding_repo }}
+  #         path: mmtk-ruby
+  #         ref: ${{ needs.binding-refs.outputs.ruby_binding_ref }}
 
-      - name: Setup script dependencies
-        run: ./.github/scripts/ci-setup-script-deps.sh
-        working-directory: mmtk-ruby
+  #     - name: Setup script dependencies
+  #       run: ./.github/scripts/ci-setup-script-deps.sh
+  #       working-directory: mmtk-ruby
 
-      - name: Determine Ruby repository and revision
-        id: extract-ruby-revision
-        run: python ./.github/scripts/extract-ruby-revision.py ./mmtk/Cargo.toml --github-output=$GITHUB_OUTPUT
-        working-directory: mmtk-ruby
+  #     - name: Determine Ruby repository and revision
+  #       id: extract-ruby-revision
+  #       run: python ./.github/scripts/extract-ruby-revision.py ./mmtk/Cargo.toml --github-output=$GITHUB_OUTPUT
+  #       working-directory: mmtk-ruby
 
-      - name: Checkout Ruby
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ steps.extract-ruby-revision.outputs.ruby_repo }}
-          ref: ${{ steps.extract-ruby-revision.outputs.ruby_rev }}
-          path: ruby
+  #     - name: Checkout Ruby
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: ${{ steps.extract-ruby-revision.outputs.ruby_repo }}
+  #         ref: ${{ steps.extract-ruby-revision.outputs.ruby_rev }}
+  #         path: ruby
 
-      - name: Override mmtk-core dependency for binding
-        run: ./.github/scripts/ci-replace-mmtk-dep.sh ../mmtk-ruby/mmtk/Cargo.toml --mmtk-core-path .
-        working-directory: mmtk-core
+  #     - name: Override mmtk-core dependency for binding
+  #       run: ./.github/scripts/ci-replace-mmtk-dep.sh ../mmtk-ruby/mmtk/Cargo.toml --mmtk-core-path .
+  #       working-directory: mmtk-core
 
-      - name: Setup environment
-        run: ./.github/scripts/ci-setup.sh
-        working-directory: mmtk-ruby
+  #     - name: Setup environment
+  #       run: ./.github/scripts/ci-setup.sh
+  #       working-directory: mmtk-ruby
 
-      - name: Build MMTk Ruby ${{ matrix.debug-level }}
-        run: ./.github/scripts/ci-build.sh
-        working-directory: mmtk-ruby
+  #     - name: Build MMTk Ruby ${{ matrix.debug-level }}
+  #       run: ./.github/scripts/ci-build.sh
+  #       working-directory: mmtk-ruby
 
-      - name: Run bootstrap tests (btest)
-        run: ./.github/scripts/ci-btest.sh
-        working-directory: mmtk-ruby
+  #     - name: Run bootstrap tests (btest)
+  #       run: ./.github/scripts/ci-btest.sh
+  #       working-directory: mmtk-ruby
 
-      - name: Run all tests (test-all)
-        run: ./.github/scripts/ci-test-all.sh
-        working-directory: mmtk-ruby
+  #     - name: Run all tests (test-all)
+  #       run: ./.github/scripts/ci-test-all.sh
+  #       working-directory: mmtk-ruby

--- a/.github/workflows/extended-tests-bindings.yml
+++ b/.github/workflows/extended-tests-bindings.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Setup
         run: |
           cd mmtk-julia
-          ./.github/scripts/ci-checkout.sh JuliaLang/julia master
+          ./.github/scripts/ci-checkout.sh ${{ needs.binding-refs.outputs.julia_vm_repo }} ${{ needs.binding-refs.outputs.julia_vm_ref }}
           ./.github/scripts/ci-setup.sh
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml

--- a/.github/workflows/extended-tests-bindings.yml
+++ b/.github/workflows/extended-tests-bindings.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Setup
         run: |
           cd mmtk-julia
-          ./.github/scripts/ci-checkout.sh
+          ./.github/scripts/ci-checkout.sh JuliaLang/julia master
           ./.github/scripts/ci-setup.sh
           sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
           sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml

--- a/.github/workflows/extended-tests-bindings.yml
+++ b/.github/workflows/extended-tests-bindings.yml
@@ -19,86 +19,86 @@ jobs:
     with:
       pull_request: ${{ github.event.pull_request.number }}
 
-  # extended-tests-v8:
-  #   runs-on: ubuntu-20.04
-  #   needs: binding-refs
-  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-  #   steps:
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v4
-  #       with:
-  #         path: mmtk-core
-  #     - name: Checkout V8 Binding
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: ${{ needs.binding-refs.outputs.v8_binding_repo }}
-  #         path: mmtk-v8
-  #         ref: ${{ needs.binding-refs.outputs.v8_binding_ref }}
-  #     - name: Use mmtk-core Rust toolchain for bindings
-  #       run: |
-  #         cp mmtk-core/rust-toolchain mmtk-v8/mmtk
-  #     - name: Overwrite MMTk core in V8 binding
-  #       run: |
-  #         rm -rf mmtk-v8/repos/*
-  #         mkdir -p mmtk-v8/repos/mmtk-core
-  #         cp -r mmtk-core/* mmtk-v8/repos/mmtk-core
-  #     - name: Setup
-  #       run: |
-  #         cd mmtk-v8
-  #         ./.github/scripts/ci-setup.sh
-  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
-  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
-  #     - name: Test
-  #       run: |
-  #         cd mmtk-v8
-  #         export RUST_BACKTRACE=1
-  #         export V8_ROOT=$GITHUB_WORKSPACE/v8_deps
-  #         .github/scripts/ci-test.sh
-  #         .github/scripts/ci-style.sh
+  extended-tests-v8:
+    runs-on: ubuntu-20.04
+    needs: binding-refs
+    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v4
+        with:
+          path: mmtk-core
+      - name: Checkout V8 Binding
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.binding-refs.outputs.v8_binding_repo }}
+          path: mmtk-v8
+          ref: ${{ needs.binding-refs.outputs.v8_binding_ref }}
+      - name: Use mmtk-core Rust toolchain for bindings
+        run: |
+          cp mmtk-core/rust-toolchain mmtk-v8/mmtk
+      - name: Overwrite MMTk core in V8 binding
+        run: |
+          rm -rf mmtk-v8/repos/*
+          mkdir -p mmtk-v8/repos/mmtk-core
+          cp -r mmtk-core/* mmtk-v8/repos/mmtk-core
+      - name: Setup
+        run: |
+          cd mmtk-v8
+          ./.github/scripts/ci-setup.sh
+          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
+          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
+      - name: Test
+        run: |
+          cd mmtk-v8
+          export RUST_BACKTRACE=1
+          export V8_ROOT=$GITHUB_WORKSPACE/v8_deps
+          .github/scripts/ci-test.sh
+          .github/scripts/ci-style.sh
 
-  # extended-tests-openjdk:
-  #   needs: binding-refs
-  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-  #   uses: ./.github/workflows/binding-tests-openjdk.yml
-  #   with:
-  #     repo: ${{ needs.binding-refs.outputs.openjdk_binding_repo }}
-  #     ref: ${{ needs.binding-refs.outputs.openjdk_binding_ref }}
-  #     test-script: ci-test-extended.sh
+  extended-tests-openjdk:
+    needs: binding-refs
+    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+    uses: ./.github/workflows/binding-tests-openjdk.yml
+    with:
+      repo: ${{ needs.binding-refs.outputs.openjdk_binding_repo }}
+      ref: ${{ needs.binding-refs.outputs.openjdk_binding_ref }}
+      test-script: ci-test-extended.sh
 
-  # extended-tests-jikesrvm:
-  #   runs-on: ubuntu-22.04
-  #   needs: binding-refs
-  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-  #   steps:
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v4
-  #       with:
-  #         path: mmtk-core
-  #     - name: Checkout JikesRVM Binding
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo }}
-  #         path: mmtk-jikesrvm
-  #         ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
-  #     - name: Use mmtk-core Rust toolchain for bindings
-  #       run: |
-  #         cp mmtk-core/rust-toolchain mmtk-jikesrvm/mmtk
-  #     - name: Setup
-  #       run: |
-  #         cd mmtk-jikesrvm
-  #         ./.github/scripts/ci-checkout.sh
-  #         ./.github/scripts/ci-setup.sh
-  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
-  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
-  #     - name: Overwrite MMTk core in JikesRVM binding
-  #       run: |
-  #         cp -r mmtk-core mmtk-jikesrvm/repos
-  #     - name: Test
-  #       run: |
-  #         cd mmtk-jikesrvm
-  #         export RUST_BACKTRACE=1
-  #         ./.github/scripts/ci-test.sh
-  #         ./.github/scripts/ci-style.sh
+  extended-tests-jikesrvm:
+    runs-on: ubuntu-22.04
+    needs: binding-refs
+    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v4
+        with:
+          path: mmtk-core
+      - name: Checkout JikesRVM Binding
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.binding-refs.outputs.jikesrvm_binding_repo }}
+          path: mmtk-jikesrvm
+          ref: ${{ needs.binding-refs.outputs.jikesrvm_binding_ref }}
+      - name: Use mmtk-core Rust toolchain for bindings
+        run: |
+          cp mmtk-core/rust-toolchain mmtk-jikesrvm/mmtk
+      - name: Setup
+        run: |
+          cd mmtk-jikesrvm
+          ./.github/scripts/ci-checkout.sh
+          ./.github/scripts/ci-setup.sh
+          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk/Cargo.toml
+          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk/Cargo.toml
+      - name: Overwrite MMTk core in JikesRVM binding
+        run: |
+          cp -r mmtk-core mmtk-jikesrvm/repos
+      - name: Test
+        run: |
+          cd mmtk-jikesrvm
+          export RUST_BACKTRACE=1
+          ./.github/scripts/ci-test.sh
+          ./.github/scripts/ci-style.sh
 
   extended-tests-julia:
     runs-on: ubuntu-22.04
@@ -147,61 +147,61 @@ jobs:
           ./.github/scripts/ci-test.sh
           ./.github/scripts/ci-style.sh
 
-  # extended-tests-ruby:
-  #   runs-on: ubuntu-22.04
-  #   needs: binding-refs
-  #   if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       debug-level: ["debug", "release"]
-  #   env:
-  #     DEBUG_LEVEL: ${{ matrix.debug-level }}
-  #   steps:
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v4
-  #       with:
-  #         path: mmtk-core
+  extended-tests-ruby:
+    runs-on: ubuntu-22.04
+    needs: binding-refs
+    if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
+    strategy:
+      fail-fast: true
+      matrix:
+        debug-level: ["debug", "release"]
+    env:
+      DEBUG_LEVEL: ${{ matrix.debug-level }}
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v4
+        with:
+          path: mmtk-core
 
-  #     - name: Checkout MMTk Ruby binding
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: ${{ needs.binding-refs.outputs.ruby_binding_repo }}
-  #         path: mmtk-ruby
-  #         ref: ${{ needs.binding-refs.outputs.ruby_binding_ref }}
+      - name: Checkout MMTk Ruby binding
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.binding-refs.outputs.ruby_binding_repo }}
+          path: mmtk-ruby
+          ref: ${{ needs.binding-refs.outputs.ruby_binding_ref }}
 
-  #     - name: Setup script dependencies
-  #       run: ./.github/scripts/ci-setup-script-deps.sh
-  #       working-directory: mmtk-ruby
+      - name: Setup script dependencies
+        run: ./.github/scripts/ci-setup-script-deps.sh
+        working-directory: mmtk-ruby
 
-  #     - name: Determine Ruby repository and revision
-  #       id: extract-ruby-revision
-  #       run: python ./.github/scripts/extract-ruby-revision.py ./mmtk/Cargo.toml --github-output=$GITHUB_OUTPUT
-  #       working-directory: mmtk-ruby
+      - name: Determine Ruby repository and revision
+        id: extract-ruby-revision
+        run: python ./.github/scripts/extract-ruby-revision.py ./mmtk/Cargo.toml --github-output=$GITHUB_OUTPUT
+        working-directory: mmtk-ruby
 
-  #     - name: Checkout Ruby
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: ${{ steps.extract-ruby-revision.outputs.ruby_repo }}
-  #         ref: ${{ steps.extract-ruby-revision.outputs.ruby_rev }}
-  #         path: ruby
+      - name: Checkout Ruby
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.extract-ruby-revision.outputs.ruby_repo }}
+          ref: ${{ steps.extract-ruby-revision.outputs.ruby_rev }}
+          path: ruby
 
-  #     - name: Override mmtk-core dependency for binding
-  #       run: ./.github/scripts/ci-replace-mmtk-dep.sh ../mmtk-ruby/mmtk/Cargo.toml --mmtk-core-path .
-  #       working-directory: mmtk-core
+      - name: Override mmtk-core dependency for binding
+        run: ./.github/scripts/ci-replace-mmtk-dep.sh ../mmtk-ruby/mmtk/Cargo.toml --mmtk-core-path .
+        working-directory: mmtk-core
 
-  #     - name: Setup environment
-  #       run: ./.github/scripts/ci-setup.sh
-  #       working-directory: mmtk-ruby
+      - name: Setup environment
+        run: ./.github/scripts/ci-setup.sh
+        working-directory: mmtk-ruby
 
-  #     - name: Build MMTk Ruby ${{ matrix.debug-level }}
-  #       run: ./.github/scripts/ci-build.sh
-  #       working-directory: mmtk-ruby
+      - name: Build MMTk Ruby ${{ matrix.debug-level }}
+        run: ./.github/scripts/ci-build.sh
+        working-directory: mmtk-ruby
 
-  #     - name: Run bootstrap tests (btest)
-  #       run: ./.github/scripts/ci-btest.sh
-  #       working-directory: mmtk-ruby
+      - name: Run bootstrap tests (btest)
+        run: ./.github/scripts/ci-btest.sh
+        working-directory: mmtk-ruby
 
-  #     - name: Run all tests (test-all)
-  #       run: ./.github/scripts/ci-test-all.sh
-  #       working-directory: mmtk-ruby
+      - name: Run all tests (test-all)
+        run: ./.github/scripts/ci-test-all.sh
+        working-directory: mmtk-ruby

--- a/.github/workflows/pr-binding-refs.yml
+++ b/.github/workflows/pr-binding-refs.yml
@@ -22,6 +22,8 @@
 # V8_BINDING_REF=xxxxxx
 # JULIA_BINDING_REPO=xx/xx
 # JULIA_BINDING_REF=xxxxxx
+# JULIA_VM_REPO=xx/xx
+# JULIA_VM_REF=xxxxxx
 # RUBY_BINDING_REPO=xx/xx
 # RUBY_BINDING_REF=xxxxxx
 # ```
@@ -86,6 +88,21 @@ on:
       julia_binding_ref_default:
         description: "The default git ref of Julia binding, such as sha and branch name"
         value: ${{ jobs.binding-refs.outputs.julia_binding_ref_default }}
+      # We further define the Julia version to run with, as we no longer record the Julia
+      # version with each binding commit. Instead, we record the binding version with
+      # each Julia commit.
+      julia_vm_repo:
+        description: "The repository of Julia, such as {user}/{repo}"
+        value: ${{ jobs.binding-refs.outputs.julia_vm_repo }}
+      julia_vm_repo_default:
+        description: "The default repository of Julia, such as {user}/{repo}"
+        value: ${{ jobs.binding-refs.outputs.julia_vm_repo_default }}
+      julia_vm_ref:
+        description: "The git ref of Julia, such as sha and branch name"
+        value: ${{ jobs.binding-refs.outputs.julia_vm_ref }}
+      julia_vm_ref_default:
+        description: "The default git ref of Julia, such as sha and branch name"
+        value: ${{ jobs.binding-refs.outputs.julia_vm_ref_default }}
 
       ruby_binding_repo:
         description: "The repository of Ruby binding, such as {user}/{repo}"
@@ -111,7 +128,9 @@ jobs:
       V8_BINDING_REPO_DEFAULT: mmtk/mmtk-v8
       V8_BINDING_REF_DEFAULT: master
       JULIA_BINDING_REPO_DEFAULT: mmtk/mmtk-julia
-      JULIA_BINDING_REF_DEFAULT: dev
+      JULIA_BINDING_REF_DEFAULT: master
+      JULIA_VM_REPO_DEFAULT: JuliaLang/julia
+      JULIA_VM_REF_DEFAULT: master
       RUBY_BINDING_REPO_DEFAULT: mmtk/mmtk-ruby
       RUBY_BINDING_REF_DEFAULT: master
     outputs:
@@ -131,6 +150,10 @@ jobs:
         julia_binding_repo_default: ${{ env.JULIA_BINDING_REPO_DEFAULT }}
         julia_binding_ref: ${{ steps.print.outputs.julia_binding_ref }}
         julia_binding_ref_default: ${{ env.JULIA_BINDING_REF_DEFAULT }}
+        julia_vm_repo: ${{ steps.print.outputs.julia_vm_repo }}
+        julia_vm_repo_default: ${{ env.JULIA_VM_REPO_DEFAULT }}
+        julia_vm_ref: ${{ steps.print.outputs.julia_vm_ref }}
+        julia_vm_ref_default: ${{ env.JULIA_VM_REF_DEFAULT }}
         ruby_binding_repo: ${{ steps.print.outputs.ruby_binding_repo }}
         ruby_binding_repo_default: ${{ env.RUBY_BINDING_REPO_DEFAULT }}
         ruby_binding_ref: ${{ steps.print.outputs.ruby_binding_ref }}
@@ -141,7 +164,7 @@ jobs:
           with:
             pull_request: ${{ inputs.pull_request }}
             token: ${{ secrets.GITHUB_TOKEN }}
-            default_env: 'OPENJDK_BINDING_REPO=${{ env.OPENJDK_BINDING_REPO_DEFAULT }},OPENJDK_BINDING_REF=${{ env.OPENJDK_BINDING_REF_DEFAULT }},JIKESRVM_BINDING_REPO=${{ env.JIKESRVM_BINDING_REPO_DEFAULT }},JIKESRVM_BINDING_REF=${{ env.JIKESRVM_BINDING_REF_DEFAULT }},V8_BINDING_REPO=${{ env.V8_BINDING_REPO_DEFAULT }},V8_BINDING_REF=${{ env.V8_BINDING_REF_DEFAULT }},JULIA_BINDING_REPO=${{ env.JULIA_BINDING_REPO_DEFAULT }},JULIA_BINDING_REF=${{ env.JULIA_BINDING_REF_DEFAULT }},RUBY_BINDING_REPO=${{ env.RUBY_BINDING_REPO_DEFAULT }},RUBY_BINDING_REF=${{ env.RUBY_BINDING_REF_DEFAULT }}'
+            default_env: 'OPENJDK_BINDING_REPO=${{ env.OPENJDK_BINDING_REPO_DEFAULT }},OPENJDK_BINDING_REF=${{ env.OPENJDK_BINDING_REF_DEFAULT }},JIKESRVM_BINDING_REPO=${{ env.JIKESRVM_BINDING_REPO_DEFAULT }},JIKESRVM_BINDING_REF=${{ env.JIKESRVM_BINDING_REF_DEFAULT }},V8_BINDING_REPO=${{ env.V8_BINDING_REPO_DEFAULT }},V8_BINDING_REF=${{ env.V8_BINDING_REF_DEFAULT }},JULIA_BINDING_REPO=${{ env.JULIA_BINDING_REPO_DEFAULT }},JULIA_BINDING_REF=${{ env.JULIA_BINDING_REF_DEFAULT }},JULIA_VM_REPO=${{ env.JULIA_VM_REPO_DEFAULT }},JULIA_VM_REF=${{ env.JULIA_VM_REF_DEFAULT }},RUBY_BINDING_REPO=${{ env.RUBY_BINDING_REPO_DEFAULT }},RUBY_BINDING_REF=${{ env.RUBY_BINDING_REF_DEFAULT }}'
         - id: print
           run: |
             echo "openjdk_binding_repo=${{ env.OPENJDK_BINDING_REPO }}" >> $GITHUB_OUTPUT
@@ -152,5 +175,7 @@ jobs:
             echo "v8_binding_ref=${{ env.V8_BINDING_REF }}" >> $GITHUB_OUTPUT
             echo "julia_binding_repo=${{ env.JULIA_BINDING_REPO }}" >> $GITHUB_OUTPUT
             echo "julia_binding_ref=${{ env.JULIA_BINDING_REF }}" >> $GITHUB_OUTPUT
+            echo "julia_vm_repo=${{ env.JULIA_VM_REPO }}" >> $GITHUB_OUTPUT
+            echo "julia_vm_ref=${{ env.JULIA_VM_REF }}" >> $GITHUB_OUTPUT
             echo "ruby_binding_repo=${{ env.RUBY_BINDING_REPO }}" >> $GITHUB_OUTPUT
             echo "ruby_binding_ref=${{ env.RUBY_BINDING_REF }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR changes the extended testing workflow for Julia:
1. It now tests with `master` in the upstream Julia repo, and `master` in the binding repo by default.
2. In addition to specifying the binding version, we can also specify the Julia version to run with. This change is necessary, as we no longe record the Julia version in the binding (we record the binding version in Julia instead).