### PR TITLE
Fixing MSRV-breaking dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,13 +57,13 @@ paste = "1.0.8"
 rand = "0.9.0"
 rand_chacha = "0.9.0"
 criterion = "0.5"
-# Note: `half` v2.5.0 started to require Rust 1.8.1.
+# Note: `half` v2.5.0 started to require Rust 1.81.
 # `criterion` transitively depends on `half` via the dependency chain:
 #     criterion -> ciborium -> ciborium_ll -> half
 # The MSRV of `ciborium` v0.2.2 is declared as 1.58, and is declared to depend on `half` v2.2.
-# The Ciborium project should either bump its MSRV or select a version of `half` that satisfies its current MSRV.
+# Ciborium should either bump its MSRV or select a version of `half` that satisfies its current MSRV.
 # We lock the version of `half` to 2.4.1 to workaround this.
-# TODO: When we bump MSRV to 1.84 or above, we can rely on Cargo's MSRV-aware dependency resolver and remove this workaround.
+# TODO: When we bump MSRV to 1.84 or above, we can rely on Cargo's MSRV-aware dependency resolver and remove such workarounds.
 half = "=2.4.1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,18 @@ paste = "1.0.8"
 rand = "0.9.0"
 rand_chacha = "0.9.0"
 criterion = "0.5"
+# Note: `half` v2.5.0 started to require Rust 1.8.1.
+# `criterion` transitively depends on `half` via the dependency chain:
+#     criterion -> ciborium -> ciborium_ll -> half
+# The MSRV of `ciborium` v0.2.2 is declared as 1.58, and is declared to depend on `half` v2.2.
+# The Ciborium project should either bump its MSRV or select a version of `half` that satisfies its current MSRV.
+# We lock the version of `half` to 2.4.1 to workaround this.
+# TODO: When we bump MSRV to 1.84 or above, we can rely on Cargo's MSRV-aware dependency resolver and remove this workaround.
+half = "=2.4.1"
 
 [build-dependencies]
 built = { version = "0.7.7", features = ["git2"] }
-# Note:
-# Some components in ICU4X started to require Rust 1.81 since some versions, such as `litemap` v0.7.5.
+# Note: Some components in ICU4X started to require Rust 1.81 since some versions, such as `litemap` v0.7.5.
 # The `built` crate depends on ICU4X via the dependency chain:
 #     built -> git2 -> url -> idna -> idna_adapter --(default)--------> crates from the ICU4X projects
 #                                                  --(alternatively)--> `unicode-rs`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,14 @@ criterion = "0.5"
 
 [build-dependencies]
 built = { version = "0.7.7", features = ["git2"] }
+# Note:
+# Some components in ICU4X started to require Rust 1.81 since some versions, such as `litemap` v0.7.5.
+# The `built` crate depends on ICU4X via the dependency chain:
+#     built -> git2 -> url -> idna -> idna_adapter --(default)--------> crates from the ICU4X projects
+#                                                  --(alternatively)--> `unicode-rs`
+# But we don't need ICU4X (or even `url`) because we only use `git2` to get the Git commit hash.
+# We move away from ICU4X completely following the instruction in https://docs.rs/crate/idna_adapter/1.2.0
+idna_adapter = "=1.1.0"
 
 [[bench]]
 name = "main"


### PR DESCRIPTION
Some dependencies started to require MSRV above our current MSRV.

The build dependency `built` transitively depends on some crates from the ICU4X project that recently started to depend on Rust 1.81, such as `litemap`.  The dependency on ICU4X is completely unnecessary, and we removed it from our dependency tree by forcing the use of a particular version of `idna_adapter`.  See: https://docs.rs/crate/idna_adapter/1.2.0

The dev dependency `criterion` depends on `ciborium` which depends on the `half` crate.  Since v2.5.0, `half` started to depend on Rust 1.81.  `ciborium` needs to be fixed because its MSRV is 1.58 and shouldn't depend on a crate that requires Rust 1.81.  We lock the version of the `half` to 2.4.1.  This kind of problem should be properly addressed with the new MSRV-aware dependency resolver introduced in Rust 1.84.  See: https://doc.rust-lang.org/cargo/reference/resolver.html#rust-version