### PR TITLE
Add a stop-the-world, serial Compressor

### DIFF
--- a/src/plan/compressor/gc_work.rs
+++ b/src/plan/compressor/gc_work.rs
@@ -1,0 +1,114 @@
+use super::global::Compressor;
+use crate::policy::compressor::CompressorSpace;
+use crate::policy::compressor::{TRACE_KIND_FORWARD, TRACE_KIND_MARK};
+use crate::scheduler::gc_work::PlanProcessEdges;
+use crate::scheduler::gc_work::*;
+use crate::scheduler::GCWork;
+use crate::scheduler::GCWorker;
+use crate::scheduler::WorkBucketStage;
+use crate::vm::ActivePlan;
+use crate::vm::Scanning;
+use crate::vm::VMBinding;
+use crate::MMTK;
+use std::marker::PhantomData;
+
+/// iterate through the heap and calculate the new location of live objects
+pub struct CalculateForwardingAddress<VM: VMBinding> {
+    compressor_space: &'static CompressorSpace<VM>,
+}
+
+impl<VM: VMBinding> GCWork<VM> for CalculateForwardingAddress<VM> {
+    fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
+        self.compressor_space.calculate_offset_vector();
+    }
+}
+
+impl<VM: VMBinding> CalculateForwardingAddress<VM> {
+    pub fn new(compressor_space: &'static CompressorSpace<VM>) -> Self {
+        Self { compressor_space }
+    }
+}
+
+/// create another round of root scanning work packets
+/// to update object references
+pub struct UpdateReferences<VM: VMBinding> {
+    plan: *const Compressor<VM>,
+    p: PhantomData<VM>,
+}
+
+unsafe impl<VM: VMBinding> Send for UpdateReferences<VM> {}
+
+impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
+    fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
+        // The following needs to be done right before the second round of root scanning
+        VM::VMScanning::prepare_for_roots_re_scanning();
+        mmtk.state.prepare_for_stack_scanning();
+        // Prepare common and base spaces for the 2nd round of transitive closure
+        let plan_mut = unsafe { &mut *(self.plan as *mut Compressor<VM>) };
+        plan_mut.common.release(worker.tls, true);
+        plan_mut.common.prepare(worker.tls, true);
+        #[cfg(feature = "extreme_assertions")]
+        mmtk.slot_logger.reset();
+
+        // We do two passes of transitive closures. We clear the live bytes from the first pass.
+        mmtk.scheduler
+            .worker_group
+            .get_and_clear_worker_live_bytes();
+
+        for mutator in VM::VMActivePlan::mutators() {
+            mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots].add(ScanMutatorRoots::<
+                CompressorForwardingWorkContext<VM>,
+            >(mutator));
+        }
+
+        mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
+            .add(ScanVMSpecificRoots::<CompressorForwardingWorkContext<VM>>::new());
+    }
+}
+
+impl<VM: VMBinding> UpdateReferences<VM> {
+    pub fn new(plan: &Compressor<VM>) -> Self {
+        Self {
+            plan,
+            p: PhantomData,
+        }
+    }
+}
+
+/// compact live objects based on forwarding pointers calculated before
+pub struct Compact<VM: VMBinding> {
+    compressor_space: &'static CompressorSpace<VM>,
+}
+
+impl<VM: VMBinding> GCWork<VM> for Compact<VM> {
+    fn do_work(&mut self, worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
+        self.compressor_space.compact(worker);
+    }
+}
+
+impl<VM: VMBinding> Compact<VM> {
+    pub fn new(compressor_space: &'static CompressorSpace<VM>) -> Self {
+        Self { compressor_space }
+    }
+}
+
+/// Marking trace
+pub type MarkingProcessEdges<VM> = PlanProcessEdges<VM, Compressor<VM>, TRACE_KIND_MARK>;
+/// Forwarding trace
+pub type ForwardingProcessEdges<VM> = PlanProcessEdges<VM, Compressor<VM>, TRACE_KIND_FORWARD>;
+
+pub struct CompressorWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::scheduler::GCWorkContext for CompressorWorkContext<VM> {
+    type VM = VM;
+    type PlanType = Compressor<VM>;
+    type DefaultProcessEdges = MarkingProcessEdges<VM>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
+}
+
+pub struct CompressorForwardingWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::scheduler::GCWorkContext for CompressorForwardingWorkContext<VM> {
+    type VM = VM;
+    type PlanType = Compressor<VM>;
+    type DefaultProcessEdges = ForwardingProcessEdges<VM>;
+    type PinningProcessEdges = UnsupportedProcessEdges<VM>;
+}

