### PR TITLE
Bump Ruby binding test image to 24.04

### DIFF
--- a/.github/workflows/extended-tests-bindings.yml
+++ b/.github/workflows/extended-tests-bindings.yml
@@ -154,6 +154,8 @@ jobs:
           ./.github/scripts/ci-style.sh
 
   extended-tests-ruby:
+    # Note: CRuby requires an existing installation of CRuby 3.1.0 or newer to build itself.
+    # Ubuntu 22.04 only provides CRuby 3.0.  We need 24.04 or newer.
     runs-on: ubuntu-24.04
     needs: binding-refs
     if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')

--- a/.github/workflows/extended-tests-bindings.yml
+++ b/.github/workflows/extended-tests-bindings.yml
@@ -154,7 +154,7 @@ jobs:
           ./.github/scripts/ci-style.sh
 
   extended-tests-ruby:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: binding-refs
     if: contains(github.event.pull_request.labels.*.name, 'PR-extended-testing')
     strategy:


### PR DESCRIPTION
CRuby now requires an existing CRuby 3.1.0 installation to build itself, but Ubuntu 22.04 only provides CRuby 3.0.  We upgrade to 24.04.