### PR TITLE
(Don't merge) Test binding test using OpenJDK 21

### DIFF
--- a/.github/workflows/pr-binding-refs.yml
+++ b/.github/workflows/pr-binding-refs.yml
@@ -121,8 +121,8 @@ jobs:
   binding-refs:
     runs-on: ubuntu-latest
     env:
-      OPENJDK_BINDING_REPO_DEFAULT: mmtk/mmtk-openjdk
-      OPENJDK_BINDING_REF_DEFAULT: master
+      OPENJDK_BINDING_REPO_DEFAULT: wks/mmtk-openjdk
+      OPENJDK_BINDING_REF_DEFAULT: fix/ci-jdk21
       JIKESRVM_BINDING_REPO_DEFAULT: mmtk/mmtk-jikesrvm
       JIKESRVM_BINDING_REF_DEFAULT: master
       V8_BINDING_REPO_DEFAULT: mmtk/mmtk-v8


### PR DESCRIPTION
This PR is for checking if the CI script for binding tests work for OpenJDK 21.

When we are ready for OpenJDK 21, we will update the `master` branch of the https://github.com/mmtk/mmtk-openjdk repo so that we don't need change on the mmtk-core side.