### PR TITLE
Bump MSRV to 1.74.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ atomic-traits = "0.4.0"
 bytemuck = { version = "1.14.0", features = ["derive"] }
 cfg-if = "1.0"
 crossbeam = "0.8.1"
-delegate = "0.12.0"
-downcast-rs = "1.1.1"
+delegate = "0.13.2"
+downcast-rs = "2.0.1"
 enum-map = "2.4.2"
 env_logger = { version = "0.11.3", optional = true }
 is-terminal = "0.4.7"
-itertools = "0.12.0"
+itertools = "0.14.0"
 jemalloc-sys = { version = "0.5.3", features = ["disable_initial_exec_tls"], optional = true }
 lazy_static = "1.1"
 libc = "0.2"
@@ -48,15 +48,15 @@ regex = "1.7.0"
 rustversion = "1.0"
 spin = "0.9.5"
 static_assertions = "1.1.0"
-strum = "0.26.2"
-strum_macros = "0.26.2"
-sysinfo = "0.30.9"
+strum = "0.27.1"
+strum_macros = "0.27.1"
+sysinfo = "0.33.1"
 
 [dev-dependencies]
 paste = "1.0.8"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
-criterion = "0.4"
+rand = "0.9.0"
+rand_chacha = "0.9.0"
+criterion = "0.5"
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ rand_chacha = "0.9.0"
 criterion = "0.5"
 
 [build-dependencies]
-built = { version = "0.7.1", features = ["git2"] }
+built = { version = "0.7.7", features = ["git2"] }
 
 [[bench]]
 name = "main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/mmtk/mmtk-core"
 readme = "README.md"
 categories = ["memory-management"]
 keywords = ["gc", "garbage", "collection", "garbage-collection", "allocation"]
-rust-version = "1.71.1"
+rust-version = "1.74.1"
 build = "build.rs"
 
 [lib]

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -7,10 +7,10 @@ mod raw {
 }
 
 /// MMTk crate version such as 0.14.0
-use raw::PKG_VERSION as MMTK_PKG_VERSION;
+pub use raw::PKG_VERSION as MMTK_PKG_VERSION;
 
 /// Comma separated features enabled for this build
-use raw::FEATURES_STR as MMTK_FEATURES;
+pub use raw::FEATURES_STR as MMTK_FEATURES;
 
 lazy_static! {
     /// Git version as short commit hash, such as a96e8f9, or a96e8f9-dirty, or unknown-git-version if MMTk

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -7,10 +7,10 @@ mod raw {
 }
 
 /// MMTk crate version such as 0.14.0
-pub const MMTK_PKG_VERSION: &str = raw::PKG_VERSION;
+use raw::PKG_VERSION as MMTK_PKG_VERSION;
 
 /// Comma separated features enabled for this build
-pub const MMTK_FEATURES: &str = raw::FEATURES_STR;
+use raw::FEATURES_STR as MMTK_FEATURES;
 
 lazy_static! {
     /// Git version as short commit hash, such as a96e8f9, or a96e8f9-dirty, or unknown-git-version if MMTk

--- a/src/policy/marksweepspace/native_ms/block_list.rs
+++ b/src/policy/marksweepspace/native_ms/block_list.rs
@@ -310,7 +310,7 @@ pub(crate) fn pages_used_by_blocklists(lists: &BlockLists) -> usize {
 /// i.e. byte size == `wsize*sizeof(void*)`
 /// adapted from _mi_wsize_from_size in mimalloc
 fn mi_wsize_from_size(size: usize) -> usize {
-    (size + MI_INTPTR_SIZE - 1) / MI_INTPTR_SIZE
+    size.div_ceil(MI_INTPTR_SIZE)
 }
 
 pub fn mi_bin<VM: VMBinding>(size: usize, align: usize) -> usize {

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -465,7 +465,7 @@ pub(crate) fn get_system_total_memory() -> u64 {
     // `Options`.  If we only load memory-related components on start-up, it should only take <1ms
     // to initialize the `System` instance.
     let sys = System::new_with_specifics(
-        RefreshKind::new().with_memory(MemoryRefreshKind::new().with_ram()),
+        RefreshKind::nothing().with_memory(MemoryRefreshKind::nothing().with_ram()),
     );
     sys.total_memory()
 }


### PR DESCRIPTION
The current latest version of the "built" crate (v0.7.7) requires MSRV 1.74.  We bump the MSRV to 1.74.1.

Since version 0.7.6 of the "built" crate, it generates `static` items instead of `const` items for `PKG_VERSION`, `FEATURES_STR`, etc.  Our `build_info.rs` used to define `const` items that take their values.  After this change, the Rust compiler now interpret those lines as taking references of `static` items, which is unstable until Rust 1.83.  We instead replaced those `const` items in `build_info.rs` with `use` statements that create aliases of the items generated by "built".

Bumping MSRV to 1.74.1 also allows us to bump the version of the dependency "criterion" to 0.5 which also requires MSRV 1.74.  Previously, we locked the version of "criterion" to 0.4 due to its MSRV requirement.

We also updated all dependencies to their latest versions.  Among those changes, the "sysinfo" crate renamed several `new` methods to `nothing`.  We make changes accordingly.

We also use `usize::div_ceil` which was introduced in Rust 1.73.  This fixes a clippy warning.