### PR TITLE
User Guide chapter for address-based hashing

### DIFF
--- a/docs/userguide/src/SUMMARY.md
+++ b/docs/userguide/src/SUMMARY.md
@@ -40,6 +40,7 @@
         - [Optimizing Allocation](portingguide/perf_tuning/alloc.md)
     - [VM-specific Concerns](portingguide/concerns/prefix.md)
         - [Finalizers and Weak References](portingguide/concerns/weakref.md)
+        - [Address-based Hashing](portingguide/concerns/address-based-hashing.md)
 - [API Migration Guide](migration/prefix.md)
     - [Template (for mmtk-core developers)](migration/template.md)
 

--- a/docs/userguide/src/glossary.md
+++ b/docs/userguide/src/glossary.md
@@ -16,17 +16,18 @@ conventional graphs, an edge may originate from either another node or a *root*.
 Each *node* represents an object in the heap.
 
 Each *edge* represents an object reference from an object or a root.  A *root* is a reference held
-in a slot directly accessible from [mutators][mutator], including local variables, global variables,
+in a slot directly accessible from [mutators], including local variables, global variables,
 thread-local variables, and so on.  A object can have many fields, and some fields may hold
 references to objects, while others hold non-reference values.
 
 An object is *reachable* if there is a path in the object graph from any root to the node of the
-object.  Unreachable objects cannot be accessed by [mutators][mutator].  They are considered
+object.  Unreachable objects cannot be accessed by [mutators].  They are considered
 garbage, and can be reclaimed by the garbage collector.
 
-[mutator]: #mutator
-
 ## Mutator
+
+[mutator]: #mutator
+[mutators]: #mutator
 
 TODO
 
@@ -46,6 +47,112 @@ not retaining referents of [`SoftReference`][java-soft-ref] which is primarily d
 implementing memory-sensitive caches.
 
 [java-soft-ref]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/SoftReference.html
+
+## GC-safe Point
+
+[GC-safe point]: #gc-safe-point
+[GC-safe points]: #gc-safe-point
+
+Also known as: *GC-point*
+
+A *GC-safe point* is a place in the code executed by mutators where (stop-the-world) garbage
+collection is allowed to happen.
+
+It is impractical to allow GC to happen at any program counter (PC) for several reasons.
+
+1.  The GC needs to identify references held in stack slots and machine registers.  Allowing GC to
+    happen at any PC will either force the compiler to generate [stack maps] at all PCs, or force
+    the VM to use [conservative stack scanning].
+2.  Some operations, such as [write barriers] and [address-based hashing], need to be *atomic with
+    respect to GC*.  Allowing GC to happen in the middle of such operations will complicate the
+    implementation or make it inefficient.
+
+In practice, we only allow GC to happen at certain *GC-safe points* where the compiler generates
+[stack maps].
+
+Note that although concurrent garbage collection can run concurrently with mutators, it also needs
+to synchronize with each mutator at a GC-safe point.
+
+Examples of GC-safe points (not exhaustive):
+
+-   [yieldpoints]
+-   object allocation (may trigger GC)
+-   call sites to other functions where GC is allowed to happen inside
+
+Examples of non-GC-safe points (not exhaustive):
+
+-   [write barriers]
+-   [address-based hashing]
+-   call sites to other functions during which GC must not happen
+
+For programs without GC semantics (e.g. programs written in C, C++, Rust, etc.), their compilers
+(GCC, clang, rustc, ...) are agnostic to GC.  It is up to the VM to decide whether GC can happen
+when a mutator is executing native functions written in those languages.  For example, if a mutator
+is executing long-running native functions (such as blocking system calls) that cannot access the GC
+heap, the VM usually allows GC to happen without waiting for this mutator.  But if a mutator is
+running a runtime function that cannot be interrupted by GC (such as the write barrier slow path
+implemented as a native function), the VM must wait for the mutator to return from such native
+functions before letting GC start.
+
+## Stack Map
+
+[stack map]: #stack-map
+[stack maps]: #stack-map
+
+A *stack map* is a data structure that identifies stack slots and registers that may contain
+references.  Stack maps are essential for supporting [precise stack scanning].
+
+## Yieldpoint
+
+[yieldpoint]: #yieldpoint
+[yieldpoints]: #yieldpoint
+
+Also known as: *GC-check point*
+
+A *yieldpoint* is a point in a program where a mutator checks if it should yield from normal
+execution in order to handle certain events, such as garbage collection, profiling, biased lock
+revocation, etc.
+
+Compilers of programs with GC semantics (e.g. Java source code or byte code) insert yieldpoints in
+various places, such as loop back-edges, so that mutators can yield promptly when GC is triggered
+asynchronously by other threads.  Compilers also generate [stack maps] at yieldpoints to make them
+[GC-safe points].
+
+Read the paper [*Stop and go: Understanding yieldpoint behavior*][LWB+15] by Lin et al. for more
+details.
+
+[LWB+15]: https://dl.acm.org/doi/10.1145/2754169.2754187
+
+## Address-based Hashing
+
+[address-based hashing]: #address-based-hashing
+
+*Address-based hashing* is a GC-assisted space-efficient high-performance method for implementing
+identity hash code in copying GC.
+
+Read the [Address-based Hashing](portingguide/concerns/address-based-hashing.md) chapter for more
+details.
+
+## Precise Stack Scanning
+
+[precise stack scanning]: #precise-stack-scanning
+
+Also known as: *exact stack scanning*
+
+TODO
+
+## Conservative Stack Scanning
+
+[conservative stack scanning]: #conservative-stack-scanning
+
+TODO
+
+## Write Barrier
+
+[write barrier]: #write-barrier
+[write barriers]: #write-barrier
+
+TODO
 
 <!--
 vim: tw=100 ts=4 sw=4 sts=4 et

