### PR TITLE
Fix clippy warning about operator precedence

### DIFF
--- a/src/util/heap/space_descriptor.rs
+++ b/src/util/heap/space_descriptor.rs
@@ -39,14 +39,12 @@ impl SpaceDescriptor {
             } else {
                 start >> vm_layout().space_shift_64()
             };
-            return SpaceDescriptor(
-                space_index << INDEX_SHIFT
-                    | (if top {
-                        TYPE_CONTIGUOUS_HI
-                    } else {
-                        TYPE_CONTIGUOUS
-                    }),
-            );
+            let flags = if top {
+                TYPE_CONTIGUOUS_HI
+            } else {
+                TYPE_CONTIGUOUS
+            };
+            return SpaceDescriptor((space_index << INDEX_SHIFT) | flags);
         }
         let chunks = (end - start) >> vm_layout::LOG_BYTES_IN_CHUNK;
         debug_assert!(!start.is_zero() && chunks > 0 && chunks < (1 << SIZE_BITS));


### PR DESCRIPTION
In Rust 1.85, Clippy started to warn about the precedence of `<<` and `|` in one of our use cases, although that lint was added before Rust 1.29.

https://rust-lang.github.io/rust-clippy/master/index.html#precedence