### PR TITLE
Check if an object is in our heap before using VM map during counting live bytes

### DIFF
--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -69,10 +69,9 @@ impl<VM: VMBinding> GCWorkerShared<VM> {
 
         // The live bytes of the object
         let bytes = VM::VMObjectModel::get_current_size(object);
-        // Check if the object is in our heap. If it is not in our heap (e.g. in the VM space), we cannot use VM map to get its descriptor.
-        if crate::util::heap::vm_layout::vm_layout().in_available_range(object.to_raw_address()) {
-            // Get the space index from descriptor
-            let space_descriptor = VM_MAP.get_descriptor_for_address(object.to_raw_address());
+        // Get the space index from descriptor
+        let space_descriptor = VM_MAP.get_descriptor_for_address(object.to_raw_address());
+        if space_descriptor != crate::util::heap::space_descriptor::SpaceDescriptor::UNINITIALIZED {
             let space_index = space_descriptor.get_index();
             debug_assert!(
                 space_index < MAX_SPACES,

--- a/src/util/heap/layout/map.rs
+++ b/src/util/heap/layout/map.rs
@@ -81,6 +81,8 @@ pub trait VMMap: Sync {
 
     fn is_finalized(&self) -> bool;
 
+    /// Get the space descriptor for the given address. Return SpaceDescriptor::UNINITIALIZED if the
+    /// address is not within the MMTk heap range, or not within MMTk spaces.
     fn get_descriptor_for_address(&self, address: Address) -> SpaceDescriptor;
 
     fn add_to_cumulative_committed_pages(&self, pages: usize);

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -255,7 +255,10 @@ impl VMMap for Map32 {
 
     fn get_descriptor_for_address(&self, address: Address) -> SpaceDescriptor {
         let index = address.chunk_index();
-        self.descriptor_map[index]
+        self.descriptor_map
+            .get(index)
+            .copied()
+            .unwrap_or(SpaceDescriptor::UNINITIALIZED)
     }
 
     fn add_to_cumulative_committed_pages(&self, pages: usize) {

--- a/src/util/heap/layout/map64.rs
+++ b/src/util/heap/layout/map64.rs
@@ -206,8 +206,11 @@ impl VMMap for Map64 {
     }
 
     fn get_descriptor_for_address(&self, address: Address) -> SpaceDescriptor {
-        let index = Self::space_index(address).unwrap();
-        self.inner().descriptor_map[index]
+        if let Some(index) = Self::space_index(address) {
+            self.inner().descriptor_map[index]
+        } else {
+            SpaceDescriptor::UNINITIALIZED
+        }
     }
 
     fn add_to_cumulative_committed_pages(&self, pages: usize) {

--- a/src/util/heap/layout/vm_layout.rs
+++ b/src/util/heap/layout/vm_layout.rs
@@ -63,10 +63,6 @@ impl VMLayout {
     pub const fn available_end(&self) -> Address {
         self.heap_end
     }
-    /// Is the given address within the address space between available start and available end?
-    pub fn in_available_range(&self, addr: Address) -> bool {
-        addr >= self.available_start() && addr < self.available_end()
-    }
     /// Size of the address space available to the MMTk heap.
     pub const fn available_bytes(&self) -> usize {
         self.available_end().get_extent(self.available_start())

--- a/src/util/heap/layout/vm_layout.rs
+++ b/src/util/heap/layout/vm_layout.rs
@@ -63,6 +63,10 @@ impl VMLayout {
     pub const fn available_end(&self) -> Address {
         self.heap_end
     }
+    /// Is the given address within the address space between available start and available end?
+    pub fn in_available_range(&self, addr: Address) -> bool {
+        addr >= self.available_start() && addr < self.available_end()
+    }
     /// Size of the address space available to the MMTk heap.
     pub const fn available_bytes(&self) -> usize {
         self.available_end().get_extent(self.available_start())


### PR DESCRIPTION
This PR fixes a bug in `increase_live_bytes`. If an object in the VM space is scanned, the method will be called with an object reference into the VM space, which may not be in our heap range. Then we get a space descriptor from the VM map, and we will see panics in the following code.
https://github.com/mmtk/mmtk-core/blob/129362d4f39a1191562d276c42f5b03e52aa287a/src/util/heap/layout/map64.rs#L209
https://github.com/mmtk/mmtk-core/blob/129362d4f39a1191562d276c42f5b03e52aa287a/src/util/heap/layout/map32.rs#L258

This PR works around the problem by checking if the object is in our heap range first.