### PR TITLE
Experimental: Delegating `trace_object` to a dedicated struct

### DIFF
--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -120,7 +120,7 @@ pub trait SFT {
 // In this way, we can store the refs with <VM> in SFT (which cannot have parameters with generic type parameters)
 
 use crate::util::erase_vm::define_erased_vm_mut_ref;
-define_erased_vm_mut_ref!(SFTProcessEdgesMutRef = SFTProcessEdges<VM>);
+define_erased_vm_mut_ref!(SFTProcessEdgesMutRef = Vec<ObjectReference>);
 define_erased_vm_mut_ref!(GCWorkerMutRef = GCWorker<VM>);
 
 /// Print debug info for SFT. Should be false when committed.

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -24,6 +24,7 @@ pub use controller::GCController;
 
 pub(crate) mod gc_work;
 pub use gc_work::ProcessEdgesWork;
+pub use gc_work::TracingDelegate;
 // TODO: We shouldn't need to expose ScanStackRoot. However, OpenJDK uses it.
 // We should do some refactoring related to Scanning::SCAN_MUTATORS_IN_SAFEPOINT
 // to make sure this type is not exposed to the bindings.


### PR DESCRIPTION
**DRAFT: This is very old, and is not intended to be merged directly.**

This PR contains a hypothetical change I made for the purpose of killing the `ProcessEdgesWork`.  The point is, the `trace_object` method is at the heart of a trace, the counterpart of the `Trace` or `TraceLocal` type in the old JikesRVM.  Each plan should provide a custom `trace_object` method instead of a custom `ProcessEdgesWork` implementation.

On the contrary, a `ProcessEdgesWork` work packet simply encapsulates enqueued **slots**, and should contain methods that (1) load from the slots, (2) call `trace_object` and (3) store the forwarded reference back to the slot.  It should not implement the `trace_object` method itself.