### PR TITLE
Fix clippy warnings for Rust 1.86

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! * GC components:
 //!   * [Allocators](util/alloc/allocator/trait.Allocator.html): handlers of allocation requests which allocate objects to the bound space.
 //!   * [Policies](policy/space/trait.Space.html): definitions of semantics and behaviors for memory regions.
-//!      Each space is an instance of a policy, and takes up a unique proportion of the heap.
+//!     Each space is an instance of a policy, and takes up a unique proportion of the heap.
 //!   * [Work packets](scheduler/work/trait.GCWork.html): units of GC work scheduled by the MMTk's scheduler.
 //! * [GC plans](plan/global/trait.Plan.html): GC algorithms composed from components.
 //! * [Heap implementations](util/heap/index.html): the underlying implementations of memory resources that support spaces.

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -568,7 +568,7 @@ impl<VM: VMBinding> MMTK<VM> {
     /// Arguments:
     /// *   `out`: the place to print the VM maps.
     /// *   `space_name`: If `None`, print all spaces;
-    ///                   if `Some(n)`, only print the space whose name is `n`.
+    ///     if `Some(n)`, only print the space whose name is `n`.
     pub fn debug_print_vm_maps(
         &self,
         out: &mut impl std::fmt::Write,

--- a/src/util/heap/vmrequest.rs
+++ b/src/util/heap/vmrequest.rs
@@ -12,7 +12,7 @@ pub enum VMRequest {
 
 impl VMRequest {
     pub fn is_discontiguous(&self) -> bool {
-        matches!(self, VMRequest::Discontiguous { .. })
+        matches!(self, VMRequest::Discontiguous)
     }
 
     pub fn common64bit(top: bool) -> Self {

--- a/src/vm/active_plan.rs
+++ b/src/vm/active_plan.rs
@@ -48,7 +48,7 @@ pub trait ActivePlan<VM: VMBinding> {
     ///
     /// Arguments:
     /// * `queue`: The object queue. If an object is encountered for the first time in this GC, we expect the implementation to call `queue.enqueue()`
-    ///            for the object. If the object is moved during the tracing, the new object reference (after copying) should be enqueued instead.
+    ///   for the object. If the object is moved during the tracing, the new object reference (after copying) should be enqueued instead.
     /// * `object`: The object to trace.
     /// * `worker`: The GC worker that is doing this tracing. This is used to copy object (see [`crate::vm::ObjectModel::copy`])
     fn vm_trace_object<Q: ObjectQueue>(


### PR DESCRIPTION
Fixed over-indented list items which may be interpreted by MarkDown processors as code blocks.

Removed an unnecessary struct pattern in the `matches!` macro.