--- a/docs/userguide/src/glossary.md
+++ b/docs/userguide/src/glossary.md
@@ -56,43 +56,61 @@ implementing memory-sensitive caches.
 Also known as: *GC-point*
 
 A *GC-safe point* is a place in the code executed by mutators where (stop-the-world) garbage
-collection is allowed to happen.
+collection is allowed to happen.  Concurrent GC can run concurrently with mutators, but still needs
+to synchronize with mutators at GC-safe points.  Regardless, the following statements must be true
+when a mutator is at a GC-safe point.
 
-It is impractical to allow GC to happen at any program counter (PC) for several reasons.
+-   References held by a mutator can be identified.  That include references in local variables,
+    thread-local variables, and so on.  For compiled code, that include those in stack slots and
+    machine registers.
+-   The mutator cannot be in the middle of operations that must be *atomic with respect to GC*.
+    That includes [write barriers], [address-based hashing], etc.
 
-1.  The GC needs to identify references held in stack slots and machine registers.  Allowing GC to
-    happen at any PC will either force the compiler to generate [stack maps] at all PCs, or force
-    the VM to use [conservative stack scanning].
-2.  Some operations, such as [write barriers] and [address-based hashing], need to be *atomic with
-    respect to GC*.  Allowing GC to happen in the middle of such operations will complicate the
-    implementation or make it inefficient.
+### Code With GC Semantics
 
-In practice, we only allow GC to happen at certain *GC-safe points* where the compiler generates
-[stack maps].
+Compilers (including ahead-of-time and just-in-time compilers) for programs with garbage collection
+semantics (such as Java source code or bytecode) usually understand GC semantics, too, and can
+generate [yieldpoints] and [stack maps] to assist GC.
 
-Note that although concurrent garbage collection can run concurrently with mutators, it also needs
-to synchronize with each mutator at a GC-safe point.
-
-Examples of GC-safe points (not exhaustive):
+In practice, such compilers only make certain places in a function GC-safe and only generate [stack
+maps] at those places, including but not limited to:
 
 -   [yieldpoints]
--   object allocation (may trigger GC)
+-   object allocation sites (may trigger GC)
 -   call sites to other functions where GC is allowed to happen inside
 