--- a/src/plan/compressor/global.rs
+++ b/src/plan/compressor/global.rs
@@ -1,0 +1,196 @@
+use super::gc_work::CompressorWorkContext;
+use super::gc_work::{
+    CalculateForwardingAddress,
+    ForwardingProcessEdges,
+    MarkingProcessEdges,
+    Compact,
+    UpdateReferences
+};
+use crate::plan::global::{BasePlan, CommonPlan};
+use crate::plan::global::CreateGeneralPlanArgs;
+use crate::plan::global::CreateSpecificPlanArgs;
+use crate::plan::compressor::mutator::ALLOCATOR_MAPPING;
+use crate::plan::AllocationSemantics;
+use crate::plan::Plan;
+use crate::plan::PlanConstraints;
+use crate::policy::compressor::CompressorSpace;
+use crate::policy::space::Space;
+use crate::scheduler::gc_work::*;
+use crate::scheduler::GCWorkScheduler;
+use crate::scheduler::WorkBucketStage;
+use crate::util::alloc::allocators::AllocatorSelector;
+use crate::util::heap::gc_trigger::SpaceStats;
+#[allow(unused_imports)]
+use crate::util::heap::VMRequest;
+use crate::util::metadata::side_metadata::SideMetadataContext;
+use crate::util::opaque_pointer::*;
+use crate::vm::VMBinding;
+use enum_map::EnumMap;
+use mmtk_macros::{HasSpaces, PlanTraceObject};
+
+#[derive(HasSpaces, PlanTraceObject)]
+pub struct Compressor<VM: VMBinding> {
+    #[parent]
+    pub common: CommonPlan<VM>,
+    #[space]
+    pub compressor_space: CompressorSpace<VM>,
+}
+
+/// The plan constraints for the no gc plan.
+pub const COMPRESSOR_CONSTRAINTS: PlanConstraints = PlanConstraints {
+    moves_objects: true,
+    needs_forward_after_liveness: true,
+    ..PlanConstraints::default()
+};
+
+impl<VM: VMBinding> Plan for Compressor<VM> {
+    fn constraints(&self) -> &'static PlanConstraints {
+        &COMPRESSOR_CONSTRAINTS
+    }
+    
+    fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
+        self.base().collection_required(self, space_full)
+    }
+    
+    fn common(&self) -> &CommonPlan<VM> {
+        &self.common
+    }
+    
+    fn base(&self) -> &BasePlan<VM> {
+        &self.common.base
+    }
+    
+    fn base_mut(&mut self) -> &mut BasePlan<Self::VM> {
+        &mut self.common.base
+    }
+
+    fn prepare(&mut self, tls: VMWorkerThread) {
+        self.common.prepare(tls, true);
+        self.compressor_space.prepare();
+    }
+
+    fn release(&mut self, tls: VMWorkerThread) {
+        self.common.release(tls, true);
+        self.compressor_space.release();
+    }
+
+    fn end_of_gc(&mut self, tls: VMWorkerThread) {
+        self.common.end_of_gc(tls);
+    }
+
+    fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
+        &ALLOCATOR_MAPPING
+    }
+
+    fn schedule_collection(&'static self, scheduler: &GCWorkScheduler<VM>) {
+        // TODO use schedule_common once it can work with the Compressor
+        // The main issue there is that we need to ForwardingProcessEdges
+        // in FinalizableForwarding.
+        
+        // Stop & scan mutators (mutator scanning can happen before STW)
+        scheduler.work_buckets[WorkBucketStage::Unconstrained]
+            .add(StopMutators::<CompressorWorkContext<VM>>::new());
+
+        // Prepare global/collectors/mutators
+        scheduler.work_buckets[WorkBucketStage::Prepare]
+            .add(Prepare::<CompressorWorkContext<VM>>::new(self));
+
+        scheduler.work_buckets[WorkBucketStage::CalculateForwarding]
+            .add(CalculateForwardingAddress::<VM>::new(&self.compressor_space));
+        // do another trace to update references
+        scheduler.work_buckets[WorkBucketStage::SecondRoots].add(UpdateReferences::<VM>::new(self));
+        scheduler.work_buckets[WorkBucketStage::Compact].add(Compact::<VM>::new(&self.compressor_space));
+
+        // Release global/collectors/mutators
+        scheduler.work_buckets[WorkBucketStage::Release]
+            .add(Release::<CompressorWorkContext<VM>>::new(self));
+
+        // Reference processing
+        if !*self.base().options.no_reference_types {
+            use crate::util::reference_processor::{
+                PhantomRefProcessing, SoftRefProcessing, WeakRefProcessing,
+            };
+            scheduler.work_buckets[WorkBucketStage::SoftRefClosure]
+                .add(SoftRefProcessing::<MarkingProcessEdges<VM>>::new());
+            scheduler.work_buckets[WorkBucketStage::WeakRefClosure]
+                .add(WeakRefProcessing::<VM>::new());
+            scheduler.work_buckets[WorkBucketStage::PhantomRefClosure]
+                .add(PhantomRefProcessing::<VM>::new());
+
+            use crate::util::reference_processor::RefForwarding;
+            scheduler.work_buckets[WorkBucketStage::RefForwarding]
+                .add(RefForwarding::<ForwardingProcessEdges<VM>>::new());
+
+            use crate::util::reference_processor::RefEnqueue;
+            scheduler.work_buckets[WorkBucketStage::Release].add(RefEnqueue::<VM>::new());
+        }
+
+        // Finalization
+        if !*self.base().options.no_finalizer {
+            use crate::util::finalizable_processor::{Finalization, ForwardFinalization};
+            // finalization
+            // treat finalizable objects as roots and perform a closure (marking)
+            // must be done before calculating forwarding pointers
+            scheduler.work_buckets[WorkBucketStage::FinalRefClosure]
+                .add(Finalization::<MarkingProcessEdges<VM>>::new());
+            // update finalizable object references
+            // must be done before compacting
+            scheduler.work_buckets[WorkBucketStage::FinalizableForwarding]
+                .add(ForwardFinalization::<ForwardingProcessEdges<VM>>::new());
+        }
+
+        // VM-specific weak ref processing
+        scheduler.work_buckets[WorkBucketStage::VMRefClosure]
+            .set_sentinel(Box::new(VMProcessWeakRefs::<MarkingProcessEdges<VM>>::new()));
+
+        // VM-specific weak ref forwarding
+        scheduler.work_buckets[WorkBucketStage::VMRefForwarding]
+            .add(VMForwardWeakRefs::<ForwardingProcessEdges<VM>>::new());
+
+        // VM-specific work after forwarding, possible to implement ref enququing.
+        scheduler.work_buckets[WorkBucketStage::Release].add(VMPostForwarding::<VM>::default());
+
+        // Analysis GC work
+        #[cfg(feature = "analysis")]
+        {
+            use crate::util::analysis::GcHookWork;
+            scheduler.work_buckets[WorkBucketStage::Unconstrained].add(GcHookWork);
+        }
+        #[cfg(feature = "sanity")]
+        scheduler.work_buckets[WorkBucketStage::Final]
+            .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new(self));
+    }
+
+    fn current_gc_may_move_object(&self) -> bool {
+        true
+    }
+
+    fn get_used_pages(&self) -> usize {
+        self.compressor_space.reserved_pages()
+            + self.common.get_used_pages()
+    }
+}
+
+impl<VM: VMBinding> Compressor<VM> {
+    pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
+        let mut plan_args = CreateSpecificPlanArgs {
+            global_args: args,
+            constraints: &COMPRESSOR_CONSTRAINTS,
+            global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
+        };
+
+        let res = Compressor {
+            compressor_space: CompressorSpace::new(plan_args.get_space_args(
+                "compressor_space",
+                true,
+                false,
+                VMRequest::discontiguous(),
+            )),
+            common: CommonPlan::new(plan_args),
+        };
+
+        res.verify_side_metadata_sanity();
+
+        res
+    }
+}

