### PR TITLE
Use EnumMap::from_fn

### DIFF
--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -11,7 +11,6 @@ use crate::global_state::GcStatus;
 use crate::mmtk::MMTK;
 use crate::util::opaque_pointer::*;
 use crate::util::options::AffinityKind;
-use crate::util::rust_util::array_from_fn;
 use crate::vm::Collection;
 use crate::vm::VMBinding;
 use crate::Plan;
@@ -43,12 +42,10 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         let worker_group = WorkerGroup::new(num_workers);
 
         // Create work buckets for workers.
-        // TODO: Replace `array_from_fn` with `std::array::from_fn` after bumping MSRV.
-        let mut work_buckets = EnumMap::from_array(array_from_fn(|stage_num| {
-            let stage = WorkBucketStage::from_usize(stage_num);
+        let mut work_buckets = EnumMap::from_fn(|stage| {
             let active = stage == WorkBucketStage::Unconstrained;
             WorkBucket::new(active, worker_monitor.clone())
-        }));
+        });
 
         // Set the open condition of each bucket.
         {

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -105,29 +105,6 @@ impl<T> std::ops::Deref for InitializeOnce<T> {
 
 unsafe impl<T> Sync for InitializeOnce<T> {}
 
-/// This implements `std::array::from_fn` introduced in Rust 1.63.
-/// We should replace this with the standard counterpart after bumping MSRV,
-/// but we also need to evaluate whether it would use too much stack space (see code comments).
-pub(crate) fn array_from_fn<T, const N: usize, F>(mut cb: F) -> [T; N]
-where
-    F: FnMut(usize) -> T,
-{
-    // Note on unsafety: An alternative to the unsafe implementation below is creating a fixed
-    // array of `[0, 1, 2, ..., N-1]` and using the `.map(cb)` method to create the result.
-    // However, the `array::map` method implemented in the standard library consumes a surprisingly
-    // large amount of stack space.  For VMs that run on confined stacks, such as JikesRVM, that
-    // would cause stack overflow.  Therefore we implement it manually using unsafe primitives.
-    let mut result_array: MaybeUninit<[T; N]> = MaybeUninit::zeroed();
-    let array_ptr = result_array.as_mut_ptr();
-    for index in 0..N {
-        let item = cb(index);
-        unsafe {
-            std::ptr::addr_of_mut!((*array_ptr)[index]).write(item);
-        }
-    }
-    unsafe { result_array.assume_init() }
-}
-
 /// Create a formatted string that makes the best effort idenfying the current process and thread.
 pub fn debug_process_thread_id() -> String {
     let pid = unsafe { libc::getpid() };


### PR DESCRIPTION
The `enum-map` crate introduced `EnumMap::from_fn` in 2.7.0.  We use that instead of constructing an array and then calling `EnumMap::from_array`.  We also remove the utility function `rust_util::array_from_fn` because it is no longer needed.

Related issue: https://github.com/mmtk/mmtk-core/issues/921