### PR TITLE
Allow configuring each Immix space to be non moving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,11 +152,6 @@ object_pinning = []
 # Disable any object copying in Immix. This makes Immix a non-moving policy.
 immix_non_moving = []
 
-# Disable any object copying in nursery GC for Sticky Immix while allowing other kinds of copying.
-# `immix_non_moving` disables all kinds of copying in Immix, so this feature is not needed
-# if `immix_non_moving` is in use.
-sticky_immix_non_moving_nursery = []
-
 # Turn on stress copying for Immix. This is a debug feature to test copying for Immix plans.
 immix_stress_copying = []
 # Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,11 @@ object_pinning = []
 # Disable any object copying in Immix. This makes Immix a non-moving policy.
 immix_non_moving = []
 
+# Disable any object copying in nursery GC for Sticky Immix while allowing other kinds of copying.
+# `immix_non_moving` disables all kinds of copying in Immix, so this feature is not needed
+# if `immix_non_moving` is in use.
+sticky_immix_non_moving_nursery = []
+
 # Turn on stress copying for Immix. This is a debug feature to test copying for Immix plans.
 immix_stress_copying = []
 # Reduce block size for ImmixSpace.  This mitigates fragmentation when defrag is disabled.

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -87,9 +87,9 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
 
     fn last_collection_was_exhaustive(&self) -> bool {
         self.last_gc_was_full_heap.load(Ordering::Relaxed)
-            && ImmixSpace::<VM>::is_last_gc_exhaustive(
-                self.last_gc_was_defrag.load(Ordering::Relaxed),
-            )
+            && self
+                .immix_space
+                .is_last_gc_exhaustive(self.last_gc_was_defrag.load(Ordering::Relaxed))
     }
 
     fn collection_required(&self, space_full: bool, space: Option<SpaceStats<Self::VM>>) -> bool