--- a/src/plan/compressor/mod.rs
+++ b/src/plan/compressor/mod.rs
@@ -1,0 +1,5 @@
+pub(super) mod gc_work;
+pub(super) mod global;
+pub(super) mod mutator;
+
+pub use self::global::Compressor;

--- a/src/plan/compressor/mutator.rs
+++ b/src/plan/compressor/mutator.rs
@@ -1,0 +1,60 @@
+use crate::plan::mutator_context::common_prepare_func;
+use crate::plan::mutator_context::Mutator;
+use crate::plan::mutator_context::MutatorBuilder;
+use crate::plan::mutator_context::MutatorConfig;
+use crate::plan::mutator_context::{
+    create_space_mapping, ReservedAllocators,
+};
+use crate::plan::compressor::Compressor;
+use crate::plan::AllocationSemantics;
+use crate::util::alloc::BumpAllocator;
+use crate::util::alloc::allocators::AllocatorSelector;
+use crate::util::{VMMutatorThread, VMWorkerThread};
+use crate::vm::VMBinding;
+use crate::MMTK;
+use enum_map::{enum_map, EnumMap};
+
+const RESERVED_ALLOCATORS: ReservedAllocators = ReservedAllocators {
+    n_bump_pointer: 1,
+    ..ReservedAllocators::DEFAULT
+};
+
+lazy_static! {
+    pub static ref ALLOCATOR_MAPPING: EnumMap<AllocationSemantics, AllocatorSelector> = enum_map! {
+        _ => AllocatorSelector::BumpPointer(0),
+    };
+}
+
+pub fn create_compressor_mutator<VM: VMBinding>(
+    mutator_tls: VMMutatorThread,
+    mmtk: &'static MMTK<VM>,
+) -> Mutator<VM> {
+    let plan = mmtk.get_plan().downcast_ref::<Compressor<VM>>().unwrap();
+    let config = MutatorConfig {
+        allocator_mapping: &ALLOCATOR_MAPPING,
+        space_mapping: Box::new({
+            let mut vec = create_space_mapping(RESERVED_ALLOCATORS, false, plan);
+            vec.push((AllocatorSelector::BumpPointer(0), &plan.compressor_space));
+            vec
+        }),
+        prepare_func: &common_prepare_func,
+        release_func: &compressor_mutator_release,
+    };
+
+    let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
+    builder.build()
+}
+
+pub fn compressor_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, _tls: VMWorkerThread) {
+    // reset the thread-local allocation bump pointer
+    let bump_allocator = unsafe {
+        mutator
+            .allocators
+            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+    }
+    .downcast_mut::<BumpAllocator<VM>>()
+    .unwrap();
+    bump_allocator.reset();
+    // This doesn't do anything sensible.
+    //common_release_func(mutator, _tls);
+}

--- a/src/plan/compressor/mutator.rs
+++ b/src/plan/compressor/mutator.rs
@@ -1,14 +1,12 @@
+use crate::plan::compressor::Compressor;
 use crate::plan::mutator_context::common_prepare_func;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorBuilder;
 use crate::plan::mutator_context::MutatorConfig;
-use crate::plan::mutator_context::{
-    create_space_mapping, ReservedAllocators,
-};
-use crate::plan::compressor::Compressor;
+use crate::plan::mutator_context::{create_space_mapping, ReservedAllocators};
 use crate::plan::AllocationSemantics;
-use crate::util::alloc::BumpAllocator;
 use crate::util::alloc::allocators::AllocatorSelector;
+use crate::util::alloc::BumpAllocator;
 use crate::util::{VMMutatorThread, VMWorkerThread};
 use crate::vm::VMBinding;
 use crate::MMTK;

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -58,6 +58,9 @@ pub fn create_mutator<VM: VMBinding>(
         PlanSelector::StickyImmix => {
             crate::plan::sticky::immix::mutator::create_stickyimmix_mutator(tls, mmtk)
         }
+        PlanSelector::Compressor => {
+            crate::plan::compressor::mutator::create_compressor_mutator(tls, mmtk)
+        }
     })
 }
 
@@ -90,6 +93,9 @@ pub fn create_plan<VM: VMBinding>(
         }
         PlanSelector::StickyImmix => {
             Box::new(crate::plan::sticky::immix::StickyImmix::new(args)) as Box<dyn Plan<VM = VM>>
+        }
+        PlanSelector::Compressor => {
+            Box::new(crate::plan::compressor::Compressor::new(args)) as Box<dyn Plan<VM = VM>>
         }
     };
 

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -44,6 +44,7 @@ mod generational;
 /// Sticky plans (using sticky marks for generational behaviors without a copying nursery)
 mod sticky;
 
+mod compressor;
 mod immix;
 mod markcompact;
 mod marksweep;

