### PR TITLE
implement mutator builder

### DIFF
--- a/src/plan/generational/copying/mutator.rs
+++ b/src/plan/generational/copying/mutator.rs
@@ -8,7 +8,6 @@ use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::allocators::Allocators;
 use crate::util::alloc::BumpAllocator;
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;

--- a/src/plan/generational/copying/mutator.rs
+++ b/src/plan/generational/copying/mutator.rs
@@ -41,12 +41,7 @@ pub fn create_gencopy_mutator<VM: VMBinding>(
         release_func: &gencopy_mutator_release,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        gencopy,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder
         .barrier(Box::new(ObjectBarrier::new(
             GenObjectBarrierSemantics::new(mmtk, gencopy),

--- a/src/plan/generational/immix/mutator.rs
+++ b/src/plan/generational/immix/mutator.rs
@@ -8,7 +8,6 @@ use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::allocators::Allocators;
 use crate::util::alloc::BumpAllocator;
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;

--- a/src/plan/generational/immix/mutator.rs
+++ b/src/plan/generational/immix/mutator.rs
@@ -41,12 +41,7 @@ pub fn create_genimmix_mutator<VM: VMBinding>(
         release_func: &genimmix_mutator_release,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        genimmix,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder
         .barrier(Box::new(ObjectBarrier::new(
             GenObjectBarrierSemantics::new(mmtk, genimmix),

--- a/src/plan/generational/immix/mutator.rs
+++ b/src/plan/generational/immix/mutator.rs
@@ -5,6 +5,7 @@ use crate::plan::generational::create_gen_space_mapping;
 use crate::plan::generational::immix::GenImmix;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::AllocationSemantics;
 use crate::util::alloc::allocators::Allocators;
@@ -40,13 +41,15 @@ pub fn create_genimmix_mutator<VM: VMBinding>(
         release_func: &genimmix_mutator_release,
     };
 
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(ObjectBarrier::new(GenObjectBarrierSemantics::new(
-            mmtk, genimmix,
-        ))),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
+        genimmix,
         config,
-        plan: genimmix,
-    }
+    );
+    builder
+        .barrier(Box::new(ObjectBarrier::new(
+            GenObjectBarrierSemantics::new(mmtk, genimmix),
+        )))
+        .build()
 }

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -7,7 +7,7 @@ use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
+use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::alloc::ImmixAllocator;
 use crate::util::opaque_pointer::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -54,11 +54,6 @@ pub fn create_immix_mutator<VM: VMBinding>(
         release_func: &immix_mutator_release,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        immix,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -9,12 +9,9 @@ use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::AllocationSemantics;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
 use crate::util::alloc::ImmixAllocator;
+use crate::util::opaque_pointer::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;
 use crate::MMTK;
-use crate::{
-    plan::barriers::NoBarrier,
-    util::opaque_pointer::{VMMutatorThread, VMWorkerThread},
-};
 use enum_map::EnumMap;
 
 pub fn immix_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -3,6 +3,7 @@ use crate::plan::mutator_context::create_allocator_mapping;
 use crate::plan::mutator_context::create_space_mapping;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::AllocationSemantics;
@@ -56,11 +57,11 @@ pub fn create_immix_mutator<VM: VMBinding>(
         release_func: &immix_mutator_release,
     };
 
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(NoBarrier),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
+        immix,
         config,
-        plan: immix,
-    }
+    );
+    builder.build()
 }

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -4,6 +4,7 @@ use crate::plan::mutator_context::create_allocator_mapping;
 use crate::plan::mutator_context::create_space_mapping;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::AllocationSemantics;
@@ -42,14 +43,13 @@ pub fn create_markcompact_mutator<VM: VMBinding>(
         prepare_func: &unreachable_prepare_func,
         release_func: &markcompact_mutator_release,
     };
-
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(NoBarrier),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
+        markcompact,
         config,
-        plan: markcompact,
-    }
+    );
+    builder.build()
 }
 
 pub fn markcompact_mutator_release<VM: VMBinding>(

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -1,5 +1,4 @@
 use super::MarkCompact;
-use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::create_allocator_mapping;
 use crate::plan::mutator_context::create_space_mapping;
 use crate::plan::mutator_context::unreachable_prepare_func;

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -7,7 +7,7 @@ use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
+use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::alloc::MarkCompactAllocator;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -42,12 +42,7 @@ pub fn create_markcompact_mutator<VM: VMBinding>(
         prepare_func: &unreachable_prepare_func,
         release_func: &markcompact_mutator_release,
     };
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        markcompact,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }
 

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -7,7 +7,7 @@ use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::mutator_context::SpaceMapping;
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
-use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
+use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;
 use crate::MMTK;

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -121,11 +121,6 @@ pub fn create_ms_mutator<VM: VMBinding>(
         release_func: &ms_mutator_release,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        mmtk.get_plan(),
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -1,4 +1,3 @@
-use crate::plan::barriers::NoBarrier;
 use crate::plan::marksweep::MarkSweep;
 use crate::plan::mutator_context::create_allocator_mapping;
 use crate::plan::mutator_context::Mutator;

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -2,6 +2,7 @@ use crate::plan::barriers::NoBarrier;
 use crate::plan::marksweep::MarkSweep;
 use crate::plan::mutator_context::create_allocator_mapping;
 use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::mutator_context::SpaceMapping;
@@ -121,11 +122,11 @@ pub fn create_ms_mutator<VM: VMBinding>(
         release_func: &ms_mutator_release,
     };
 
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(NoBarrier),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
+        mmtk.get_plan(),
         config,
-        plan: mmtk.get_plan(),
-    }
+    );
+    builder.build()
 }

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -56,11 +56,6 @@ pub fn create_nogc_mutator<VM: VMBinding>(
         release_func: &unreachable_release_func,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        plan,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -1,4 +1,3 @@
-use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::unreachable_release_func;
 use crate::plan::mutator_context::Mutator;

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -2,6 +2,7 @@ use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::unreachable_release_func;
 use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::{
     create_allocator_mapping, create_space_mapping, ReservedAllocators,
@@ -56,11 +57,11 @@ pub fn create_nogc_mutator<VM: VMBinding>(
         release_func: &unreachable_release_func,
     };
 
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(NoBarrier),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
-        config,
         plan,
-    }
+        config,
+    );
+    builder.build()
 }

