### PR TITLE
Fix incongruent defaults for copying GCs

### DIFF
--- a/src/plan/plan_constraints.rs
+++ b/src/plan/plan_constraints.rs
@@ -56,7 +56,7 @@ impl PlanConstraints {
             max_non_los_default_alloc_bytes: MAX_INT,
             max_non_los_copy_bytes: MAX_INT,
             // As `LAZY_SWEEP` is true, needs_linear_scan is true for all the plans. This is strange.
-            // https://github.com/mmtk/mmtk-core/issues/1027 trackes the issue.
+            // https://github.com/mmtk/mmtk-core/issues/1027 tracks the issue.
             needs_linear_scan: crate::util::constants::SUPPORT_CARD_SCANNING
                 || crate::util::constants::LAZY_SWEEP,
             needs_concurrent_workers: false,
@@ -69,9 +69,9 @@ impl PlanConstraints {
     }
 }
 
-/// The default plan constraints. Each plan should define their own plan contraints.
+/// The default plan constraints. Each plan should define their own plan constraints.
 /// They can start from the default constraints and explicitly set some of the fields.
 pub(crate) const DEFAULT_PLAN_CONSTRAINTS: PlanConstraints = PlanConstraints::default();
 
-// Use 16 pages as the size limit for non-LOS objects to avoid copying large objects
-pub const MAX_NON_LOS_ALLOC_BYTES_COPYING_PLAN: usize = 16 << LOG_BYTES_IN_PAGE;
+// Use two pages as the size limit for non-LOS objects to avoid copying large objects
+pub const MAX_NON_LOS_ALLOC_BYTES_COPYING_PLAN: usize = 2 << LOG_BYTES_IN_PAGE;

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -9,8 +9,8 @@ use crate::util::conversions::bytes_to_pages_up;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
 
-const BYTES_IN_PAGE: usize = 1 << 12;
-const BLOCK_SIZE: usize = 8 * BYTES_IN_PAGE;
+/// Size of a bump allocator block. Currently it is set to 32 KB.
+const BLOCK_SIZE: usize = 8 << crate::util::constants::LOG_BYTES_IN_PAGE;
 const BLOCK_MASK: usize = BLOCK_SIZE - 1;
 
 /// A bump pointer allocator. It keeps a thread local allocation buffer,


### PR DESCRIPTION
We change the max non-LOS allocation size to 8 KB.