### PR TITLE
Properly handle multiple plans in GITHUB-CI in CI scripts

### DIFF
--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -22,7 +22,7 @@ find ./src ./tests -type f -name "mock_test_*" | while read -r file; do
     # Get the required plans.
     # Some tests need to be run with multiple plans because
     # some bugs can only be reproduced in some plans but not others.
-    PLANS=$(sed -n 's/^\/\/ *GITHUB-CI: *MMTK_PLAN=//p' $file)
+    PLANS=$(sed -n 's/^\/\/ *GITHUB-CI: *MMTK_PLAN=//p' $file | tr ',' '\n')
     if [[ $PLANS == 'all' ]]; then
         PLANS=$ALL_PLANS
     elif [[ -z $PLANS ]]; then

--- a/src/vm/tests/mock_tests/mock_test_doc_mutator_storage.rs
+++ b/src/vm/tests/mock_tests/mock_test_doc_mutator_storage.rs
@@ -1,4 +1,5 @@
-// GITHUB-CI: MMTK_PLAN=NoGC,SemiSpace,Immix,GenImmix,StickyImmix
+// GITHUB-CI: MMTK_PLAN=NoGC,SemiSpace,GenImmix
+// The test assumes the default allocator is a bump pointer allocator, thus only works for plans that use BumpAlloator (not ImmixAllocator or other allocators).
 
 use super::mock_test_prelude::*;
 


### PR DESCRIPTION
The PR fixes an issue in our CI script. We sometimes want to run a test with multiple plans, such as `GITHUB-CI: MMTK_PLAN=NoGC,SemiSpace`. The CI script does not parse `MMTK_PLAN`, and It instead just set the entire string as the env var (`MMTK_PLAN=NoGC,SemiSpace`). This results in an invalid value for `MMTK_PLAN`, and the default plan is used.