-Examples of non-GC-safe points (not exhaustive):
+If we allow GC to happen at arbitrary PC, it will either force the compiler to generate [stack maps]
+at all PCs, or force the VM to use [shadow stacks] or [conservative stack scanning], instead.  It
+will also break operations that must be *atomic with respect to GC*, such as [write barrier] and
+[address-based hashing].
 
--   [write barriers]
--   [address-based hashing]
--   call sites to other functions during which GC must not happen
+### Code Without GC Semantics
 
-For programs without GC semantics (e.g. programs written in C, C++, Rust, etc.), their compilers
-(GCC, clang, rustc, ...) are agnostic to GC.  It is up to the VM to decide whether GC can happen
-when a mutator is executing native functions written in those languages.  For example, if a mutator
-is executing long-running native functions (such as blocking system calls) that cannot access the GC
-heap, the VM usually allows GC to happen without waiting for this mutator.  But if a mutator is
-running a runtime function that cannot be interrupted by GC (such as the write barrier slow path
-implemented as a native function), the VM must wait for the mutator to return from such native
-functions before letting GC start.
+In contrast, for programs without GC semantics (e.g. programs written in C, C++, Rust, etc.), their
+compilers (GCC, clang, rustc, ...) are agnostic to GC.  But many VMs (such as OpenJDK, CRuby, Julia,
+etc.) are implemented in such languages.  We don't usually use the term "GC-safe point" for
+functions written in C, C++, Rust, etc., but each VM has its own rules to determine whether GC can
+happen within functions written in those languages.
+
+Interpreters usually maintain local variables in dedicated stacks or frames data structures.
+References in such structures are identified by traversing those stacks or frames, and GC is usually
+allowed between bytecode instructions.
+
+Some runtime functions implement operations tightly related to GC, and must be *atomic w.r.t. GC*.
+For example, if a function initializes the type information in the header of an object, GC cannot
+happen in the middle.  Otherwise the GC will read a corrupted header and crash.  Other examples
+include functions that implement the write barrier [slow path] and [address-based hashing].  Such
+functions cannot allocate objects, and cannot call any function that may trigger GC.
+
+Some functions do not access the GC heap, or only access the heap in controlled ways (e.g. utilizing
+[object pinning], or via safe APIs such as [JNI]).  Some of such functions (such as wrappers for
+blocking system calls including `read` and `write`) are long-running.  GC is usually safe when some
+mutators are executing such functions.  Compilers for languages with GC semantics usually make *call
+sites* to such functions [GC-safe points], and generate [stack maps] at those call sites.  The
+runtime usually transitions the state of the current mutator thread so that the GC knows it is in
+such a function when requesting all mutators to stop at their next GC-safe points.
+
+[JNI]: https://docs.oracle.com/en/java/javase/21/docs/specs/jni/index.html
 
 ## Stack Map
 
@@ -109,14 +127,17 @@ references.  Stack maps are essential for supporting [precise stack scanning].
 
 Also known as: *GC-check point*
 
-A *yieldpoint* is a point in a program where a mutator checks if it should yield from normal
+A *yieldpoint* is a point in a program where a mutator thread checks if it should yield from normal
 execution in order to handle certain events, such as garbage collection, profiling, biased lock
 revocation, etc.
 
-Compilers of programs with GC semantics (e.g. Java source code or byte code) insert yieldpoints in
-various places, such as loop back-edges, so that mutators can yield promptly when GC is triggered
-asynchronously by other threads.  Compilers also generate [stack maps] at yieldpoints to make them
-[GC-safe points].
+Compilers of programs with GC semantics (e.g. Java source code and byte code) insert yieldpoints in
+various places, such as function epilogues and loop back-edges.  In this way, when GC is triggered
+asynchronously by other threads, the current mutator can reach the next yieldpoint quickly and yield
+for GC promptly.  Compilers also generate [stack maps] at yieldpoints to make them [GC-safe points].
+
+Because some operations (such as [write barrier]) must be *atomic w.r.t. GC*, [yieldpoints] must not
+be inserted in the middle of such operations.
 
 Read the paper [*Stop and go: Understanding yieldpoint behavior*][LWB+15] by Lin et al. for more
 details.