@@ -254,6 +254,7 @@ impl<VM: VMBinding> GenImmix<VM> {
                 // In GenImmix, young objects are not allocated in ImmixSpace directly.
                 #[cfg(feature = "vo_bit")]
                 mixed_age: false,
+                never_move_objects: cfg!(feature = "immix_non_moving"),
             },
         );
 

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -254,7 +254,7 @@ impl<VM: VMBinding> GenImmix<VM> {
                 // In GenImmix, young objects are not allocated in ImmixSpace directly.
                 #[cfg(feature = "vo_bit")]
                 mixed_age: false,
-                never_move_objects: cfg!(feature = "immix_non_moving"),
+                never_move_objects: false,
             },
         );
 

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -140,7 +140,7 @@ impl<VM: VMBinding> Immix<VM> {
                 unlog_object_when_traced: false,
                 #[cfg(feature = "vo_bit")]
                 mixed_age: false,
-                never_move_objects: cfg!(feature = "immix_non_moving"),
+                never_move_objects: false,
             },
         )
     }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -38,7 +38,7 @@ pub struct Immix<VM: VMBinding> {
 
 /// The plan constraints for the immix plan.
 pub const IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
-    moves_objects: crate::policy::immix::DEFRAG,
+    moves_objects: true,
     // Max immix object size is half of a block.
     max_non_los_default_alloc_bytes: crate::policy::immix::MAX_IMMIX_OBJECT_SIZE,
     needs_prepare_mutator: false,
@@ -51,7 +51,8 @@ impl<VM: VMBinding> Plan for Immix<VM> {
     }
 
     fn last_collection_was_exhaustive(&self) -> bool {
-        ImmixSpace::<VM>::is_last_gc_exhaustive(self.last_gc_was_defrag.load(Ordering::Relaxed))
+        self.immix_space
+            .is_last_gc_exhaustive(self.last_gc_was_defrag.load(Ordering::Relaxed))
     }
 
     fn constraints(&self) -> &'static PlanConstraints {
@@ -139,6 +140,7 @@ impl<VM: VMBinding> Immix<VM> {
                 unlog_object_when_traced: false,
                 #[cfg(feature = "vo_bit")]
                 mixed_age: false,
+                never_move_objects: cfg!(feature = "immix_non_moving"),
             },
         )
     }

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -38,7 +38,8 @@ pub struct Immix<VM: VMBinding> {
 
 /// The plan constraints for the immix plan.
 pub const IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
-    moves_objects: true,
+    // If we disable moving in Immix, this is a non-moving plan.
+    moves_objects: !cfg!(feature = "immix_non_moving"),
     // Max immix object size is half of a block.
     max_non_los_default_alloc_bytes: crate::policy::immix::MAX_IMMIX_OBJECT_SIZE,
     needs_prepare_mutator: false,

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -40,7 +40,8 @@ pub struct StickyImmix<VM: VMBinding> {
 
 /// The plan constraints for the sticky immix plan.
 pub const STICKY_IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
-    moves_objects: true,
+    // If we disable moving in Immix, this is a non-moving plan.
+    moves_objects: !cfg!(feature = "immix_non_moving"),
     needs_log_bit: true,
     barrier: crate::plan::BarrierSelector::ObjectBarrier,
     // We may trace duplicate edges in sticky immix (or any plan that uses object remembering barrier). See https://github.com/mmtk/mmtk-core/issues/743.

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -7,7 +7,6 @@ use crate::plan::PlanConstraints;
 use crate::policy::gc_work::TraceKind;
 use crate::policy::gc_work::TRACE_KIND_TRANSITIVE_PIN;
 use crate::policy::immix::ImmixSpace;
-use crate::policy::immix::PREFER_COPY_ON_NURSERY_GC;
 use crate::policy::immix::TRACE_KIND_FAST;
 use crate::policy::sft::SFT;
 use crate::policy::space::Space;
@@ -41,7 +40,7 @@ pub struct StickyImmix<VM: VMBinding> {
 
 /// The plan constraints for the sticky immix plan.
 pub const STICKY_IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
-    moves_objects: crate::policy::immix::DEFRAG || crate::policy::immix::PREFER_COPY_ON_NURSERY_GC,
+    moves_objects: true,
     needs_log_bit: true,
     barrier: crate::plan::BarrierSelector::ObjectBarrier,
     // We may trace duplicate edges in sticky immix (or any plan that uses object remembering barrier). See https://github.com/mmtk/mmtk-core/issues/743.
@@ -164,7 +163,7 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
 
     fn current_gc_may_move_object(&self) -> bool {
         if self.is_current_gc_nursery() {
-            PREFER_COPY_ON_NURSERY_GC
+            self.get_immix_space().prefer_copy_on_nursery_gc()
         } else {
             self.get_immix_space().in_defrag()
         }
@@ -263,7 +262,7 @@ impl<VM: VMBinding> crate::plan::generational::global::GenerationalPlanExt<VM> f
                     self.immix
                         .immix_space
                         .trace_object_without_moving(queue, object)
-                } else if crate::policy::immix::PREFER_COPY_ON_NURSERY_GC {
+                } else if self.immix.immix_space.is_nursery_copy_enabled() {
                     let ret = self.immix.immix_space.trace_object_with_opportunistic_copy(
                         queue,
                         object,
@@ -330,6 +329,7 @@ impl<VM: VMBinding> StickyImmix<VM> {
                 // In StickyImmix, both young and old objects are allocated in the ImmixSpace.
                 #[cfg(feature = "vo_bit")]
                 mixed_age: true,
+                never_move_objects: cfg!(feature = "immix_non_moving"),
             },
         );
         Self {

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -329,7 +329,7 @@ impl<VM: VMBinding> StickyImmix<VM> {
                 // In StickyImmix, both young and old objects are allocated in the ImmixSpace.
                 #[cfg(feature = "vo_bit")]
                 mixed_age: true,
-                never_move_objects: cfg!(feature = "immix_non_moving"),
+                never_move_objects: false,
             },
         );
         Self {

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -262,7 +262,7 @@ impl<VM: VMBinding> crate::plan::generational::global::GenerationalPlanExt<VM> f
                     self.immix
                         .immix_space
                         .trace_object_without_moving(queue, object)
-                } else if self.immix.immix_space.is_nursery_copy_enabled() {
+                } else if self.immix.immix_space.prefer_copy_on_nursery_gc() {
                     let ret = self.immix.immix_space.trace_object_with_opportunistic_copy(
                         queue,
                         object,

--- a/src/policy/immix/defrag.rs
+++ b/src/policy/immix/defrag.rs
@@ -63,8 +63,10 @@ impl Defrag {
     }
 
     /// Determine whether the current GC should do defragmentation.
+    #[allow(clippy::too_many_arguments)]
     pub fn decide_whether_to_defrag(
         &self,
+        defrag_enabled: bool,
         emergency_collection: bool,
         collect_whole_heap: bool,
         collection_attempts: usize,
@@ -72,11 +74,12 @@ impl Defrag {
         exhausted_reusable_space: bool,
         full_heap_system_gc: bool,
     ) {
-        let in_defrag = emergency_collection
-            || (collection_attempts > 1)
-            || !exhausted_reusable_space
-            || super::STRESS_DEFRAG
-            || (collect_whole_heap && user_triggered && full_heap_system_gc);
+        let in_defrag = defrag_enabled
+            && (emergency_collection
+                || (collection_attempts > 1)
+                || !exhausted_reusable_space
+                || super::STRESS_DEFRAG
+                || (collect_whole_heap && user_triggered && full_heap_system_gc));
         info!("Defrag: {}", in_defrag);
         probe!(mmtk, immix_defrag, in_defrag);
         self.in_defrag_collection

--- a/src/policy/immix/defrag.rs
+++ b/src/policy/immix/defrag.rs
@@ -72,12 +72,11 @@ impl Defrag {
         exhausted_reusable_space: bool,
         full_heap_system_gc: bool,
     ) {
-        let in_defrag = super::DEFRAG
-            && (emergency_collection
-                || (collection_attempts > 1)
-                || !exhausted_reusable_space
-                || super::STRESS_DEFRAG
-                || (collect_whole_heap && user_triggered && full_heap_system_gc));
+        let in_defrag = emergency_collection
+            || (collection_attempts > 1)
+            || !exhausted_reusable_space
+            || super::STRESS_DEFRAG
+            || (collect_whole_heap && user_triggered && full_heap_system_gc);
         info!("Defrag: {}", in_defrag);
         probe!(mmtk, immix_defrag, in_defrag);
         self.in_defrag_collection
@@ -116,9 +115,8 @@ impl Defrag {
     }
 
     /// Prepare work. Should be called in ImmixSpace::prepare.
-    #[allow(clippy::assertions_on_constants)]
     pub fn prepare<VM: VMBinding>(&self, space: &ImmixSpace<VM>, plan_stats: StatsForDefrag) {
-        debug_assert!(super::DEFRAG);
+        debug_assert!(space.is_defrag_enabled());
         self.defrag_space_exhausted.store(false, Ordering::Release);
 
         // Calculate available free space for defragmentation.
@@ -207,9 +205,7 @@ impl Defrag {
     }
 
     /// Reset the in-defrag state.
-    #[allow(clippy::assertions_on_constants)]
     pub fn reset_in_defrag(&self) {
-        debug_assert!(super::DEFRAG);
         self.in_defrag_collection.store(false, Ordering::Release);
     }
 }

--- a/src/policy/immix/mod.rs
+++ b/src/policy/immix/mod.rs
@@ -14,9 +14,6 @@ pub const MAX_IMMIX_OBJECT_SIZE: usize = Block::BYTES >> 1;
 /// Mark/sweep memory for block-level only
 pub const BLOCK_ONLY: bool = false;
 
-/// Do we allow Immix to do defragmentation?
-pub const DEFRAG: bool = !cfg!(feature = "immix_non_moving"); // defrag if we are allowed to move.
-
 // STRESS COPYING: Set the feature 'immix_stress_copying' so that Immix will copy as many objects as possible.
 // Useful for debugging copying GC if you cannot use SemiSpace.
 //
@@ -46,28 +43,6 @@ pub const DEFRAG_HEADROOM_PERCENT: usize = if cfg!(feature = "immix_stress_copyi
     2
 };
 
-/// If Immix is used as a nursery space, do we prefer copy?
-pub const PREFER_COPY_ON_NURSERY_GC: bool =
-    !cfg!(feature = "immix_non_moving") && !cfg!(feature = "sticky_immix_non_moving_nursery"); // copy nursery objects if we are allowed to move.
-
-/// In some cases/settings, Immix may never move objects.
-/// Currently we only have two cases where we move objects: 1. defrag, 2. nursery copy.
-/// If we do neither, we will not move objects.
-/// If we have other reasons to move objects, we need to add them here.
-pub const NEVER_MOVE_OBJECTS: bool = !DEFRAG && !PREFER_COPY_ON_NURSERY_GC;
-
 /// Mark lines when scanning objects.
 /// Otherwise, do it at mark time.
 pub const MARK_LINE_AT_SCAN_TIME: bool = true;
-
-macro_rules! validate {
-    ($x: expr) => { assert!($x, stringify!($x)) };
-    ($x: expr => $y: expr) => { if $x { assert!($y, stringify!($x implies $y)) } };
-}
-
-fn validate_features() {
-    // Block-only immix cannot do defragmentation
-    validate!(DEFRAG => !BLOCK_ONLY);
-    // Number of lines in a block should not exceed BlockState::MARK_MARKED
-    assert!(Block::LINES / 2 <= u8::MAX as usize - 2);
-}


### PR DESCRIPTION
We plan to use non-moving Immix as a non-moving space. In this case, we will have two Immix spaces, one allows moving, and the other does not. We currently use global constants to control whether Immix moves objects or not, and we cannot have two Immix spaces that are configured differently.

This PR removes those constants, and adds a flag `never_move_objects` in `ImmixSpaceArgs` to indicate whether this Immix space disallows moving. 