### PR TITLE
Add MultiLevelMapper

### DIFF
--- a/src/util/heap/layout/mod.rs
+++ b/src/util/heap/layout/mod.rs
@@ -6,6 +6,7 @@ pub use self::mmapper::Mmapper;
 mod byte_map_mmapper;
 #[cfg(target_pointer_width = "64")]
 mod fragmented_mapper;
+mod multi_level_mapper;
 
 mod map;
 pub(crate) use self::map::CreateFreeListResult;
@@ -37,7 +38,8 @@ pub fn create_mmapper() -> Box<dyn Mmapper + Send + Sync> {
 #[cfg(target_pointer_width = "64")]
 pub fn create_mmapper() -> Box<dyn Mmapper + Send + Sync> {
     // TODO: ByteMapMmapper for 39-bit or less virtual space
-    Box::new(fragmented_mapper::FragmentedMapper::new())
+    // Box::new(fragmented_mapper::FragmentedMapper::new())
+    Box::new(multi_level_mapper::MultiLevelMapper::new())
 }
 
 use crate::util::Address;

--- a/src/util/heap/layout/multi_level_mapper.rs
+++ b/src/util/heap/layout/multi_level_mapper.rs
@@ -1,0 +1,503 @@
+use super::mmapper::MapState;
+use super::Mmapper;
+use crate::util::constants::BYTES_IN_PAGE;
+use crate::util::conversions;
+use crate::util::heap::layout::vm_layout::*;
+use crate::util::memory::{MmapAnnotation, MmapStrategy};
+use crate::util::rust_util::atomic_box::OnceOptionBox;
+use crate::util::Address;
+use atomic::{Atomic, Ordering};
+use std::fmt;
+use std::io::Result;
+use std::sync::Mutex;
+
+/// Logarithm of the address space size a user-space program is allowed to use.
+/// This is the address space size of x86_64 and some other architectures,
+/// although we don't usually have this much physical memory.
+const LOG_MAPPABLE_BYTES: usize = 48;
+/// Address space size a user-space program is allowed to use.
+const MAPPABLE_BYTES: usize = 1 << LOG_MAPPABLE_BYTES;
+
+/// Log number of bytes per slab.
+/// For a two-level array, it is advisable to choose the arithmetic mean of [`LOG_MAPPABLE_BYTES`]
+/// and [`LOG_MMAP_CHUNK_BYTES`] in order to make [`MMAP_SLAB_BYTES`] the geometric mean of
+/// [`MAPPABLE_BYTES`] and [`MMAP_CHUNK_BYTES`].  This will balance the array size of
+/// [`MultiLevelMapper::slabs`] and [`Slab`].
+///
+/// TODO: Use `usize::midpoint` after bumping MSRV to 1.85
+const LOG_MMAP_SLAB_BYTES: usize = LOG_MMAP_CHUNK_BYTES + (LOG_MAPPABLE_BYTES - LOG_MMAP_CHUNK_BYTES) / 2;
+/// Number of bytes per slab.
+const MMAP_SLAB_BYTES: usize = 1 << LOG_MMAP_SLAB_BYTES;
+
+/// Log number of chunks per slab.
+const LOG_MMAP_CHUNKS_PER_SLAB: usize = LOG_MMAP_SLAB_BYTES - LOG_MMAP_CHUNK_BYTES;
+/// Number of chunks per slab.
+const MMAP_CHUNKS_PER_SLAB: usize = 1 << LOG_MMAP_CHUNKS_PER_SLAB;
+
+/// Mask for getting in-slab bits from an address.
+/// Invert this to get out-of-slab bits.
+const MMAP_SLAB_MASK: usize = (1 << LOG_MMAP_SLAB_BYTES) - 1;
+
+/// Logarithm of maximum number of slabs, which determines the maximum mappable address space.
+const LOG_MAX_SLABS: usize = LOG_MAPPABLE_BYTES - LOG_MMAP_SLAB_BYTES;
+/// maximum number of slabs, which determines the maximum mappable address space.
+const MAX_SLABS: usize = 1 << LOG_MAX_SLABS;
+
+/// The slab type.  Each slab holds the `MapState` of multiple chunks.
+type Slab = [Atomic<MapState>; 1 << LOG_MMAP_CHUNKS_PER_SLAB];
+
+/// A multi-level implementation of `Mmapper`.
+pub struct MultiLevelMapper {
+    /// Lock for transitioning map states.
+    ///
+    /// FIXME: We only needs the lock when transitioning map states.
+    /// The `MultiLevelMapper` itself is completely lock-free even when allocating new slabs.
+    /// We should move the lock one leve above, to `MapState`.
+    transition_lock: Mutex<()>,
+    /// Slabs
+    slabs: Vec<OnceOptionBox<Slab>>,
+}
+
+unsafe impl Send for MultiLevelMapper {}
+unsafe impl Sync for MultiLevelMapper {}
+
+impl fmt::Debug for MultiLevelMapper {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MultiLevelMapper({})", 1 << LOG_MAX_SLABS)
+    }
+}
+
+impl Mmapper for MultiLevelMapper {
+    fn eagerly_mmap_all_spaces(&self, _space_map: &[Address]) {}
+
+    fn mark_as_mapped(&self, mut start: Address, bytes: usize) {
+        let end = start + bytes;
+        // Iterate over the slabs covered
+        while start < end {
+            let high = if end > Self::slab_limit(start) && !Self::slab_limit(start).is_zero() {
+                Self::slab_limit(start)
+            } else {
+                end
+            };
+            let slab = Self::slab_align_down(start);
+            let start_chunk = Self::chunk_index(slab, start);
+            let end_chunk = Self::chunk_index(slab, conversions::mmap_chunk_align_up(high));
+
+            let mapped = self.get_or_allocate_slab_table(start);
+            for entry in mapped.iter().take(end_chunk).skip(start_chunk) {
+                entry.store(MapState::Mapped, Ordering::Relaxed);
+            }
+            start = high;
+        }
+    }
+
+    fn quarantine_address_range(
+        &self,
+        mut start: Address,
+        pages: usize,
+        strategy: MmapStrategy,
+        anno: &MmapAnnotation,
+    ) -> Result<()> {
+        debug_assert!(start.is_aligned_to(BYTES_IN_PAGE));
+
+        let end = start + conversions::pages_to_bytes(pages);
+
+        // Each `MapState` entry governs a chunk.
+        // Align down to the chunk start because we only mmap multiples of whole chunks.
+        let mmap_start = conversions::mmap_chunk_align_down(start);
+
+        // We collect the chunk states from slabs to process them in bulk.
+        let mut state_slices = vec![];
+
+        // Iterate over the slabs covered
+        while start < end {
+            let high = if end > Self::slab_limit(start) && !Self::slab_limit(start).is_zero() {
+                Self::slab_limit(start)
+            } else {
+                end
+            };
+
+            let slab = Self::slab_align_down(start);
+            let start_chunk = Self::chunk_index(slab, start);
+            let end_chunk = Self::chunk_index(slab, conversions::mmap_chunk_align_up(high));
+
+            let mapped = self.get_or_allocate_slab_table(start);
+            state_slices.push(&mapped[start_chunk..end_chunk]);
+
+            start = high;
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            // Check if the number of entries are normal.
+            let mmap_end = conversions::mmap_chunk_align_up(end);
+            let num_slices = state_slices.iter().map(|s| s.len()).sum::<usize>();
+
+            debug_assert_eq!(mmap_start + BYTES_IN_CHUNK * num_slices, mmap_end);
+        }
+
+        // Transition the chunks in bulk.
+        {
+            let _guard = self.transition_lock.lock().unwrap();
+            MapState::bulk_transition_to_quarantined(
+                state_slices.as_slice(),
+                mmap_start,
+                strategy,
+                anno,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn ensure_mapped(
+        &self,
+        mut start: Address,
+        pages: usize,
+        strategy: MmapStrategy,
+        anno: &MmapAnnotation,
+    ) -> Result<()> {
+        let end = start + conversions::pages_to_bytes(pages);
+        // Iterate over the slabs covered
+        while start < end {
+            let base = Self::slab_align_down(start);
+            let high = if end > Self::slab_limit(start) && !Self::slab_limit(start).is_zero() {
+                Self::slab_limit(start)
+            } else {
+                end
+            };
+
+            let slab = Self::slab_align_down(start);
+            let start_chunk = Self::chunk_index(slab, start);
+            let end_chunk = Self::chunk_index(slab, conversions::mmap_chunk_align_up(high));
+
+            let mapped = self.get_or_allocate_slab_table(start);
+
+            /* Iterate over the chunks within the slab */
+            for (chunk, entry) in mapped.iter().enumerate().take(end_chunk).skip(start_chunk) {
+                if matches!(entry.load(Ordering::Relaxed), MapState::Mapped) {
+                    continue;
+                }
+
+                let mmap_start = Self::chunk_index_to_address(base, chunk);
+                let _guard = self.transition_lock.lock().unwrap();
+                MapState::transition_to_mapped(entry, mmap_start, strategy, anno)?;
+            }
+            start = high;
+        }
+        Ok(())
+    }
+
+    /**
+     * Return {@code true} if the given address has been mmapped
+     *
+     * @param addr The address in question.
+     * @return {@code true} if the given address has been mmapped
+     */
+    fn is_mapped_address(&self, addr: Address) -> bool {
+        let mapped = self.slab_table(addr);
+        match mapped {
+            Some(mapped) => {
+                mapped[Self::chunk_index(Self::slab_align_down(addr), addr)].load(Ordering::Relaxed)
+                    == MapState::Mapped
+            }
+            _ => false,
+        }
+    }
+
+    fn protect(&self, mut start: Address, pages: usize) {
+        let end = start + conversions::pages_to_bytes(pages);
+        let _guard = self.transition_lock.lock().unwrap();
+        // Iterate over the slabs covered
+        while start < end {
+            let base = Self::slab_align_down(start);
+            let high = if end > Self::slab_limit(start) && !Self::slab_limit(start).is_zero() {
+                Self::slab_limit(start)
+            } else {
+                end
+            };
+
+            let slab = Self::slab_align_down(start);
+            let start_chunk = Self::chunk_index(slab, start);
+            let end_chunk = Self::chunk_index(slab, conversions::mmap_chunk_align_up(high));
+
+            let mapped = self.get_or_allocate_slab_table(start);
+
+            for (chunk, entry) in mapped.iter().enumerate().take(end_chunk).skip(start_chunk) {
+                let mmap_start = Self::chunk_index_to_address(base, chunk);
+                MapState::transition_to_protected(entry, mmap_start).unwrap();
+            }
+            start = high;
+        }
+    }
+}
+
+impl MultiLevelMapper {
+    pub fn new() -> Self {
+        Self {
+            transition_lock: Default::default(),
+            slabs: unsafe { crate::util::rust_util::zeroed_alloc::new_zeroed_vec(MAX_SLABS) },
+        }
+    }
+
+    fn new_slab() -> Slab {
+        std::array::from_fn(|_| Atomic::new(MapState::Unmapped))
+    }
+
+    fn slab_table(&self, addr: Address) -> Option<&Slab> {
+        self.get_or_optionally_allocate_slab_table(addr, false)
+    }
+
+    fn get_or_allocate_slab_table(&self, addr: Address) -> &Slab {
+        self.get_or_optionally_allocate_slab_table(addr, true)
+            .unwrap()
+    }
+
+    fn get_or_optionally_allocate_slab_table(
+        &self,
+        addr: Address,
+        allocate: bool,
+    ) -> Option<&Slab> {
+        let index = addr >> LOG_MMAP_SLAB_BYTES;
+        if index > self.slabs.len() {
+            panic!("addr: {addr}, index: {index}, slabs.len: {sl}", sl = self.slabs.len());
+        }
+        let slot = &self.slabs[index];
+        if allocate {
+            slot.get_or_init(Ordering::Acquire, Ordering::Release, Self::new_slab)
+        } else {
+            slot.get(Ordering::Acquire)
+        }
+    }
+
+    fn chunk_index_to_address(base: Address, chunk: usize) -> Address {
+        base + (chunk << LOG_MMAP_CHUNK_BYTES)
+    }
+
+    /// Align `addr` down to slab size.
+    fn slab_align_down(addr: Address) -> Address {
+        addr.align_down(MMAP_SLAB_BYTES)
+    }
+
+    /// Get the base address of the next slab after the slab that contains `addr`.
+    fn slab_limit(addr: Address) -> Address {
+        Self::slab_align_down(addr) + MMAP_SLAB_BYTES
+    }
+
+    /// Return the index of the chunk that contains `addr` within the slab starting at `slab`
+    /// If `addr` is beyond the end of the slab, the result could be beyond the end of the slab.
+    fn chunk_index(slab: Address, addr: Address) -> usize {
+        let delta = addr - slab;
+        delta >> LOG_MMAP_CHUNK_BYTES
+    }
+}
+
+impl Default for MultiLevelMapper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mmap_anno_test;
+    use crate::util::constants::LOG_BYTES_IN_PAGE;
+    use crate::util::heap::layout::vm_layout::MMAP_CHUNK_BYTES;
+    use crate::util::memory;
+    use crate::util::test_util::FRAGMENTED_MMAPPER_TEST_REGION;
+    use crate::util::test_util::{serial_test, with_cleanup};
+    use crate::util::{conversions, Address};
+
+    const FIXED_ADDRESS: Address = FRAGMENTED_MMAPPER_TEST_REGION.start;
+    const MAX_BYTES: usize = FRAGMENTED_MMAPPER_TEST_REGION.size;
+
+    fn pages_to_chunks_up(pages: usize) -> usize {
+        conversions::raw_align_up(pages, MMAP_CHUNK_BYTES) / MMAP_CHUNK_BYTES
+    }
+
+    fn get_chunk_map_state(mmapper: &MultiLevelMapper, chunk: Address) -> Option<MapState> {
+        assert_eq!(conversions::mmap_chunk_align_up(chunk), chunk);
+        let mapped = mmapper.slab_table(chunk);
+        mapped.map(|m| {
+            m[MultiLevelMapper::chunk_index(MultiLevelMapper::slab_align_down(chunk), chunk)]
+                .load(Ordering::Relaxed)
+        })
+    }
+
+    #[test]
+    fn ensure_mapped_1page() {
+        serial_test(|| {
+            let pages = 1;
+            with_cleanup(
+                || {
+                    let mmapper = MultiLevelMapper::new();
+                    mmapper
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST, mmap_anno_test!())
+                        .unwrap();
+
+                    let chunks = pages_to_chunks_up(pages);
+                    for i in 0..chunks {
+                        assert_eq!(
+                            get_chunk_map_state(
+                                &mmapper,
+                                FIXED_ADDRESS + (i << LOG_BYTES_IN_CHUNK)
+                            ),
+                            Some(MapState::Mapped)
+                        );
+                    }
+                },
+                || {
+                    memory::munmap(FIXED_ADDRESS, MAX_BYTES).unwrap();
+                },
+            )
+        })
+    }
+    #[test]
+    fn ensure_mapped_1chunk() {
+        serial_test(|| {
+            let pages = MMAP_CHUNK_BYTES >> LOG_BYTES_IN_PAGE as usize;
+            with_cleanup(
+                || {
+                    let mmapper = MultiLevelMapper::new();
+                    mmapper
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST, mmap_anno_test!())
+                        .unwrap();
+
+                    let chunks = pages_to_chunks_up(pages);
+                    for i in 0..chunks {
+                        assert_eq!(
+                            get_chunk_map_state(
+                                &mmapper,
+                                FIXED_ADDRESS + (i << LOG_BYTES_IN_CHUNK)
+                            ),
+                            Some(MapState::Mapped)
+                        );
+                    }
+                },
+                || {
+                    memory::munmap(FIXED_ADDRESS, MAX_BYTES).unwrap();
+                },
+            )
+        })
+    }
+
+    #[test]
+    fn ensure_mapped_more_than_1chunk() {
+        serial_test(|| {
+            let pages = (MMAP_CHUNK_BYTES + MMAP_CHUNK_BYTES / 2) >> LOG_BYTES_IN_PAGE as usize;
+            with_cleanup(
+                || {
+                    let mmapper = MultiLevelMapper::new();
+                    mmapper
+                        .ensure_mapped(FIXED_ADDRESS, pages, MmapStrategy::TEST, mmap_anno_test!())
+                        .unwrap();
+
+                    let chunks = pages_to_chunks_up(pages);
+                    for i in 0..chunks {
+                        assert_eq!(
+                            get_chunk_map_state(
+                                &mmapper,
+                                FIXED_ADDRESS + (i << LOG_BYTES_IN_CHUNK)
+                            ),
+                            Some(MapState::Mapped)
+                        );
+                    }
+                },
+                || {
+                    memory::munmap(FIXED_ADDRESS, MAX_BYTES).unwrap();
+                },
+            )
+        })
+    }
+
+    #[test]
+    fn protect() {
+        serial_test(|| {
+            with_cleanup(
+                || {
+                    // map 2 chunks
+                    let mmapper = MultiLevelMapper::new();
+                    let pages_per_chunk = MMAP_CHUNK_BYTES >> LOG_BYTES_IN_PAGE as usize;
+                    mmapper
+                        .ensure_mapped(
+                            FIXED_ADDRESS,
+                            pages_per_chunk * 2,
+                            MmapStrategy::TEST,
+                            mmap_anno_test!(),
+                        )
+                        .unwrap();
+
+                    // protect 1 chunk
+                    mmapper.protect(FIXED_ADDRESS, pages_per_chunk);
+
+                    assert_eq!(
+                        get_chunk_map_state(&mmapper, FIXED_ADDRESS),
+                        Some(MapState::Protected)
+                    );
+                    assert_eq!(
+                        get_chunk_map_state(&mmapper, FIXED_ADDRESS + MMAP_CHUNK_BYTES),
+                        Some(MapState::Mapped)
+                    );
+                },
+                || {
+                    memory::munmap(FIXED_ADDRESS, MAX_BYTES).unwrap();
+                },
+            )
+        })
+    }
+
+    #[test]
+    fn ensure_mapped_on_protected_chunks() {
+        serial_test(|| {
+            with_cleanup(
+                || {
+                    // map 2 chunks
+                    let mmapper = MultiLevelMapper::new();
+                    let pages_per_chunk = MMAP_CHUNK_BYTES >> LOG_BYTES_IN_PAGE as usize;
+                    mmapper
+                        .ensure_mapped(
+                            FIXED_ADDRESS,
+                            pages_per_chunk * 2,
+                            MmapStrategy::TEST,
+                            mmap_anno_test!(),
+                        )
+                        .unwrap();
+
+                    // protect 1 chunk
+                    mmapper.protect(FIXED_ADDRESS, pages_per_chunk);
+
+                    assert_eq!(
+                        get_chunk_map_state(&mmapper, FIXED_ADDRESS),
+                        Some(MapState::Protected)
+                    );
+                    assert_eq!(
+                        get_chunk_map_state(&mmapper, FIXED_ADDRESS + MMAP_CHUNK_BYTES),
+                        Some(MapState::Mapped)
+                    );
+
+                    // ensure mapped - this will unprotect the previously protected chunk
+                    mmapper
+                        .ensure_mapped(
+                            FIXED_ADDRESS,
+                            pages_per_chunk * 2,
+                            MmapStrategy::TEST,
+                            mmap_anno_test!(),
+                        )
+                        .unwrap();
+                    assert_eq!(
+                        get_chunk_map_state(&mmapper, FIXED_ADDRESS),
+                        Some(MapState::Mapped)
+                    );
+                    assert_eq!(
+                        get_chunk_map_state(&mmapper, FIXED_ADDRESS + MMAP_CHUNK_BYTES),
+                        Some(MapState::Mapped)
+                    );
+                },
+                || {
+                    memory::munmap(FIXED_ADDRESS, MAX_BYTES).unwrap();
+                },
+            )
+        })
+    }
+}

