### PR TITLE
Move `inside_harness` to `GlobalState`

### DIFF
--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -42,6 +42,8 @@ pub struct GlobalState {
     pub(crate) stacks_prepared: AtomicBool,
     /// A counter that keeps tracks of the number of bytes allocated since last stress test
     pub(crate) allocation_bytes: AtomicUsize,
+    /// Are we inside the benchmark harness?
+    pub(crate) inside_harness: AtomicBool,
     /// A counteer that keeps tracks of the number of bytes allocated by malloc
     #[cfg(feature = "malloc_counted_size")]
     pub(crate) malloc_bytes: AtomicUsize,
@@ -200,6 +202,7 @@ impl Default for GlobalState {
             cur_collection_attempts: AtomicUsize::new(0),
             scanned_stacks: AtomicUsize::new(0),
             allocation_bytes: AtomicUsize::new(0),
+            inside_harness: AtomicBool::new(false),
             #[cfg(feature = "malloc_counted_size")]
             malloc_bytes: AtomicUsize::new(0),
             live_bytes_in_last_gc: AtomicRefCell::new(HashMap::new()),

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -29,7 +29,7 @@ use crate::vm::VMBinding;
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::default::Default;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -123,7 +123,6 @@ pub struct MMTK<VM: VMBinding> {
     pub(crate) gc_trigger: Arc<GCTrigger<VM>>,
     pub(crate) gc_requester: Arc<GCRequester<VM>>,
     pub(crate) stats: Arc<Stats>,
-    inside_harness: AtomicBool,
     #[cfg(feature = "sanity")]
     inside_sanity: AtomicBool,
     /// Analysis counters. The feature analysis allows us to periodically stop the world and collect some statistics.
@@ -220,7 +219,6 @@ impl<VM: VMBinding> MMTK<VM> {
             sanity_checker: Mutex::new(SanityChecker::new()),
             #[cfg(feature = "sanity")]
             inside_sanity: AtomicBool::new(false),
-            inside_harness: AtomicBool::new(false),
             #[cfg(feature = "extreme_assertions")]
             slot_logger: SlotLogger::new(),
             #[cfg(feature = "analysis")]
@@ -324,7 +322,7 @@ impl<VM: VMBinding> MMTK<VM> {
     pub fn harness_begin(&self, tls: VMMutatorThread) {
         probe!(mmtk, harness_begin);
         self.handle_user_collection_request(tls, true, true);
-        self.inside_harness.store(true, Ordering::SeqCst);
+        self.state.inside_harness.store(true, Ordering::SeqCst);
         self.stats.start_all();
         self.scheduler.enable_stat();
     }
@@ -334,7 +332,7 @@ impl<VM: VMBinding> MMTK<VM> {
     /// This is usually called by the benchmark harness right after the actual benchmark.
     pub fn harness_end(&'static self) {
         self.stats.stop_all(self);
-        self.inside_harness.store(false, Ordering::SeqCst);
+        self.state.inside_harness.store(false, Ordering::SeqCst);
         probe!(mmtk, harness_end);
     }
 

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -29,7 +29,7 @@ use crate::vm::VMBinding;
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::default::Default;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -29,7 +29,7 @@ use crate::vm::VMBinding;
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::default::Default;
-#[cfg(feature = "sanity")];
+#[cfg(feature = "sanity")]
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -29,7 +29,9 @@ use crate::vm::VMBinding;
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::default::Default;
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "sanity")];
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 


### PR DESCRIPTION
This can be useful in case we want to be able to measure timing in parts of the code where we don't have access to the `MMTK` struct.