--- a/src/plan/nogc/mutator.rs
+++ b/src/plan/nogc/mutator.rs
@@ -8,7 +8,7 @@ use crate::plan::mutator_context::{
 };
 use crate::plan::nogc::NoGC;
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
+use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::VMMutatorThread;
 use crate::vm::VMBinding;
 use crate::MMTK;

--- a/src/plan/pageprotect/mutator.rs
+++ b/src/plan/pageprotect/mutator.rs
@@ -9,9 +9,9 @@ use crate::plan::mutator_context::{
 };
 use crate::plan::AllocationSemantics;
 use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
+use crate::util::opaque_pointer::VMMutatorThread;
 use crate::vm::VMBinding;
 use crate::MMTK;
-use crate::{plan::barriers::NoBarrier, util::opaque_pointer::VMMutatorThread};
 use enum_map::EnumMap;
 
 const RESERVED_ALLOCATORS: ReservedAllocators = ReservedAllocators {

--- a/src/plan/pageprotect/mutator.rs
+++ b/src/plan/pageprotect/mutator.rs
@@ -8,7 +8,7 @@ use crate::plan::mutator_context::{
     create_allocator_mapping, create_space_mapping, ReservedAllocators,
 };
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
+use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::opaque_pointer::VMMutatorThread;
 use crate::vm::VMBinding;
 use crate::MMTK;

--- a/src/plan/pageprotect/mutator.rs
+++ b/src/plan/pageprotect/mutator.rs
@@ -2,6 +2,7 @@ use super::PageProtect;
 use crate::plan::mutator_context::no_op_release_func;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::{
     create_allocator_mapping, create_space_mapping, ReservedAllocators,
@@ -44,11 +45,11 @@ pub fn create_pp_mutator<VM: VMBinding>(
         release_func: &no_op_release_func,
     };
 
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(NoBarrier),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
+        page,
         config,
-        plan: page,
-    }
+    );
+    builder.build()
 }