--- a/src/policy/compressor/compressorspace.rs
+++ b/src/policy/compressor/compressorspace.rs
@@ -1,0 +1,362 @@
+use crate::plan::VectorObjectQueue;
+use crate::policy::sft::SFT;
+use crate::policy::space::{CommonSpace, Space};
+use crate::policy::compressor::forwarding::ForwardingMetadata;
+use crate::policy::gc_work::{TraceKind, TRACE_KIND_TRANSITIVE_PIN};
+use crate::policy::sft::GCWorkerMutRef;
+use crate::scheduler::GCWorker;
+use crate::util::constants::{BYTES_IN_PAGE, LOG_MIN_OBJECT_SIZE};
+use crate::util::copy::CopySemantics;
+use crate::util::heap::{MonotonePageResource, PageResource};
+use crate::util::metadata::MetadataSpec;
+use crate::util::metadata::extract_side_metadata;
+#[cfg(feature = "vo_bit")]
+use crate::util::metadata::vo_bit;
+use crate::util::metadata::side_metadata::SideMetadataSpec;
+use crate::util::object_enum::{self, ObjectEnumerator};
+use crate::util::{Address, ObjectReference};
+use crate::{vm::*, ObjectQueue};
+use crate::vm::slot::Slot;
+use atomic::Ordering;
+
+pub(crate) const TRACE_KIND_MARK: TraceKind = 0;
+pub(crate) const TRACE_KIND_FORWARD: TraceKind = 1;
+
+pub struct CompressorSpace<VM: VMBinding> {
+    common: CommonSpace<VM>,
+    pr: MonotonePageResource<VM>,
+    mark_bit_spec: SideMetadataSpec,
+    forwarding: ForwardingMetadata<VM>,
+}
+
+pub(crate) const GC_MARK_BIT_MASK: u8 = 1;
+
+impl<VM: VMBinding> SFT for CompressorSpace<VM> {
+    fn name(&self) -> &'static str {
+        self.get_name()
+    }
+
+    fn get_forwarded_object(&self, object: ObjectReference) -> Option<ObjectReference> {
+        Some(self.forward(object, false))
+    }
+
+    fn is_live(&self, object: ObjectReference) -> bool {
+        Self::is_marked(object)
+    }
+
+    #[cfg(feature = "object_pinning")]
+    fn pin_object(&self, _object: ObjectReference) -> bool {
+        panic!("Cannot pin/unpin objects of CompressorSpace.")
+    }
+
+    #[cfg(feature = "object_pinning")]
+    fn unpin_object(&self, _object: ObjectReference) -> bool {
+        panic!("Cannot pin/unpin objects of CompressorSpace.")
+    }
+
+    #[cfg(feature = "object_pinning")]
+    fn is_object_pinned(&self, _object: ObjectReference) -> bool {
+        false
+    }
+
+    fn is_movable(&self) -> bool {
+        true
+    }
+
+    fn initialize_object_metadata(&self, _object: ObjectReference, _alloc: bool) {
+        #[cfg(feature = "vo_bit")]
+        crate::util::metadata::vo_bit::set_vo_bit(_object);
+    }
+
+    #[cfg(feature = "sanity")]
+    fn is_sane(&self) -> bool {
+        true
+    }
+
+    #[cfg(feature = "is_mmtk_object")]
+    fn is_mmtk_object(&self, addr: Address) -> Option<ObjectReference> {
+        crate::util::metadata::vo_bit::is_vo_bit_set_for_addr(addr)
+    }
+
+    #[cfg(feature = "is_mmtk_object")]
+    fn find_object_from_internal_pointer(
+        &self,
+        ptr: Address,
+        max_search_bytes: usize,
+    ) -> Option<ObjectReference> {
+        crate::util::metadata::vo_bit::find_object_from_internal_pointer::<VM>(
+            ptr,
+            max_search_bytes,
+        )
+    }
+
+    fn sft_trace_object(
+        &self,
+        _queue: &mut VectorObjectQueue,
+        _object: ObjectReference,
+        _worker: GCWorkerMutRef,
+    ) -> ObjectReference {
+        // We should not use trace_object for compressor space.
+        // Depending on which trace it is, we should manually call either trace_mark or trace_forward.
+        panic!("sft_trace_object() cannot be used with Compressor space")
+    }
+
+    fn debug_print_object_info(&self, object: ObjectReference) {
+        println!("marked = {}", CompressorSpace::<VM>::is_marked(object));
+        self.common.debug_print_object_global_info(object);
+    }
+}
+
+impl<VM: VMBinding> Space<VM> for CompressorSpace<VM> {
+    fn as_space(&self) -> &dyn Space<VM> {
+        self
+    }
+
+    fn as_sft(&self) -> &(dyn SFT + Sync + 'static) {
+        self
+    }
+
+    fn get_page_resource(&self) -> &dyn PageResource<VM> {
+        &self.pr
+    }
+
+    fn maybe_get_page_resource_mut(&mut self) -> Option<&mut dyn PageResource<VM>> {
+        Some(&mut self.pr)
+    }
+
+    fn common(&self) -> &CommonSpace<VM> {
+        &self.common
+    }
+
+    fn initialize_sft(&self, sft_map: &mut dyn crate::policy::sft_map::SFTMap) {
+        self.common().initialize_sft(self.as_sft(), sft_map)
+    }
+
+    fn release_multiple_pages(&mut self, _start: Address) {
+        panic!("compressorspace only releases pages enmasse")
+    }
+
+    fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
+        object_enum::enumerate_blocks_from_monotonic_page_resource(enumerator, &self.pr);
+    }
+}
+
+impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for CompressorSpace<VM> {
+    fn trace_object<Q: ObjectQueue, const KIND: crate::policy::gc_work::TraceKind>(
+        &self,
+        queue: &mut Q,
+        object: ObjectReference,
+        _copy: Option<CopySemantics>,
+        _worker: &mut GCWorker<VM>,
+    ) -> ObjectReference {
+        debug_assert!(
+            KIND != TRACE_KIND_TRANSITIVE_PIN,
+            "Compressor does not support transitive pin trace."
+        );
+        if KIND == TRACE_KIND_MARK {
+            self.trace_mark_object(queue, object)
+        } else if KIND == TRACE_KIND_FORWARD {
+            self.trace_forward_object(queue, object)
+        } else {
+            unreachable!()
+        }
+    }
+    fn may_move_objects<const KIND: crate::policy::gc_work::TraceKind>() -> bool {
+        if KIND == TRACE_KIND_MARK {
+            false
+        } else if KIND == TRACE_KIND_FORWARD {
+            true
+        }else {
+            unreachable!()
+        }
+    }
+}
+
+impl<VM: VMBinding> CompressorSpace<VM> {
+    pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
+        let vm_map = args.vm_map;
+        assert!(!args.vmrequest.is_discontiguous(), "The Compressor requires a contiguous heap");
+        let local_specs = extract_side_metadata(&[*VM::VMObjectModel::LOCAL_MARK_BIT_SPEC]);
+        let common = CommonSpace::new(args.into_policy_args(true, false, local_specs));
+        // Check that we really have a mark *bitmap*.
+        let MetadataSpec::OnSide(mark_bit_spec) = *VM::VMObjectModel::LOCAL_MARK_BIT_SPEC.as_spec() else {
+            panic!("The Compressor requires marks to be side metadata");
+        };
+        let SideMetadataSpec { log_num_of_bits, log_bytes_in_region, .. } = mark_bit_spec;
+        assert_eq!(log_num_of_bits, 0 as usize);
+        assert_eq!(log_bytes_in_region, LOG_MIN_OBJECT_SIZE as usize);
+        let trigger = common.gc_trigger.as_ref();
+        let size = trigger.policy.get_max_heap_size_in_pages() * BYTES_IN_PAGE;
+        
+        CompressorSpace {
+            pr: MonotonePageResource::new_contiguous(common.start, common.extent, vm_map),
+            forwarding: ForwardingMetadata::new(mark_bit_spec, common.start, size),
+            common,
+            mark_bit_spec,
+        }
+    }
+
+    pub fn prepare(&self) {
+        for (from_start, size) in self.pr.iterate_allocated_regions() {
+            self.mark_bit_spec.bzero_metadata(from_start, size);
+        }
+    }
+
+    pub fn release(&self) { self.forwarding.release(); }
+
+    pub fn trace_mark_object<Q: ObjectQueue>(
+        &self,
+        queue: &mut Q,
+        object: ObjectReference,
+    ) -> ObjectReference {
+        #[cfg(feature = "vo_bit")]
+        debug_assert!(
+            crate::util::metadata::vo_bit::is_vo_bit_set(object),
+            "{:x}: VO bit not set",
+            object
+        );
+        if CompressorSpace::<VM>::test_and_mark(object) {
+            queue.enqueue(object);
+            self.forwarding.mark_end_of_object(object);
+        }
+        object
+    }
+    
+    pub fn trace_forward_object<Q: ObjectQueue>(
+        &self,
+        _queue: &mut Q,
+        object: ObjectReference
+    ) -> ObjectReference {
+        self.forward(object, true)
+    }
+
+    pub fn test_and_mark(object: ObjectReference) -> bool {
+        loop {
+            let old_value = VM::VMObjectModel::LOCAL_MARK_BIT_SPEC.load_atomic::<VM, u8>(
+                object,
+                None,
+                Ordering::SeqCst,
+            );
+            let mark_bit = old_value & GC_MARK_BIT_MASK;
+            if mark_bit != 0 {
+                return false;
+            }
+            if VM::VMObjectModel::LOCAL_MARK_BIT_SPEC
+                .compare_exchange_metadata::<VM, u8>(
+                    object,
+                    old_value,
+                    1,
+                    None,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                )
+                .is_ok()
+            {
+                break;
+            }
+        }
+        true
+    }
+
+    pub fn is_marked(object: ObjectReference) -> bool {
+        let old_value = VM::VMObjectModel::LOCAL_MARK_BIT_SPEC.load_atomic::<VM, u8>(
+            object,
+            None,
+            Ordering::SeqCst,
+        );
+        let mark_bit = old_value & GC_MARK_BIT_MASK;
+        mark_bit != 0
+    }
+
+    pub fn calculate_offset_vector(&self) {
+        self.forwarding.calculate_offset_vector(&self.pr);
+    }
+    
+    pub fn forward(&self, object: ObjectReference, _vo_bit_valid: bool) -> ObjectReference {
+        // We can't expect the VO bit to be valid whilst in the compaction loop.
+        // If we are fixing a reference to an object which precedes the referent
+        // the VO bit will have been cleared already.
+        // Thus the assertion really only is any good whilst we are fixing
+        // the roots.
+        #[cfg(feature = "vo_bit")]
+        if _vo_bit_valid {
+            debug_assert!(
+                crate::util::metadata::vo_bit::is_vo_bit_set(object),
+                "{:x}: VO bit not set",
+                object
+            );
+        }
+        ObjectReference::from_raw_address(self.forwarding.forward(object.to_raw_address())).unwrap()
+    }
+
+    fn heap_span(&self) -> (Address, Address) {
+        (self.forwarding.first_address, self.pr.cursor())
+    }
+    
+    pub fn compact(&self, worker: &mut GCWorker<VM>) {
+        let mut to = Address::ZERO;
+        // The allocator will never cause an object to span multiple regions,
+        // but the Compressor may move an object to span multiple regions.
+        // Thus we must treat all regions as one contiguous space when
+        // walking the mark bitmap.
+        let (start, end) = self.heap_span();
+        #[cfg(feature = "vo_bit")]
+        {
+            #[cfg(debug_assertions)]
+            self.forwarding.scan_marked_objects(
+                start,
+                end,
+                &mut |object: ObjectReference| {
+                    debug_assert!(
+                        crate::util::metadata::vo_bit::is_vo_bit_set(object),
+                        "{:x}: VO bit not set",
+                        object
+                    );
+                }
+            );
+            for (region_start, size) in self.pr.iterate_allocated_regions() {
+                crate::util::metadata::vo_bit::bzero_vo_bit(region_start, size);
+            }
+        }
+        
+        self.forwarding.scan_marked_objects(
+            start,
+            end,
+            &mut |obj: ObjectReference| {
+                let copied_size = VM::VMObjectModel::get_size_when_copied(obj);
+                debug_assert!(copied_size == VM::VMObjectModel::get_current_size(obj));
+                let new_object = self.forward(obj, false);
+                debug_assert!(new_object.to_raw_address() >= to, "{0} < {to}", new_object.to_raw_address());
+                // copy object
+                trace!(" copy from {} to {}", obj, new_object);
+                let end_of_new_object =
+                    VM::VMObjectModel::copy_to(obj, new_object, Address::ZERO);
+                // update VO bit
+                #[cfg(feature = "vo_bit")]
+                vo_bit::set_vo_bit(new_object);
+                to = new_object.to_object_start::<VM>() + copied_size;
+                debug_assert_eq!(end_of_new_object, to);
+                // update references in object
+                if VM::VMScanning::support_slot_enqueuing(worker.tls, new_object) {
+                    VM::VMScanning::scan_object(
+                        worker.tls,
+                        new_object,
+                        &mut |s: VM::VMSlot|
+                        if let Some(o) = s.load() {
+                            s.store(self.forward(o, false));
+                        }
+                    );
+                } else {
+                    VM::VMScanning::scan_object_and_trace_edges(
+                        worker.tls,
+                        new_object,
+                        &mut |o| self.forward(o, false)
+                    );
+                }
+            }
+        );
+        debug!("Compact end: to = {}", to);
+        // reset the bump pointer
+        self.pr.reset_cursor(to);
+    }
+}