--- a/src/util/rust_util/atomic_box.rs
+++ b/src/util/rust_util/atomic_box.rs
@@ -1,0 +1,48 @@
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+/// A lazily initialized box.  Similar to an `Option<Box<T>>`, but can be initialized atomically.
+pub struct OnceOptionBox<T> {
+    inner: AtomicPtr<T>,
+}
+
+impl<T> OnceOptionBox<T> {
+    pub fn new() -> OnceOptionBox<T> {
+        Self {
+            inner: AtomicPtr::new(std::ptr::null_mut()),
+        }
+    }
+
+    pub fn get(&self, order: Ordering) -> Option<&T> {
+        let ptr = self.inner.load(order);
+        unsafe { ptr.as_ref() }
+    }
+
+    pub fn get_or_init(
+        &self,
+        order_load: Ordering,
+        order_store: Ordering,
+        init: impl FnOnce() -> T,
+    ) -> Option<&T> {
+        if let Some(get_result) = self.get(order_load) {
+            return Some(get_result);
+        }
+
+        let new_inner = Box::into_raw(Box::new(init()));
+        let cas_result = self.inner.compare_exchange(
+            std::ptr::null_mut(),
+            new_inner,
+            order_store,
+            Ordering::Relaxed,
+        );
+        match cas_result {
+            Ok(old_inner) => {
+                debug_assert_eq!(old_inner, std::ptr::null_mut());
+                unsafe { new_inner.as_ref() }
+            }
+            Err(old_inner) => {
+                drop(unsafe { Box::from_raw(new_inner) });
+                unsafe { old_inner.as_ref() }
+            }
+        }
+    }
+}

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -2,6 +2,7 @@
 //! functionalities that we may expect the Rust programming language and its standard libraries
 //! to provide.
 
+pub mod atomic_box;
 pub mod rev_group;
 pub mod zeroed_alloc;
 


### PR DESCRIPTION
**DRAFT**:
-   [ ] Needs more correctness testing
-   [ ] Needs performance evaluation

This is a replacement for `FragmentedMapper`.  It does not use hash tables and is lock-free when looking up or lazily initializing the slabs table.  It is intended to eliminate the pathological case of `FragmentedMapper` where a hash collision can result in many locking operations to find the matching or vacant slab table entry.

Fixes: https://github.com/mmtk/mmtk-core/issues/1336