### PR TITLE
Move lint config to Cargo.toml. Adapt to Rust 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,9 @@ idna_adapter = "=1.1.0"
 # not worth it.
 upper_case_acronyms = "allow"
 # Temporarily allow this -- 9 July 2025. Clippy suggests that we should always inline format args if possible.
-# We see pushbacks on this in Rust 1.67, and the lint was downgraded to pedantic in 1.67.1. It was upgraded
+# We see pushbacks on this lint in Rust 1.67, and the lint was downgraded to pedantic in 1.67.1. It was upgraded
 # again in Rust 1.88. We temporarily disable this lint and see the reaction from the community.
-# If this was no pushback for this lint in a few momnths' time, we should remove the following line and migrate the codebase.
+# If there is no pushback for this lint in a few momnths' time, we should remove the following line and migrate the codebase.
 # See https://github.com/mmtk/mmtk-core/issues/1334.
 uninlined_format_args = "allow"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ cfg-if = "1.0"
 crossbeam = "0.8.1"
 delegate = "0.13.2"
 downcast-rs = "2.0.1"
-enum-map = "2.4.2"
+enum-map = "2.7.3"
 env_logger = { version = "0.11.3", optional = true }
 is-terminal = "0.4.7"
 itertools = "0.14.0"
@@ -76,6 +76,23 @@ built = { version = "0.7.7", features = ["git2"] }
 # But we don't need ICU4X (or even `url`) because we only use `git2` to get the Git commit hash.
 # We move away from ICU4X completely following the instruction in https://docs.rs/crate/idna_adapter/1.2.0
 idna_adapter = "=1.1.0"
+
+[lints.clippy]
+# Allow this. Clippy suggests we should use Sft, Mmtk, rather than SFT and MMTK.
+# According to its documentation (https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms),
+# with upper-case-acronyms-aggressive turned on, it should also warn us about SFTMap, VMBinding, GCWorker.
+# However, it seems clippy does not catch all these patterns at the moment. So it would be hard for us to
+# find all the patterns and consistently change all of them. I think it would be a better idea to just allow this.
+# We may reconsider this in the future. Plus, using upper case letters for acronyms does not sound a big issue
+# to me - considering it will break our API and all the efforts for all the developers to make the change, it may
+# not worth it.
+upper_case_acronyms = "allow"
+# Temporarily allow this -- 9 July 2025. Clippy suggests that we should always inline format args if possible.
+# We see pushbacks on this in Rust 1.67, and the lint was downgraded to pedantic in 1.67.1. It was upgraded
+# again in Rust 1.88. We temporarily disable this lint and see the reaction from the community.
+# If this was no pushback for this lint in a few momnths' time, we should remove the following line and migrate the codebase.
+# See https://github.com/mmtk/mmtk-core/issues/1334.
+uninlined_format_args = "allow"
 
 [[bench]]
 name = "main"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,3 @@
-// Allow this for now. Clippy suggests we should use Sft, Mmtk, rather than SFT and MMTK.
-// According to its documentation (https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms),
-// with upper-case-acronyms-aggressive turned on, it should also warn us about SFTMap, VMBinding, GCWorker.
-// However, it seems clippy does not catch all these patterns at the moment. So it would be hard for us to
-// find all the patterns and consistently change all of them. I think it would be a better idea to just allow this.
-// We may reconsider this in the future. Plus, using upper case letters for acronyms does not sound a big issue
-// to me - considering it will break our API and all the efforts for all the developers to make the change, it may
-// not worth it.
-#![allow(clippy::upper_case_acronyms)]
 // Use the `{likely, unlikely}` provided by compiler when using nightly
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -265,6 +265,9 @@ impl Map32 {
         &mut *self.inner.get()
     }
 
+    /// Get a mutable reference to the inner Map32Inner with a lock.
+    /// The caller should only use the mutable reference while holding the lock.
+    #[allow(clippy::mut_from_ref)]
     fn mut_self_with_sync(&self) -> (MutexGuard<()>, &mut Map32Inner) {
         let guard = self.sync.lock().unwrap();
         (guard, unsafe { self.mut_self() })


### PR DESCRIPTION
This PR fixes issues for Rust 1.88 style check.
* Move lint configurations to Cargo.toml from `lib.rs` (Lint configs in `Cargo.toml` is effective for the `bench` source code, but `lib.rs` does not effect `bench`)
* Disable `uninlined_format_args`.
* Allow one more case of `mut_from_ref`, identified by clippy.
* Set `enum-map` to `2.7.3` (We use `EnumMap::from_fn`. [`2.7.3`](https://docs.rs/enum-map/latest/enum_map/struct.EnumMap.html#method.from_fn) has this function, but [`2.6.3`](https://docs.rs/enum-map/2.6.3/enum_map/struct.EnumMap.html#) does not have this function)