--- a/src/policy/compressor/compressorspace.rs
+++ b/src/policy/compressor/compressorspace.rs
@@ -22,6 +22,10 @@ use atomic::Ordering;
 pub(crate) const TRACE_KIND_MARK: TraceKind = 0;
 pub(crate) const TRACE_KIND_FORWARD: TraceKind = 1;
 
+/// CompressorSpace is a stop-the-world and serial implementation of
+/// the Compressor, as described in Kermany and Petrank
+/// "The Compressor: concurrent, incremental, and parallel compaction"
+/// https://dl.acm.org/doi/10.1145/1133255.1134023
 pub struct CompressorSpace<VM: VMBinding> {
     common: CommonSpace<VM>,
     pr: MonotonePageResource<VM>,
@@ -166,7 +170,7 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for Compressor
             false
         } else if KIND == TRACE_KIND_FORWARD {
             true
-        }else {
+        } else {
             unreachable!()
         }
     }

--- a/src/policy/compressor/forwarding.rs
+++ b/src/policy/compressor/forwarding.rs
@@ -1,0 +1,146 @@
+use crate::policy::compressor::GC_MARK_BIT_MASK;
+use crate::util::constants::MIN_OBJECT_SIZE;
+use crate::vm::VMBinding;
+use crate::vm::object_model::ObjectModel;
+use crate::util::{Address, ObjectReference};
+use crate::util::heap::MonotonePageResource;
+use crate::util::metadata::side_metadata::SideMetadataSpec;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::marker::PhantomData;
+use atomic::Ordering;
+
+/// A finite-state machine which processes the positions of mark bits,
+/// and accumulates the size of live data that it has seen.
+#[derive(Debug)]
+struct Transducer {
+    live: usize,
+    last_bit_seen: Address,
+    in_object: bool
+}
+impl Transducer {
+    pub fn new() -> Self {
+        Self {
+            live: 0,
+            last_bit_seen: Address::ZERO,
+            in_object: false
+        }
+    }
+    pub fn step(&mut self, address: Address) {
+        //println!("Address: {self:?} {address:?}");
+        if self.in_object {
+            self.live += address - self.last_bit_seen + (MIN_OBJECT_SIZE as usize);
+        }
+        self.in_object = !self.in_object;
+        self.last_bit_seen = address;
+    }
+    
+    pub fn encode(&self, address: Address) -> usize {
+        if self.in_object {
+            // We count the space between the last mark bit and
+            // the current address as live when we stop in the
+            // middle of an object.
+            self.live + (address - self.last_bit_seen) + 1
+        } else {
+            self.live
+        }
+    }
+    
+    pub fn decode(offset: usize, address: Address) -> Self {
+        Transducer {
+            live: offset & !1,
+            last_bit_seen: address,
+            in_object: (offset & 1) == 1
+        }
+    }
+}
+
+pub struct ForwardingMetadata<VM: VMBinding> {
+    mark_bit_spec: SideMetadataSpec,
+    pub(crate) first_address: Address,
+    calculated: AtomicBool,
+    block_offsets: Vec<AtomicUsize>,
+    vm: PhantomData<VM>
+}
+
+const BLOCK_SIZE: usize = 512;
+
+impl<VM: VMBinding> ForwardingMetadata<VM> {
+    pub fn new(mark_bit_spec: SideMetadataSpec, start: Address, size: usize) -> ForwardingMetadata<VM> {
+        let mut block_offsets = vec![];
+        let blocks = size / BLOCK_SIZE;
+        block_offsets.resize_with(blocks, || AtomicUsize::new(0));
+        ForwardingMetadata {
+            mark_bit_spec: mark_bit_spec,
+            first_address: start,
+            calculated: AtomicBool::new(false),
+            block_offsets,
+            vm: PhantomData
+        }
+    }
+    
+    pub fn mark_end_of_object(&self, object: ObjectReference) {
+        use crate::util::metadata::side_metadata::{address_to_meta_address, meta_byte_lshift};
+        let end_of_object = object.to_raw_address() + VM::VMObjectModel::get_current_size(object) - (MIN_OBJECT_SIZE as usize);
+        let a1 = address_to_meta_address(&self.mark_bit_spec, object.to_raw_address());
+        let s1 = meta_byte_lshift(&self.mark_bit_spec, object.to_raw_address());
+        let a2 = address_to_meta_address(&self.mark_bit_spec, end_of_object);
+        let s2 = meta_byte_lshift(&self.mark_bit_spec, end_of_object);
+        assert!((a1, s1) < (a2, s2));
+        
+        self.mark_bit_spec.fetch_or_atomic(
+            end_of_object,
+            GC_MARK_BIT_MASK,
+            Ordering::SeqCst
+        );
+    }
+
+    pub fn calculate_offset_vector(&self, pr: &MonotonePageResource<VM>) {
+        let mut state = Transducer::new();
+        let last_block = (pr.cursor() - self.first_address) / BLOCK_SIZE;
+        debug!("calculating offset of {last_block} blocks");
+        for block in 0..last_block {
+            let block_start = self.first_address + (block * BLOCK_SIZE);
+            let block_end = block_start + BLOCK_SIZE;
+            self.block_offsets[block].store(state.encode(block_start), Ordering::Relaxed);
+            self.mark_bit_spec.scan_non_zero_values::<u8>(
+                block_start,
+                block_end,
+                &mut |addr: Address| { state.step(addr); }
+            );
+        }
+        self.calculated.store(true, Ordering::Relaxed);
+    }
+
+    pub fn release(&self) {
+        self.calculated.store(false, Ordering::Relaxed);
+    }
+    
+    pub fn forward(&self, address: Address) -> Address {
+        debug_assert!(self.calculated.load(Ordering::Relaxed), "forward() should only be called when we have calculated an offset vector");
+        let block = (address - self.first_address) / BLOCK_SIZE;
+        let block_start = self.first_address + (block * BLOCK_SIZE);
+        let mut state = Transducer::decode(self.block_offsets[block].load(Ordering::Relaxed), block_start);
+        //println!("running {state:?} from {block_start} to {address}:");
+        self.mark_bit_spec.scan_non_zero_values::<u8>(
+            block_start,
+            address,
+            &mut |addr: Address| { state.step(addr); }
+        );
+        return self.first_address + state.live;
+    }
+    
+    pub fn scan_marked_objects(&self, start: Address, end: Address, f: &mut impl FnMut(ObjectReference)) {
+        let mut in_object = false;
+        self.mark_bit_spec.scan_non_zero_values::<u8>(
+            start,
+            end,
+            &mut |addr: Address| {
+                if !in_object {
+                    let object = ObjectReference::from_raw_address(addr).unwrap();
+                    f(object);
+                }
+                in_object = !in_object;
+            }
+        );
+    }
+}

