### PR TITLE
Fix lychee command

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,22 +17,25 @@ jobs:
             key: cache-lychee-${{ github.sha }}
             restore-keys: cache-lychee-
       - name: Check links in docs/*.md
-        uses: lycheeverse/lychee-action@v1.9.3
+        uses: lycheeverse/lychee-action@v2
         with:
           fail: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Notes:
-          # - Do not use `--base`.  All relative URLs in Markdown are based on the file itself.
-          # - Verbosity level 2 enables debug logs and shows redirections. \
-          # - Exclude dl.acm.org because it responses 403. \
-          args: |
-            --accept '200..=204,429,500' \
-            --verbose --verbose \
-            --no-progress \
-            --cache \
-            --max-cache-age 1d \
-            --exclude 'https://users.cecs.anu.edu.au/~steveb/pubs/papers/**' \
-            --exclude 'https://dl.acm.org/**' \
+          args:
+            # Notes:
+            # - Do not use `--base`.  All relative URLs in Markdown are based on the file itself.
+            # - Verbosity level 2 enables debug logs and shows redirections.
+            # - Exclude dl.acm.org because it responses 403.
+            # According to the YAML syntax,
+            # the following lines will be concatenated into one single YAML string,
+            # which is intended because the `args:` argument of the lychee-action takes one single string.
+            --accept '200..=204,429,500'
+            --verbose --verbose
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --exclude 'https://users.cecs.anu.edu.au/~steveb/pubs/papers/**'
+            --exclude 'https://dl.acm.org/**'
             './docs/**/*.md'
       - name: Save lychee cache
         uses: actions/cache/save@v4

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,7 +21,19 @@ jobs:
         with:
           fail: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --base docs --accept '200,201,202,203,204,429,500' --no-progress --cache --max-cache-age 1d './docs/**/*.md' --exclude https://users.cecs.anu.edu.au/~steveb/pubs/papers/**
+          # Notes:
+          # - Do not use `--base`.  All relative URLs in Markdown are based on the file itself.
+          # - Verbosity level 2 enables debug logs and shows redirections. \
+          # - Exclude dl.acm.org because it responses 403. \
+          args: |
+            --accept '200..=204,429,500' \
+            --verbose --verbose \
+            --no-progress \
+            --cache \
+            --max-cache-age 1d \
+            --exclude 'https://users.cecs.anu.edu.au/~steveb/pubs/papers/**' \
+            --exclude 'https://dl.acm.org/**' \
+            './docs/**/*.md'
       - name: Save lychee cache
         uses: actions/cache/save@v4
         if: always()


### PR DESCRIPTION
Removed `--base`.  All relative URLs in Markdown are relative to the file itself.

Increased verbosity to print the checked URLs and redirections.

Excluded `dl.acm.org`.  It always responses 403 when using Lychee to check links.