### PR TITLE
Fix `CopySpace::is_live`

### DIFF
--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -30,7 +30,11 @@ impl<VM: VMBinding> SFT for CopySpace<VM> {
     }
 
     fn is_live(&self, object: ObjectReference) -> bool {
-        !self.is_from_space() || object_forwarding::is_forwarded::<VM>(object)
+        if !self.is_from_space() {
+            object.to_raw_address() < self.pr.cursor()
+        } else {
+            object_forwarding::is_forwarded::<VM>(object)
+        }
     }
 
     #[cfg(feature = "object_pinning")]


### PR DESCRIPTION
This commit fixes the `CopySpace::is_live` function to check if a to-space object's address is actually below the current page resource cursor. By definition, a to-space object cannot be live if it is beyond the cursor.