@@ -147,10 +168,30 @@ TODO
 
 TODO
 
+## Shadow Stack
+
+[shadow stack]: #shadow-stack
+[shadow stacks]: #shadow-stack
+
+TODO
+
 ## Write Barrier
 
 [write barrier]: #write-barrier
 [write barriers]: #write-barrier
+
+TODO
+
+## Fast Path and Slow Path
+
+[fast path]: #fast-path-and-slow-path
+[slow path]: #fast-path-and-slow-path
+
+TODO
+
+## Object Pinning
+
+[object pinning]: #object-pinning
 
 TODO
 

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -71,11 +71,12 @@ Each object is in one of the three **hash code states**:
 The state-transition graph is shown below:
 
 ```
-   move           hash          move or hash  
-   ┌──┐           ┌──┐              ┌──┐      
-┌──▼──┴──┐ hash ┌─▼──┴─┐ move ┌─────▼──┴─────┐
-│Unhashed├─────►│Hashed├─────►│HashedAndMoved│
-└────────┘      └──────┘      └──────────────┘
+       move                        hash                    move or hash   
+     ┌──────┐                    ┌──────┐                    ┌──────┐     
+     │      │                    │      │                    │      │     
+┌────▼──────┴────┐   hash   ┌────▼──────┴────┐   move   ┌────▼──────┴────┐
+│    Unhashed    ├─────────►│     Hashed     ├─────────►│ HashedAndMoved │
+└────────────────┘          └────────────────┘          └────────────────┘
 ```
 
 States are transitioned upon events labelled on the edges:

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -166,7 +166,7 @@ MMTk calls the following trait methods implemented by the VM binding during copy
     -   `ObjectModel::get_align_when_copied`
     -   `ObjectModel::get_align_offset_when_copied`
 
-When using a non-delayed-copy collector, MMTk calls `ObjectgModel::copy` which is defined as:
+When using a non-delayed-copy collector, MMTk calls `ObjectModel::copy` which is defined as:
 
 ```rust
 {{#include ../../../../../src/vm/object_model.rs:copy}}

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -223,11 +223,11 @@ If, as in JikesRVM, the `Unhashed` state is encoded as `00` and the `Hashed` sta
 `01`, this state transition can be done with a single atomic bit-set or fetch-or operation.
 
 There is also a risk if GC can happen concurrently, moving the object and changing its state.  If
-copying only happens during stop-the-world (that includes all stop-the-world GC algorithms and
-mostly-concurrent GC algorithms that only copy objects during stop-the-world, such as [LXR]), we can
-make the computing of identity hash code *atomic with respect to copying GC* by not inserting
-[GC-safe points] in the middle of computing identity hash code.  MMTk currently does not have
-concurrent copying GC.
+copying only happens during stop-the-world (that includes all stop-the-world GC algorithms and some
+concurrent GC algorithms that only copy objects during stop-the-world, such as [LXR]), we can make
+the computing of identity hash code *atomic with respect to copying GC* by not inserting [GC-safe
+points] in the middle of computing identity hash code.  MMTk currently does not have concurrent
+copying GC.
 
 [LXR]: https://dl.acm.org/doi/10.1145/3519939.3523440
 [GC-safe points]: ../../glossary.md#gc-safe-point

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -169,7 +169,11 @@ MMTk calls the following trait methods implemented by the VM binding during copy
 When using a non-delayed-copy collector, MMTk calls `ObjectModel::copy` which is defined as:
 
 ```rust
