### PR TITLE
Fix to bytemuck_derive 1.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ atomic = "0.6.0"
 atomic_refcell = "0.1.7"
 atomic-traits = "0.4.0"
 bytemuck = { version = "1.14.0", features = ["derive"] }
+bytemuck_derive = "=1.8.1" # We can remove this dependency when we use MSRV 1.84+
 cfg-if = "1.0"
 crossbeam = "0.8.1"
 delegate = "0.13.2"


### PR DESCRIPTION
`bytemuck` uses `bytemuck_derive ^1.4.1`. Recent `bytemuck_derive` versions are not compatible with our MSRV 1.74.1 (1.9.1 requires Rust 1.84+, 1.9.0 requires edition 2024 which is stablized in 1.84). So fix `bytemuck_derive` to the last version before 1.9.0.