### PR TITLE
Aggregate live bytes info in on_gc_finished

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -153,15 +153,6 @@ impl<C: GCWorkContext + 'static> GCWork<C::VM> for Release<C> {
             let result = w.designated_work.push(Box::new(ReleaseCollector));
             debug_assert!(result.is_ok());
         }
-
-        if *mmtk.get_options().count_live_bytes_in_gc {
-            let live_bytes = mmtk
-                .scheduler
-                .worker_group
-                .get_and_clear_worker_live_bytes();
-            *mmtk.state.live_bytes_in_last_gc.borrow_mut() =
-                mmtk.aggregate_live_bytes_in_last_gc(live_bytes);
-        }
     }
 }
 

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -559,10 +559,10 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                 .scheduler
                 .worker_group
                 .get_and_clear_worker_live_bytes();
-            let mut stats = mmtk.state.live_bytes_in_last_gc.borrow_mut();
-            *stats = mmtk.aggregate_live_bytes_in_last_gc(live_bytes);
+            let mut live_bytes_in_last_gc = mmtk.state.live_bytes_in_last_gc.borrow_mut();
+            *live_bytes_in_last_gc = mmtk.aggregate_live_bytes_in_last_gc(live_bytes);
             // Logging
-            for (space_name, &stats) in stats.iter() {
+            for (space_name, &stats) in live_bytes_in_last_gc.iter() {
                 info!(
                     "{} = {} pages ({:.1}% live)",
                     space_name,


### PR DESCRIPTION
This PR moves the call to `aggregate_live_bytes_in_last_gc` from the `Release` work packet to `on_gc_finished`. Spaces may do release work in parallel with the `Release` work packet, and `aggregate_live_bytes_in_last_gc` accesses reserved pages of spaces. This leads to a data race. We observed the reserved pages in the collected live bytes stats to be larger than the actual reserved pages at the end of a GC, as some pages were not released yet.