### PR TITLE
Remove dead trace_object methods.

### DIFF
--- a/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/gc_work.rs
@@ -73,7 +73,9 @@ impl<VM: VMBinding> ProcessEdgesWork for MyGCProcessEdges<VM> {
                 worker,
             )
         } else {
-            self.plan.common.trace_object(queue, object, worker)
+            use crate::plan::PlanTraceObject;
+            use crate::policy::gc_work::DEFAULT_TRACE;
+            self.plan.common.trace_object::<_, DEFAULT_TRACE>(queue, object, worker)
         }
     }
 

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -202,25 +202,6 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
         is_full_heap
     }
 
-    /// Trace objects for spaces in generational and common plans for a full heap GC.
-    #[allow(unused)] // We now use `PlanTraceObject`, and this mehtod is not used.
-    pub fn trace_object_full_heap<Q: ObjectQueue>(
-        &self,
-        queue: &mut Q,
-        object: ObjectReference,
-        worker: &mut GCWorker<VM>,
-    ) -> ObjectReference {
-        if self.nursery.in_space(object) {
-            return self.nursery.trace_object::<Q>(
-                queue,
-                object,
-                Some(CopySemantics::PromoteToMature),
-                worker,
-            );
-        }
-        self.common.trace_object::<Q>(queue, object, worker)
-    }
-
     /// Trace objects for spaces in generational and common plans for a nursery GC.
     pub fn trace_object_nursery<Q: ObjectQueue, const KIND: TraceKind>(
         &self,


### PR DESCRIPTION
Now that we are using the `#[derive(HasSpaces, PlanTraceObject)]` derive macros to generate the trace_object methods, we can remove the manually-written dead code.