-{{#include ../../../../../src/vm/object_model.rs:copy}}
+    fn copy(
+        from: ObjectReference,
+        semantics: CopySemantics,
+        copy_context: &mut GCWorkerCopyContext<VM>,
+    ) -> ObjectReference;
 ```
 
 The `copy` method should

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -157,7 +157,7 @@ Hash at the end                    │   Header   │ ordinary fields...       �
 
 MMTk calls the following trait methods implemented by the VM binding during copying GC.
 
--   For non-delayed-copy collectors (all moving plans except MarkCompact) 
+-   For non-delayed-copy collectors (all moving plans except MarkCompact)
     -   `ObjectModel::copy`
 -   For delayed-copy collectors (MarkCompact)
     -   `ObjectModel::copy_to`

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -194,6 +194,26 @@ header bits and the hash field in `copy_to`.  The reference to the old copy is p
 three methods as a parameter so that the VM binding can look up the state of the old copy, and
 determine the state of the new copy.
 
+### Observing the Identity Hash Code
+
+Mutators should get the identity hash code of an object by first finding the state of the object.
+
+If the object is in the `Unhashed` or `Hashed` state, the hash code shall be the address of the
+object.  Specifically, if the object is in the `Unhashed` state, it should change its state to
+`Hashed`.  This should be done *atomically* because other mutators may be observing the identity
+hash code of the same object concurrently.  If `Unhashed` is encoded as 00 and `Hashed` is encoded
+as 01 in binary, this can be done with an atomic bit-set or fetch-or operation.
+
+If the object is in the `HashedAndMoved` state, the hash code shall be read from the added hash
+field.
+
+Note that the operation for the mutator to observe the identity hash code must be *atomic with
+respect to the GC*.  One way to ensure this in stop-the-world GC is not having [GC-safe points] in
+the function that computes the identity hash code.  Currently, all plans in the `master` branch of
+`mmtk-core` are stop-the-world.
+
+[GC-safe points]: ../../glossary.md#gc-safe-point
+
 ## Alternative Implementation Strategies
 
 

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -1,0 +1,103 @@
+# Address-based Hashing
+
+Address-based hashing is a GC-assisted method for implementing identity hash code in copying GC.  It
+has the advantage of high performance and not requiring a dedicated hash field for most objects.
+
+This chapter is especially useful for VMs that previously used non-moving GC and naively used the
+object address as identity hash code.
+
+## Concepts
+
+An **identity hash code** of an object is a hash code that never changes during the lifetime of the
+object, i.e. since it is allocated, until it is reclaimed by the GC.
+
+-   It is unrelated to the *value* the object represents.  This means modifying the fields of an
+    object does not modify its identity hash code.
+-   Copying GC does *not* change object identities.  If an object is moved by a copying GC, its
+    identity hash code remains the same.
+-   It is not required to be *unique*.  Two different objects are allowed to have the same hash
+    code.
+
+For non-copying GC algorithms, the *address* of an object never changes, and is therefore an ideal
+identity hash code.
+
+For copying GC algorithms, however, we cannot simply use the address of an object because it will be
+changed when the GC moves the object.  A naive solution is adding an extra field to every object to
+hold its hash code, and the field is copied when the GC moves the object.  Although this approach
+works (and it is used by real-world VMs such as OpenJDK), it has obvious drawbacks.  It
+unconditionally adds a field to every object.  However,
+
+-   **Objects are rarely moved** in advanced GC algorithms such as Immix.
+-   **Few objects ever have identity hash code _observed_** (e.g.  by calling
+    `System.identityHashCode(object)` in Java) in real-world applications.  According to [the
+    Lilliput project of the OpenJDK][openjdk-lilliput], with most workloads, only relatively few
+    (<1%) Java objects are ever assigned an identity hash.
+
+[openjdk-lilliput]: https://wiki.openjdk.org/display/lilliput
+
+**Address-based hashing** solves the problem by not adding the extra hash field until both of the
+following conditions are true:
+
+1.  The identity hash code of the object has been observed, and
+2.  the object is moved by the GC *after* its identity hash code has been observed.
+
+Under the *weak generational hypothesis*, i.e. most objects die young, most objects won't live long
+enough until the extra hash field becomes necessary.
+
+The address-based hashing algorithm is implemented [in JikesRVM][jikesrvm-hash], and is planned to
+be implemented in OpenJDK ([the Lilliput project][lilliput-ihash]).
+
+[jikesrvm-hash]: https://www.jikesrvm.org/JavaDoc/org/jikesrvm/objectmodel/JavaHeader.html
+[lilliput-ihash]: https://wiki.openjdk.org/display/lilliput/Compact+Identity+Hashcode
+
+## The Address-based Hashing Algorithm
+
+Each object is in one of the three states:
+
+-   `Unhashed`
+-   `Hashed`
+-   `HashedAndMoved`
+
+The state-transition graph is shown below:
+
+```
+   move           hash          move or hash  
+   ┌──┐           ┌──┐              ┌──┐      
+┌──▼──┴──┐ hash ┌─▼──┴─┐ move ┌─────▼──┴─────┐
+│Unhashed├─────►│Hashed├─────►│HashedAndMoved│
+└────────┘      └──────┘      └──────────────┘
+```
+
+States are transitioned upon events labelled on the edges:
+
+-   `hash`: The mutator observes the identity hash code of an object.
+-   `move`: The GC moves the object.
+
+An object starts in the `Unhashed` state when allocated.  The GC is free to move it any times, and
+its state remains `Unhashed`, as long as its identity hash code is not observed.
+
+When the identity hash code is observed for the first time, its state is changed to `Hashed`.  **In
+the `Hashed` state, the identity hash code of an object is its address.**  The object will continue
+to use its address as its identity hash code until the object is moved.
+
+When a `Hashed` object is moved, the GC adds a hash field (distinct from high-level language fields
+defined by the application) to the new copy of the object, and writes its old address into that
+field.  The state of the object is transitioned to `HashedAndMoved`.  **In the `HashedAndMoved`
+state, the identity hash code of an object is the value in its added hash field**, and it will keep
+using the value in the field as the identity hash code from then on.
+
+When a `HashedAndMoved` object is moved again, the GC copies the hash field to the newer copy, but
+no state transition happens.
+
+## Implementing Address-based Hashing with MMTk
+
+Since there are three states, each object needs two bits of metadata to represent that state.  The
+two bits are usually held in the object header, but it is also possible to use side metadata albeit
+slightly higher memory overhead.
+
+When getting (i.e. observing) the identity hash code of an object, it n
+
+
+<!--
+vim: tw=100 ts=4 sw=4 sts=4 et
+-->

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -360,11 +360,13 @@ pub trait ObjectModel<VM: VMBinding> {
     /// * `from`: The address of the object to be copied.
     /// * `semantics`: The copy semantic to use.
     /// * `copy_context`: The `GCWorkerCopyContext` for the GC thread.
+    // ANCHOR: copy
     fn copy(
         from: ObjectReference,
         semantics: CopySemantics,
         copy_context: &mut GCWorkerCopyContext<VM>,
     ) -> ObjectReference;
+    // ANCHOR_END: copy
 
     /// Copy an object. This is required
     /// for delayed-copy collectors such as compacting collectors. During the
@@ -385,7 +387,7 @@ pub trait ObjectModel<VM: VMBinding> {
     ///
     /// Arguments:
     /// * `from`: The object to be copied.
-    /// * `to`: The region to be copied to.
+    /// * `to`: The start of the region to be copied to.
     fn get_reference_when_copied_to(from: ObjectReference, to: Address) -> ObjectReference;
 
     /// Return the size used by an object.

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -360,13 +360,11 @@ pub trait ObjectModel<VM: VMBinding> {
     /// * `from`: The address of the object to be copied.
     /// * `semantics`: The copy semantic to use.
     /// * `copy_context`: The `GCWorkerCopyContext` for the GC thread.
-    // ANCHOR: copy
     fn copy(
         from: ObjectReference,
         semantics: CopySemantics,
         copy_context: &mut GCWorkerCopyContext<VM>,
     ) -> ObjectReference;
-    // ANCHOR_END: copy
 
     /// Copy an object. This is required
     /// for delayed-copy collectors such as compacting collectors. During the


### PR DESCRIPTION
This PR adds a User Guide chapter for address-based hashing.

We also extended the Glossary to introduce GC-safe points and related concepts.