--- a/src/policy/compressor/forwarding.rs
+++ b/src/policy/compressor/forwarding.rs
@@ -1,13 +1,13 @@
 use crate::policy::compressor::GC_MARK_BIT_MASK;
 use crate::util::constants::MIN_OBJECT_SIZE;
-use crate::vm::VMBinding;
-use crate::vm::object_model::ObjectModel;
-use crate::util::{Address, ObjectReference};
 use crate::util::heap::MonotonePageResource;
 use crate::util::metadata::side_metadata::SideMetadataSpec;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
-use std::marker::PhantomData;
+use crate::util::{Address, ObjectReference};
+use crate::vm::object_model::ObjectModel;
+use crate::vm::VMBinding;
 use atomic::Ordering;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 /// A finite-state machine which processes the positions of mark bits,
 /// and accumulates the size of live data that it has seen.
@@ -19,14 +19,14 @@ use atomic::Ordering;
 struct Transducer {
     live: usize,
     last_bit_seen: Address,
-    in_object: bool
+    in_object: bool,
 }
 impl Transducer {
     pub fn new() -> Self {
         Self {
             live: 0,
             last_bit_seen: Address::ZERO,
-            in_object: false
+            in_object: false,
         }
     }
     pub fn step(&mut self, address: Address) {
@@ -36,7 +36,7 @@ impl Transducer {
         self.in_object = !self.in_object;
         self.last_bit_seen = address;
     }
-    
+
     pub fn encode(&self, address: Address) -> usize {
         if self.in_object {
             // We count the space between the last mark bit and
@@ -47,12 +47,12 @@ impl Transducer {
             self.live
         }
     }
-    
+
     pub fn decode(offset: usize, address: Address) -> Self {
         Transducer {
             live: offset & !1,
             last_bit_seen: address,
-            in_object: (offset & 1) == 1
+            in_object: (offset & 1) == 1,
         }
     }
 }
@@ -62,13 +62,17 @@ pub struct ForwardingMetadata<VM: VMBinding> {
     pub(crate) first_address: Address,
     calculated: AtomicBool,
     block_offsets: Vec<AtomicUsize>,
-    vm: PhantomData<VM>
+    vm: PhantomData<VM>,
 }
 
 const BLOCK_SIZE: usize = 512;
 
 impl<VM: VMBinding> ForwardingMetadata<VM> {
-    pub fn new(mark_bit_spec: SideMetadataSpec, start: Address, size: usize) -> ForwardingMetadata<VM> {
+    pub fn new(
+        mark_bit_spec: SideMetadataSpec,
+        start: Address,
+        size: usize,
+    ) -> ForwardingMetadata<VM> {
         let mut block_offsets = vec![];
         let blocks = size / BLOCK_SIZE;
         block_offsets.resize_with(blocks, || AtomicUsize::new(0));
@@ -77,24 +81,22 @@ impl<VM: VMBinding> ForwardingMetadata<VM> {
             first_address: start,
             calculated: AtomicBool::new(false),
             block_offsets,
-            vm: PhantomData
+            vm: PhantomData,
         }
     }
-    
+
     pub fn mark_end_of_object(&self, object: ObjectReference) {
         use crate::util::metadata::side_metadata::{address_to_meta_address, meta_byte_lshift};
-        let end_of_object = object.to_raw_address() + VM::VMObjectModel::get_current_size(object) - (MIN_OBJECT_SIZE as usize);
+        let end_of_object = object.to_raw_address() + VM::VMObjectModel::get_current_size(object)
+            - (MIN_OBJECT_SIZE as usize);
         let a1 = address_to_meta_address(&self.mark_bit_spec, object.to_raw_address());
         let s1 = meta_byte_lshift(&self.mark_bit_spec, object.to_raw_address());
         let a2 = address_to_meta_address(&self.mark_bit_spec, end_of_object);
         let s2 = meta_byte_lshift(&self.mark_bit_spec, end_of_object);
         debug_assert!((a1, s1) < (a2, s2));
-        
-        self.mark_bit_spec.fetch_or_atomic(
-            end_of_object,
-            GC_MARK_BIT_MASK,
-            Ordering::SeqCst
-        );
+
+        self.mark_bit_spec
+            .fetch_or_atomic(end_of_object, GC_MARK_BIT_MASK, Ordering::SeqCst);
     }
 
     pub fn calculate_offset_vector(&self, pr: &MonotonePageResource<VM>) {
@@ -108,7 +110,9 @@ impl<VM: VMBinding> ForwardingMetadata<VM> {
             self.mark_bit_spec.scan_non_zero_values::<u8>(
                 block_start,
                 block_end,
-                &mut |addr: Address| { state.step(addr); }
+                &mut |addr: Address| {
+                    state.step(addr);
+                },
             );
         }
         self.calculated.store(true, Ordering::Relaxed);
@@ -117,14 +121,17 @@ impl<VM: VMBinding> ForwardingMetadata<VM> {
     pub fn release(&self) {
         self.calculated.store(false, Ordering::Relaxed);
     }
-    
+
     pub fn forward(&self, address: Address) -> Address {
-        debug_assert!(self.calculated.load(Ordering::Relaxed), "forward() should only be called when we have calculated an offset vector");
+        debug_assert!(
+            self.calculated.load(Ordering::Relaxed),
+            "forward() should only be called when we have calculated an offset vector"
+        );
         let block_number = (address - self.first_address) / BLOCK_SIZE;
         let block_address = self.first_address + (block_number * BLOCK_SIZE);
         let mut state = Transducer::decode(
             self.block_offsets[block_number].load(Ordering::Relaxed),
-            block_address
+            block_address,
         );
         // The transducer in this implementation computes the offset
         // relative to the start of the heap; whereas Total-Live-Data in
@@ -132,23 +139,27 @@ impl<VM: VMBinding> ForwardingMetadata<VM> {
         self.mark_bit_spec.scan_non_zero_values::<u8>(
             block_address,
             address,
-            &mut |addr: Address| { state.step(addr); }
+            &mut |addr: Address| {
+                state.step(addr);
+            },
         );
         self.first_address + state.live
     }
-    
-    pub fn scan_marked_objects(&self, start: Address, end: Address, f: &mut impl FnMut(ObjectReference)) {
+
+    pub fn scan_marked_objects(
+        &self,
+        start: Address,
+        end: Address,
+        f: &mut impl FnMut(ObjectReference),
+    ) {
         let mut in_object = false;
-        self.mark_bit_spec.scan_non_zero_values::<u8>(
-            start,
-            end,
-            &mut |addr: Address| {
+        self.mark_bit_spec
+            .scan_non_zero_values::<u8>(start, end, &mut |addr: Address| {
                 if !in_object {
                     let object = ObjectReference::from_raw_address(addr).unwrap();
                     f(object);
                 }
                 in_object = !in_object;
-            }
-        );
+            });
     }
 }

--- a/src/policy/compressor/mod.rs
+++ b/src/policy/compressor/mod.rs
@@ -1,0 +1,4 @@
+pub mod compressorspace;
+pub mod forwarding;
+
+pub use compressorspace::*;

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -42,8 +42,6 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
     }
 
     fn is_live(&self, object: ObjectReference) -> bool {
-        // Sanity checker cannot use this method to do the verification
-        // since the mark bit will be cleared during the second trace(update forwarding pointer)
         Self::is_marked(object)
     }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -27,6 +27,7 @@ pub mod immortalspace;
 pub mod largeobjectspace;
 pub mod lockfreeimmortalspace;
 pub mod markcompactspace;
+pub mod compressor;
 pub mod marksweepspace;
 #[cfg(feature = "vm_space")]
 pub mod vmspace;

--- a/src/util/metadata/side_metadata/helpers.rs
+++ b/src/util/metadata/side_metadata/helpers.rs
@@ -224,7 +224,7 @@ pub(super) const fn metadata_address_range_size(metadata_spec: &SideMetadataSpec
     1usize << (VMLayout::LOG_ARCH_ADDRESS_SPACE - log_data_meta_ratio(metadata_spec))
 }
 
-pub(super) fn meta_byte_lshift(metadata_spec: &SideMetadataSpec, data_addr: Address) -> u8 {
+pub(crate) fn meta_byte_lshift(metadata_spec: &SideMetadataSpec, data_addr: Address) -> u8 {
     let bits_num_log = metadata_spec.log_num_of_bits as i32;
     if bits_num_log >= 3 {
         return 0;

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -46,6 +46,8 @@ pub enum PlanSelector {
     Immix,
     /// A mark-compact collector that marks objects and performs Cheney-style copying.
     MarkCompact,
+    /// A mark-compact collector that uses Compressor-style bitmaps.
+    Compressor,
     /// An Immix collector that uses a sticky mark bit to allow generational behaviors without a copying nursery.
     StickyImmix,
 }


### PR DESCRIPTION
This PR adds a [Compressor](https://dl.acm.org/doi/10.1145/1133255.1134023)-esque garbage collector, which is based on MarkCompact but uses a mark bitmap for forwarding metadata like the Compressor.