### PR TITLE
Make scan_non_zero_values_fast scan entirely forwards

### DIFF
--- a/src/util/metadata/side_metadata/global.rs
+++ b/src/util/metadata/side_metadata/global.rs
@@ -1234,7 +1234,7 @@ impl SideMetadataSpec {
             start_meta_shift,
             end_meta_addr,
             end_meta_shift,
-            false,
+            true,
             &mut visitor,
         );
     }


### PR DESCRIPTION
Presently the `forwards` argument to `ranges::break_bit_range` is false, causing the function to scan the last bits, then the middle bytes, then the first bits. The argument should be true, so that the function scans the first bits first.