--- a/src/plan/pageprotect/mutator.rs
+++ b/src/plan/pageprotect/mutator.rs
@@ -45,11 +45,6 @@ pub fn create_pp_mutator<VM: VMBinding>(
         release_func: &no_op_release_func,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        page,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -61,11 +61,6 @@ pub fn create_ss_mutator<VM: VMBinding>(
         release_func: &ss_mutator_release,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        ss,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -1,5 +1,4 @@
 use super::SemiSpace;
-use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorBuilder;

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -2,6 +2,7 @@ use super::SemiSpace;
 use crate::plan::barriers::NoBarrier;
 use crate::plan::mutator_context::unreachable_prepare_func;
 use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::{
     create_allocator_mapping, create_space_mapping, ReservedAllocators,
@@ -61,11 +62,11 @@ pub fn create_ss_mutator<VM: VMBinding>(
         release_func: &ss_mutator_release,
     };
 
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(NoBarrier),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
+        ss,
         config,
-        plan: ss,
-    }
+    );
+    builder.build()
 }

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -7,7 +7,7 @@ use crate::plan::mutator_context::{
     create_allocator_mapping, create_space_mapping, ReservedAllocators,
 };
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::allocators::{AllocatorSelector, Allocators};
+use crate::util::alloc::allocators::AllocatorSelector;
 use crate::util::alloc::BumpAllocator;
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;

--- a/src/plan/sticky/immix/mutator.rs
+++ b/src/plan/sticky/immix/mutator.rs
@@ -5,7 +5,6 @@ use crate::plan::mutator_context::{
     create_space_mapping, unreachable_prepare_func, MutatorBuilder, MutatorConfig,
 };
 use crate::plan::sticky::immix::global::StickyImmix;
-use crate::util::alloc::allocators::Allocators;
 use crate::util::alloc::AllocatorSelector;
 use crate::util::opaque_pointer::VMWorkerThread;
 use crate::util::VMMutatorThread;

--- a/src/plan/sticky/immix/mutator.rs
+++ b/src/plan/sticky/immix/mutator.rs
@@ -1,7 +1,9 @@
 use crate::plan::barriers::ObjectBarrier;
 use crate::plan::generational::barrier::GenObjectBarrierSemantics;
 use crate::plan::immix;
-use crate::plan::mutator_context::{create_space_mapping, unreachable_prepare_func, MutatorConfig};
+use crate::plan::mutator_context::{
+    create_space_mapping, unreachable_prepare_func, MutatorBuilder, MutatorConfig,
+};
 use crate::plan::sticky::immix::global::StickyImmix;
 use crate::util::alloc::allocators::Allocators;
 use crate::util::alloc::AllocatorSelector;
@@ -33,14 +35,15 @@ pub fn create_stickyimmix_mutator<VM: VMBinding>(
         release_func: &stickyimmix_mutator_release,
     };
 
-    Mutator {
-        allocators: Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        barrier: Box::new(ObjectBarrier::new(GenObjectBarrierSemantics::new(
-            mmtk,
-            stickyimmix,
-        ))),
+    let builder = MutatorBuilder::new(
+        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
         mutator_tls,
+        stickyimmix,
         config,
-        plan: mmtk.get_plan(),
-    }
+    );
+    builder
+        .barrier(Box::new(ObjectBarrier::new(
+            GenObjectBarrierSemantics::new(mmtk, stickyimmix),
+        )))
+        .build()
 }

--- a/src/plan/sticky/immix/mutator.rs
+++ b/src/plan/sticky/immix/mutator.rs
@@ -35,12 +35,7 @@ pub fn create_stickyimmix_mutator<VM: VMBinding>(
         release_func: &stickyimmix_mutator_release,
     };
 
-    let builder = MutatorBuilder::new(
-        Allocators::<VM>::new(mutator_tls, mmtk, &config.space_mapping),
-        mutator_tls,
-        stickyimmix,
-        config,
-    );
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder
         .barrier(Box::new(ObjectBarrier::new(
             GenObjectBarrierSemantics::new(mmtk, stickyimmix),


### PR DESCRIPTION
https://mmtk.zulipchat.com/#narrow/channel/262673-mmtk-core/topic/create.20plan.2Fmutator/near/504996362
Introducing `MutatorBuilder` to simplify customising `Mutator`, adding/removing fields of a certain plan's `Mutator` no longer affects other plan as `MutatorBuilder` provides default values for `Mutator`