### PR TITLE
Refactor log bits

### DIFF
--- a/.github/workflows/binding-tests-openjdk.yml
+++ b/.github/workflows/binding-tests-openjdk.yml
@@ -45,3 +45,6 @@ jobs:
             cd mmtk-openjdk
             export RUST_BACKTRACE=1
             ./.github/scripts/${{ inputs.test-script }}
+        - name: Setup tmate session
+          if: ${{ failure() }}
+          uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/binding-tests-openjdk.yml
+++ b/.github/workflows/binding-tests-openjdk.yml
@@ -45,6 +45,3 @@ jobs:
             cd mmtk-openjdk
             export RUST_BACKTRACE=1
             ./.github/scripts/${{ inputs.test-script }}
-        - name: Setup tmate session
-          if: ${{ failure() }}
-          uses: mxschmitt/action-tmate@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ portable-atomic = "1.4.3"
 probe = "0.5"
 regex = "1.7.0"
 rustversion = "1.0"
+rayon-core = "=1.12.1" # We can remove this dependency when we use MSRV 1.80+
 spin = "0.9.5"
 static_assertions = "1.1.0"
 strum = "0.27.1"

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -181,9 +181,9 @@ impl<VM: VMBinding> MyGC<VM> {
         let res = MyGC {
             hi: AtomicBool::new(false),
             // ANCHOR: copyspace_new
-            copyspace0: CopySpace::new(plan_args.get_space_args("copyspace0", true, false, VMRequest::discontiguous()), false),
+            copyspace0: CopySpace::new(plan_args.get_normal_space_args("copyspace0", true, false, VMRequest::discontiguous()), false),
             // ANCHOR_END: copyspace_new
-            copyspace1: CopySpace::new(plan_args.get_space_args("copyspace1", true, false, VMRequest::discontiguous()), true),
+            copyspace1: CopySpace::new(plan_args.get_normal_space_args("copyspace1", true, false, VMRequest::discontiguous()), true),
             common: CommonPlan::new(plan_args),
         };
 

--- a/src/plan/compressor/global.rs
+++ b/src/plan/compressor/global.rs
@@ -183,7 +183,7 @@ impl<VM: VMBinding> Compressor<VM> {
         };
 
         let res = Compressor {
-            compressor_space: CompressorSpace::new(plan_args.get_space_args(
+            compressor_space: CompressorSpace::new(plan_args.get_normal_space_args(
                 "compressor_space",
                 true,
                 false,

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -110,6 +110,9 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.release(tls);
         if full_heap {
+            if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
+                self.fromspace().clear_side_log_bits();
+            }
             self.fromspace().release();
         }
     }

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -212,11 +212,11 @@ impl<VM: VMBinding> GenCopy<VM> {
         };
 
         let copyspace0 = CopySpace::new(
-            plan_args.get_space_args("copyspace0", true, false, VMRequest::discontiguous()),
+            plan_args.get_mature_space_args("copyspace0", true, false, VMRequest::discontiguous()),
             false,
         );
         let copyspace1 = CopySpace::new(
-            plan_args.get_space_args("copyspace1", true, false, VMRequest::discontiguous()),
+            plan_args.get_mature_space_args("copyspace1", true, false, VMRequest::discontiguous()),
             true,
         );
 

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -74,9 +74,6 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
     /// Release Gen. This should be called by a single thread in GC release work.
     pub fn release(&mut self, tls: VMWorkerThread) {
         let full_heap = !self.is_current_gc_nursery();
-        if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
-            self.nursery.clear_side_log_bits();
-        }
         self.common.release(tls, full_heap);
         self.nursery.release();
     }

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -74,6 +74,9 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
     /// Release Gen. This should be called by a single thread in GC release work.
     pub fn release(&mut self, tls: VMWorkerThread) {
         let full_heap = !self.is_current_gc_nursery();
+        if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
+            self.nursery.clear_side_log_bits();
+        }
         self.common.release(tls, full_heap);
         self.nursery.release();
     }

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -41,7 +41,7 @@ pub struct CommonGenPlan<VM: VMBinding> {
 impl<VM: VMBinding> CommonGenPlan<VM> {
     pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> Self {
         let nursery = CopySpace::new(
-            args.get_space_args("nursery", true, false, VMRequest::discontiguous()),
+            args.get_nursery_space_args("nursery", true, false, VMRequest::discontiguous()),
             true,
         );
         let full_heap_gc_count = args

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -250,10 +250,14 @@ impl<VM: VMBinding> GenImmix<VM> {
                 crate::plan::generational::new_generational_global_metadata_specs::<VM>(),
         };
         let immix_space = ImmixSpace::new(
-            plan_args.get_space_args("immix_mature", true, false, VMRequest::discontiguous()),
+            plan_args.get_mature_space_args(
+                "immix_mature",
+                true,
+                false,
+                VMRequest::discontiguous(),
+            ),
             ImmixSpaceArgs {
                 // In GenImmix, young objects are not allocated in ImmixSpace directly.
-                #[cfg(feature = "vo_bit")]
                 mixed_age: false,
                 never_move_objects: false,
             },

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -130,6 +130,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         self.gen.prepare(tls);
         if full_heap {
             if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
+                self.gen.common.clear_side_log_bits();
                 self.immix_space.clear_side_log_bits();
             }
             self.immix_space.prepare(

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -130,7 +130,6 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         self.gen.prepare(tls);
         if full_heap {
             if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
-                self.gen.common.clear_side_log_bits();
                 self.immix_space.clear_side_log_bits();
             }
             self.immix_space.prepare(

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -129,6 +129,9 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         let full_heap = !self.gen.is_current_gc_nursery();
         self.gen.prepare(tls);
         if full_heap {
+            if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
+                self.immix_space.clear_side_log_bits();
+            }
             self.immix_space.prepare(
                 full_heap,
                 Some(crate::policy::immix::defrag::StatsForDefrag::new(self)),
@@ -249,8 +252,6 @@ impl<VM: VMBinding> GenImmix<VM> {
         let immix_space = ImmixSpace::new(
             plan_args.get_space_args("immix_mature", true, false, VMRequest::discontiguous()),
             ImmixSpaceArgs {
-                // We need to unlog objects at tracing time since we currently clear all log bits during a major GC
-                unlog_object_when_traced: true,
                 // In GenImmix, young objects are not allocated in ImmixSpace directly.
                 #[cfg(feature = "vo_bit")]
                 mixed_age: false,

--- a/src/plan/generational/mod.rs
+++ b/src/plan/generational/mod.rs
@@ -45,8 +45,7 @@ pub const FULL_NURSERY_GC: bool = false;
 pub const GEN_CONSTRAINTS: PlanConstraints = PlanConstraints {
     moves_objects: true,
     needs_log_bit: ACTIVE_BARRIER.equals(BarrierSelector::ObjectBarrier),
-    unlog_allocated_object: true,
-    unlog_traced_object: true,
+    generational: true,
     barrier: ACTIVE_BARRIER,
     // We may trace duplicate edges in sticky immix (or any plan that uses object remembering barrier). See https://github.com/mmtk/mmtk-core/issues/743.
     may_trace_duplicate_edges: ACTIVE_BARRIER.equals(BarrierSelector::ObjectBarrier),

--- a/src/plan/generational/mod.rs
+++ b/src/plan/generational/mod.rs
@@ -45,6 +45,8 @@ pub const FULL_NURSERY_GC: bool = false;
 pub const GEN_CONSTRAINTS: PlanConstraints = PlanConstraints {
     moves_objects: true,
     needs_log_bit: ACTIVE_BARRIER.equals(BarrierSelector::ObjectBarrier),
+    unlog_allocated_object: true,
+    unlog_traced_object: true,
     barrier: ACTIVE_BARRIER,
     // We may trace duplicate edges in sticky immix (or any plan that uses object remembering barrier). See https://github.com/mmtk/mmtk-core/issues/743.
     may_trace_duplicate_edges: ACTIVE_BARRIER.equals(BarrierSelector::ObjectBarrier),

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -404,11 +404,13 @@ pub struct CreateSpecificPlanArgs<'a, VM: VMBinding> {
 
 impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
     /// Get a PlanCreateSpaceArgs that can be used to create a space
-    pub fn get_space_args(
+    pub fn _get_space_args(
         &mut self,
         name: &'static str,
         zeroed: bool,
         permission_exec: bool,
+        unlog_allocated_object: bool,
+        unlog_traced_object: bool,
         vmrequest: VMRequest,
     ) -> PlanCreateSpaceArgs<VM> {
         PlanCreateSpaceArgs {
@@ -416,8 +418,8 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
             zeroed,
             permission_exec,
             vmrequest,
-            unlog_allocated_object: self.constraints.unlog_allocated_object,
-            unlog_traced_object: self.constraints.unlog_traced_object,
+            unlog_allocated_object,
+            unlog_traced_object,
             global_side_metadata_specs: self.global_side_metadata_specs.clone(),
             vm_map: self.global_args.vm_map,
             mmapper: self.global_args.mmapper,
@@ -429,39 +431,121 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
             global_state: self.global_args.state.clone(),
         }
     }
+
+    // The following are some convenience methods for common presets.
+    // These are not an exhaustive list -- it is just common presets that are used by most plans.
+
+    /// Get a preset for a nursery space (where young objects are located).
+    pub fn get_nursery_space_args(
+        &mut self,
+        name: &'static str,
+        zeroed: bool,
+        permission_exec: bool,
+        vmrequest: VMRequest,
+    ) -> PlanCreateSpaceArgs<VM> {
+        // Objects are allocatd as young, and when traced, they stay young. If they are copied out of the nursery space, they will be moved to a mature space,
+        // and log bits will be set in that case by the mature space.
+        self._get_space_args(name, zeroed, permission_exec, false, false, vmrequest)
+    }
+
+    /// Get a preset for a mature space (where mature objects are located).
+    pub fn get_mature_space_args(
+        &mut self,
+        name: &'static str,
+        zeroed: bool,
+        permission_exec: bool,
+        vmrequest: VMRequest,
+    ) -> PlanCreateSpaceArgs<VM> {
+        // Objects are allocated as mature (pre-tenured), and when traced, they stay mature.
+        // If an object gets copied into a mature space, the object is also mature,
+        self._get_space_args(name, zeroed, permission_exec, true, true, vmrequest)
+    }
+
+    // Get a preset for a mixed age space (where both young and mature objects are located).
+    pub fn get_mixed_age_space_args(
+        &mut self,
+        name: &'static str,
+        zeroed: bool,
+        permission_exec: bool,
+        vmrequest: VMRequest,
+    ) -> PlanCreateSpaceArgs<VM> {
+        // Objects are allocated as young, and when traced, they become mature objects.
+        self._get_space_args(name, zeroed, permission_exec, false, true, vmrequest)
+    }
+
+    /// Get a preset for spaces in a non-generational plan.
+    pub fn get_normal_space_args(
+        &mut self,
+        name: &'static str,
+        zeroed: bool,
+        permission_exec: bool,
+        vmrequest: VMRequest,
+    ) -> PlanCreateSpaceArgs<VM> {
+        // Non generational plan: we do not use any of the flags about log bits.
+        self._get_space_args(name, zeroed, permission_exec, false, false, vmrequest)
+    }
+
+    /// Get a preset for spaces in [`crate::plan::global::CommonPlan`].
+    /// Spaces like LOS which may include both young and mature objects should not use this method.
+    pub fn get_common_space_args(
+        &mut self,
+        generational: bool,
+        name: &'static str,
+    ) -> PlanCreateSpaceArgs<VM> {
+        self.get_base_space_args(
+            generational,
+            name,
+            false, // Common spaces are not executable.
+        )
+    }
+
+    /// Get a preset for spaces in [`crate::plan::global::BasePlan`].
+    pub fn get_base_space_args(
+        &mut self,
+        generational: bool,
+        name: &'static str,
+        permission_exec: bool,
+    ) -> PlanCreateSpaceArgs<VM> {
+        if generational {
+            // In generational plans, common/base spaces behave like a mature space:
+            // * the objects in these spaces are not traced in a nursery GC
+            // * the log bits for the objects are maintained exactly the same as a mature space.
+            // Thus we consider them as mature spaces.
+            self.get_mature_space_args(name, true, permission_exec, VMRequest::discontiguous())
+        } else {
+            self.get_normal_space_args(name, true, permission_exec, VMRequest::discontiguous())
+        }
+    }
 }
 
 impl<VM: VMBinding> BasePlan<VM> {
     #[allow(unused_mut)] // 'args' only needs to be mutable for certain features
     pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> BasePlan<VM> {
+        let _generational = args.constraints.generational;
         BasePlan {
             #[cfg(feature = "code_space")]
-            code_space: ImmortalSpace::new(args.get_space_args(
+            code_space: ImmortalSpace::new(args.get_base_space_args(
+                _generational,
                 "code_space",
                 true,
-                true,
-                VMRequest::discontiguous(),
             )),
             #[cfg(feature = "code_space")]
-            code_lo_space: ImmortalSpace::new(args.get_space_args(
+            code_lo_space: ImmortalSpace::new(args.get_base_space_args(
+                _generational,
                 "code_lo_space",
                 true,
-                true,
-                VMRequest::discontiguous(),
             )),
             #[cfg(feature = "ro_space")]
-            ro_space: ImmortalSpace::new(args.get_space_args(
+            ro_space: ImmortalSpace::new(args.get_base_space_args(
+                _generational,
                 "ro_space",
-                true,
                 false,
-                VMRequest::discontiguous(),
             )),
             #[cfg(feature = "vm_space")]
-            vm_space: VMSpace::new(args.get_space_args(
+            vm_space: VMSpace::new(args.get_base_space_args(
+                _generational,
                 "vm_space",
-                false,
                 false, // it doesn't matter -- we are not mmapping for VM space.
-                VMRequest::discontiguous(),
             )),
 
             global_state: args.global_args.state.clone(),
@@ -609,15 +693,16 @@ pub struct CommonPlan<VM: VMBinding> {
 impl<VM: VMBinding> CommonPlan<VM> {
     pub fn new(mut args: CreateSpecificPlanArgs<VM>) -> CommonPlan<VM> {
         let needs_log_bit = args.constraints.needs_log_bit;
+        let generational = args.constraints.generational;
         CommonPlan {
-            immortal: ImmortalSpace::new(args.get_space_args(
-                "immortal",
-                true,
-                false,
-                VMRequest::discontiguous(),
-            )),
+            immortal: ImmortalSpace::new(args.get_common_space_args(generational, "immortal")),
             los: LargeObjectSpace::new(
-                args.get_space_args("los", true, false, VMRequest::discontiguous()),
+                // LOS is a bit special, as it is a mixed age space. It has a logical nursery.
+                if generational {
+                    args.get_mixed_age_space_args("los", true, false, VMRequest::discontiguous())
+                } else {
+                    args.get_normal_space_args("los", true, false, VMRequest::discontiguous())
+                },
                 false,
                 needs_log_bit,
             ),
@@ -677,7 +762,7 @@ impl<VM: VMBinding> CommonPlan<VM> {
     }
 
     fn new_nonmoving_space(args: &mut CreateSpecificPlanArgs<VM>) -> NonMovingSpace<VM> {
-        let space_args = args.get_space_args("nonmoving", true, false, VMRequest::discontiguous());
+        let space_args = args.get_common_space_args(args.constraints.generational, "nonmoving");
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "immortal_as_nonmoving", feature = "marksweep_as_nonmoving"))] {
                 NonMovingSpace::new(space_args)
@@ -686,7 +771,6 @@ impl<VM: VMBinding> CommonPlan<VM> {
                 NonMovingSpace::new(
                     space_args,
                     crate::policy::immix::ImmixSpaceArgs {
-                        #[cfg(feature = "vo_bit")]
                         mixed_age: false,
                         never_move_objects: true,
                     },

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -442,7 +442,7 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
         zeroed: bool,
         permission_exec: bool,
         vmrequest: VMRequest,
-    ) -> PlanCreateSpaceArgs<VM> {
+    ) -> PlanCreateSpaceArgs<'_, VM> {
         // Objects are allocatd as young, and when traced, they stay young. If they are copied out of the nursery space, they will be moved to a mature space,
         // and log bits will be set in that case by the mature space.
         self._get_space_args(name, zeroed, permission_exec, false, false, vmrequest)
@@ -455,7 +455,7 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
         zeroed: bool,
         permission_exec: bool,
         vmrequest: VMRequest,
-    ) -> PlanCreateSpaceArgs<VM> {
+    ) -> PlanCreateSpaceArgs<'_, VM> {
         // Objects are allocated as mature (pre-tenured), and when traced, they stay mature.
         // If an object gets copied into a mature space, the object is also mature,
         self._get_space_args(name, zeroed, permission_exec, true, true, vmrequest)
@@ -468,7 +468,7 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
         zeroed: bool,
         permission_exec: bool,
         vmrequest: VMRequest,
-    ) -> PlanCreateSpaceArgs<VM> {
+    ) -> PlanCreateSpaceArgs<'_, VM> {
         // Objects are allocated as young, and when traced, they become mature objects.
         self._get_space_args(name, zeroed, permission_exec, false, true, vmrequest)
     }
@@ -480,7 +480,7 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
         zeroed: bool,
         permission_exec: bool,
         vmrequest: VMRequest,
-    ) -> PlanCreateSpaceArgs<VM> {
+    ) -> PlanCreateSpaceArgs<'_, VM> {
         // Non generational plan: we do not use any of the flags about log bits.
         self._get_space_args(name, zeroed, permission_exec, false, false, vmrequest)
     }
@@ -491,7 +491,7 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
         &mut self,
         generational: bool,
         name: &'static str,
-    ) -> PlanCreateSpaceArgs<VM> {
+    ) -> PlanCreateSpaceArgs<'_, VM> {
         self.get_base_space_args(
             generational,
             name,
@@ -505,7 +505,7 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
         generational: bool,
         name: &'static str,
         permission_exec: bool,
-    ) -> PlanCreateSpaceArgs<VM> {
+    ) -> PlanCreateSpaceArgs<'_, VM> {
         if generational {
             // In generational plans, common/base spaces behave like a mature space:
             // * the objects in these spaces are not traced in a nursery GC

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -138,7 +138,6 @@ impl<VM: VMBinding> Immix<VM> {
         Self::new_with_args(
             plan_args,
             ImmixSpaceArgs {
-                unlog_object_when_traced: false,
                 #[cfg(feature = "vo_bit")]
                 mixed_age: false,
                 never_move_objects: false,

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -138,7 +138,6 @@ impl<VM: VMBinding> Immix<VM> {
         Self::new_with_args(
             plan_args,
             ImmixSpaceArgs {
-                #[cfg(feature = "vo_bit")]
                 mixed_age: false,
                 never_move_objects: false,
             },
@@ -151,7 +150,21 @@ impl<VM: VMBinding> Immix<VM> {
     ) -> Self {
         let immix = Immix {
             immix_space: ImmixSpace::new(
-                plan_args.get_space_args("immix", true, false, VMRequest::discontiguous()),
+                if space_args.mixed_age {
+                    plan_args.get_mixed_age_space_args(
+                        "immix",
+                        true,
+                        false,
+                        VMRequest::discontiguous(),
+                    )
+                } else {
+                    plan_args.get_normal_space_args(
+                        "immix",
+                        true,
+                        false,
+                        VMRequest::discontiguous(),
+                    )
+                },
                 space_args,
             ),
             common: CommonPlan::new(plan_args),

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -198,7 +198,7 @@ impl<VM: VMBinding> MarkCompact<VM> {
             global_side_metadata_specs,
         };
 
-        let mc_space = MarkCompactSpace::new(plan_args.get_space_args(
+        let mc_space = MarkCompactSpace::new(plan_args.get_normal_space_args(
             "mc",
             true,
             false,

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -112,7 +112,7 @@ impl<VM: VMBinding> MarkSweep<VM> {
         };
 
         let res = MarkSweep {
-            ms: MarkSweepSpace::new(plan_args.get_space_args(
+            ms: MarkSweepSpace::new(plan_args.get_normal_space_args(
                 "ms",
                 true,
                 false,

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -99,19 +99,19 @@ impl<VM: VMBinding> NoGC<VM> {
         };
 
         let res = NoGC {
-            nogc_space: NoGCImmortalSpace::new(plan_args.get_space_args(
+            nogc_space: NoGCImmortalSpace::new(plan_args.get_normal_space_args(
                 "nogc_space",
                 cfg!(not(feature = "nogc_no_zeroing")),
                 false,
                 VMRequest::discontiguous(),
             )),
-            immortal: ImmortalSpace::new(plan_args.get_space_args(
+            immortal: ImmortalSpace::new(plan_args.get_normal_space_args(
                 "immortal",
                 true,
                 false,
                 VMRequest::discontiguous(),
             )),
-            los: ImmortalSpace::new(plan_args.get_space_args(
+            los: ImmortalSpace::new(plan_args.get_normal_space_args(
                 "los",
                 true,
                 false,

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -108,7 +108,12 @@ impl<VM: VMBinding> PageProtect<VM> {
 
         let ret = PageProtect {
             space: LargeObjectSpace::new(
-                plan_args.get_space_args("pageprotect", true, false, VMRequest::discontiguous()),
+                plan_args.get_normal_space_args(
+                    "pageprotect",
+                    true,
+                    false,
+                    VMRequest::discontiguous(),
+                ),
                 true,
                 false, // PageProtect does not use log bit
             ),

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -110,6 +110,7 @@ impl<VM: VMBinding> PageProtect<VM> {
             space: LargeObjectSpace::new(
                 plan_args.get_space_args("pageprotect", true, false, VMRequest::discontiguous()),
                 true,
+                false, // PageProtect does not use log bit
             ),
             common: CommonPlan::new(plan_args),
         };

--- a/src/plan/plan_constraints.rs
+++ b/src/plan/plan_constraints.rs
@@ -45,10 +45,8 @@ pub struct PlanConstraints {
     /// `MutatorConfig::prepare_func`).  Those plans can set this to `false` so that the
     /// `PrepareMutator` work packets will not be created at all.
     pub needs_prepare_mutator: bool,
-    /// Should a policy unlog newly allocated objects?
-    pub unlog_allocated_object: bool,
-    /// Should a policy unlog traced objects?
-    pub unlog_traced_object: bool,
+    /// Is this plan generational?
+    pub generational: bool,
 }
 
 impl PlanConstraints {
@@ -71,8 +69,7 @@ impl PlanConstraints {
             barrier: BarrierSelector::NoBarrier,
             // If we use mark sweep as non moving space, we need to prepare mutator. See [`common_prepare_func`].
             needs_prepare_mutator: cfg!(feature = "marksweep_as_nonmoving"),
-            unlog_allocated_object: false,
-            unlog_traced_object: false,
+            generational: false,
         }
     }
 }

--- a/src/plan/plan_constraints.rs
+++ b/src/plan/plan_constraints.rs
@@ -45,6 +45,10 @@ pub struct PlanConstraints {
     /// `MutatorConfig::prepare_func`).  Those plans can set this to `false` so that the
     /// `PrepareMutator` work packets will not be created at all.
     pub needs_prepare_mutator: bool,
+    /// Should a policy unlog newly allocated objects?
+    pub unlog_allocated_object: bool,
+    /// Should a policy unlog traced objects?
+    pub unlog_traced_object: bool,
 }
 
 impl PlanConstraints {
@@ -67,6 +71,8 @@ impl PlanConstraints {
             barrier: BarrierSelector::NoBarrier,
             // If we use mark sweep as non moving space, we need to prepare mutator. See [`common_prepare_func`].
             needs_prepare_mutator: cfg!(feature = "marksweep_as_nonmoving"),
+            unlog_allocated_object: false,
+            unlog_traced_object: false,
         }
     }
 }

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -146,11 +146,21 @@ impl<VM: VMBinding> SemiSpace<VM> {
         let res = SemiSpace {
             hi: AtomicBool::new(false),
             copyspace0: CopySpace::new(
-                plan_args.get_space_args("copyspace0", true, false, VMRequest::discontiguous()),
+                plan_args.get_normal_space_args(
+                    "copyspace0",
+                    true,
+                    false,
+                    VMRequest::discontiguous(),
+                ),
                 false,
             ),
             copyspace1: CopySpace::new(
-                plan_args.get_space_args("copyspace1", true, false, VMRequest::discontiguous()),
+                plan_args.get_normal_space_args(
+                    "copyspace1",
+                    true,
+                    false,
+                    VMRequest::discontiguous(),
+                ),
                 true,
             ),
             common: CommonPlan::new(plan_args),

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -124,7 +124,6 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
         } else {
             self.full_heap_gc_count.lock().unwrap().inc();
             if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
-                self.immix.common.clear_side_log_bits();
                 self.immix.immix_space.clear_side_log_bits();
             }
             self.immix.prepare(tls);

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -46,6 +46,8 @@ pub const STICKY_IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
     barrier: crate::plan::BarrierSelector::ObjectBarrier,
     // We may trace duplicate edges in sticky immix (or any plan that uses object remembering barrier). See https://github.com/mmtk/mmtk-core/issues/743.
     may_trace_duplicate_edges: true,
+    unlog_allocated_object: true,
+    unlog_traced_object: true,
     ..immix::IMMIX_CONSTRAINTS
 };
 
@@ -122,6 +124,10 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
             self.immix.common.los.prepare(false);
         } else {
             self.full_heap_gc_count.lock().unwrap().inc();
+            if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
+                self.immix.common.clear_side_log_bits();
+                self.immix.immix_space.clear_side_log_bits();
+            }
             self.immix.prepare(tls);
         }
     }
@@ -325,10 +331,6 @@ impl<VM: VMBinding> StickyImmix<VM> {
         let immix = immix::Immix::new_with_args(
             plan_args,
             crate::policy::immix::ImmixSpaceArgs {
-                // Every object we trace in nursery GC becomes a mature object.
-                // Every object we trace in full heap GC is a mature object. Thus in both cases,
-                // they should be unlogged.
-                unlog_object_when_traced: true,
                 // In StickyImmix, both young and old objects are allocated in the ImmixSpace.
                 #[cfg(feature = "vo_bit")]
                 mixed_age: true,

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -46,8 +46,7 @@ pub const STICKY_IMMIX_CONSTRAINTS: PlanConstraints = PlanConstraints {
     barrier: crate::plan::BarrierSelector::ObjectBarrier,
     // We may trace duplicate edges in sticky immix (or any plan that uses object remembering barrier). See https://github.com/mmtk/mmtk-core/issues/743.
     may_trace_duplicate_edges: true,
-    unlog_allocated_object: true,
-    unlog_traced_object: true,
+    generational: true,
     ..immix::IMMIX_CONSTRAINTS
 };
 
@@ -332,7 +331,6 @@ impl<VM: VMBinding> StickyImmix<VM> {
             plan_args,
             crate::policy::immix::ImmixSpaceArgs {
                 // In StickyImmix, both young and old objects are allocated in the ImmixSpace.
-                #[cfg(feature = "vo_bit")]
                 mixed_age: true,
                 never_move_objects: false,
             },

--- a/src/policy/compressor/compressorspace.rs
+++ b/src/policy/compressor/compressorspace.rs
@@ -146,6 +146,14 @@ impl<VM: VMBinding> Space<VM> for CompressorSpace<VM> {
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
         object_enum::enumerate_blocks_from_monotonic_page_resource(enumerator, &self.pr);
     }
+
+    fn clear_side_log_bits(&self) {
+        unimplemented!()
+    }
+
+    fn set_side_log_bits(&self) {
+        unimplemented!()
+    }
 }
 
 impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for CompressorSpace<VM> {

--- a/src/policy/copy_context.rs
+++ b/src/policy/copy_context.rs
@@ -22,5 +22,5 @@ pub trait PolicyCopyContext: 'static + Send {
         align: usize,
         offset: usize,
     ) -> Address;
-    fn post_copy(&mut self, _obj: ObjectReference, _bytes: usize) {}
+    fn post_copy(&mut self, _obj: ObjectReference, _bytes: usize);
 }

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -709,16 +709,16 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                     object,
                     semantics,
                     copy_context,
-                    |_new_object| {
+                    |new_object| {
                         // post_copy should have set the unlog bit
                         // if `unlog_traced_object` is true.
                         debug_assert!(
                             !self.common.unlog_traced_object
                                 || VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
-                                    .is_unlogged::<VM>(object, Ordering::Relaxed)
+                                    .is_unlogged::<VM>(new_object, Ordering::Relaxed)
                         );
                         #[cfg(feature = "vo_bit")]
-                        vo_bit::helper::on_object_forwarded::<VM>(_new_object);
+                        vo_bit::helper::on_object_forwarded::<VM>(new_object);
                     },
                 )
             };

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -65,8 +65,6 @@ pub struct ImmixSpaceArgs {
     /// instance contain young objects, their VO bits need to be updated during this GC.  Currently
     /// only StickyImmix is affected.  GenImmix allocates young objects in a separete CopySpace
     /// nursery and its VO bits can be cleared in bulk.
-    // Currently only used when "vo_bit" is enabled.  Using #[cfg(...)] to eliminate dead code warning.
-    #[cfg(feature = "vo_bit")]
     pub mixed_age: bool,
     /// Disable copying for this Immix space.
     pub never_move_objects: bool,
@@ -877,6 +875,10 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         // Mark the line
         if !super::MARK_LINE_AT_SCAN_TIME {
             self.mark_lines(object);
+        }
+        if self.common.unlog_traced_object {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
+                .mark_byte_as_unlogged::<VM>(object, Ordering::Relaxed);
         }
     }
 

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -115,6 +115,20 @@ impl<VM: VMBinding> Space<VM> for ImmortalSpace<VM> {
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
         object_enum::enumerate_blocks_from_monotonic_page_resource(enumerator, &self.pr);
     }
+
+    fn clear_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        for (start, size) in self.pr.iterate_allocated_regions() {
+            log_bit.bzero_metadata(start, size);
+        }
+    }
+
+    fn set_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        for (start, size) in self.pr.iterate_allocated_regions() {
+            log_bit.bset_metadata(start, size);
+        }
+    }
 }
 
 use crate::scheduler::GCWorker;
@@ -171,20 +185,6 @@ impl<VM: VMBinding> ImmortalSpace<VM> {
 
     pub fn release(&mut self) {
         self.mark_state.on_global_release::<VM>();
-    }
-
-    pub fn clear_side_log_bits(&self) {
-        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
-        for (start, size) in self.pr.iterate_allocated_regions() {
-            log_bit.bzero_metadata(start, size);
-        }
-    }
-
-    pub fn set_side_log_bits(&self) {
-        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
-        for (start, size) in self.pr.iterate_allocated_regions() {
-            log_bit.bset_metadata(start, size);
-        }
     }
 
     pub fn trace_object<Q: ObjectQueue>(

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -9,6 +9,7 @@ use crate::util::alloc::allocator::AllocationOptions;
 use crate::util::constants::BYTES_IN_PAGE;
 use crate::util::heap::{FreeListPageResource, PageResource};
 use crate::util::metadata;
+use crate::util::object_enum::ClosureObjectEnumerator;
 use crate::util::object_enum::ObjectEnumerator;
 use crate::util::opaque_pointer::*;
 use crate::util::treadmill::TreadMill;
@@ -30,6 +31,7 @@ pub struct LargeObjectSpace<VM: VMBinding> {
     mark_state: u8,
     in_nursery_gc: bool,
     treadmill: TreadMill,
+    clear_log_bit_on_sweep: bool,
 }
 
 impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
@@ -76,7 +78,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
         );
 
         // If this object is freshly allocated, we do not set it as unlogged
-        if !alloc && self.common.needs_log_bit {
+        if !alloc && self.common.unlog_allocated_object {
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
 
@@ -216,6 +218,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
     pub fn new(
         args: crate::policy::space::PlanCreateSpaceArgs<VM>,
         protect_memory_on_release: bool,
+        clear_log_bit_on_sweep: bool,
     ) -> Self {
         let is_discontiguous = args.vmrequest.is_discontiguous();
         let vm_map = args.vm_map;
@@ -240,7 +243,24 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
             mark_state: 0,
             in_nursery_gc: false,
             treadmill: TreadMill::new(),
+            clear_log_bit_on_sweep,
         }
+    }
+
+    pub fn clear_side_log_bits(&self) {
+        let mut enumator = ClosureObjectEnumerator::<_, VM>::new(|object| {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.clear::<VM>(object, Ordering::SeqCst);
+        });
+        self.treadmill.enumerate_objects(&mut enumator);
+    }
+
+    pub fn set_side_log_bits(&self) {
+        debug_assert!(self.treadmill.is_from_space_empty());
+        debug_assert!(self.treadmill.is_nursery_empty());
+        let mut enumator = ClosureObjectEnumerator::<_, VM>::new(|object| {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
+        });
+        self.treadmill.enumerate_objects(&mut enumator);
     }
 
     pub fn prepare(&mut self, full_heap: bool) {
@@ -288,7 +308,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
                 // We just moved the object out of the logical nursery, mark it as unlogged.
                 // We also unlog mature objects as their unlog bit may have been unset before the
                 // full-heap GC
-                if self.common.needs_log_bit {
+                if self.common.unlog_traced_object {
                     VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
                         .mark_as_unlogged::<VM>(object, Ordering::SeqCst);
                 }
@@ -308,7 +328,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
             #[cfg(feature = "vo_bit")]
             crate::util::metadata::vo_bit::unset_vo_bit(object);
             // Clear log bits for dead objects to prevent a new nursery object having the unlog bit set
-            if self.common.needs_log_bit {
+            if self.clear_log_bit_on_sweep {
                 VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.clear::<VM>(object, Ordering::SeqCst);
             }
             self.pr

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -194,6 +194,22 @@ impl<VM: VMBinding> Space<VM> for LargeObjectSpace<VM> {
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
         self.treadmill.enumerate_objects(enumerator);
     }
+
+    fn clear_side_log_bits(&self) {
+        let mut enumator = ClosureObjectEnumerator::<_, VM>::new(|object| {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.clear::<VM>(object, Ordering::SeqCst);
+        });
+        self.treadmill.enumerate_objects(&mut enumator);
+    }
+
+    fn set_side_log_bits(&self) {
+        debug_assert!(self.treadmill.is_from_space_empty());
+        debug_assert!(self.treadmill.is_nursery_empty());
+        let mut enumator = ClosureObjectEnumerator::<_, VM>::new(|object| {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
+        });
+        self.treadmill.enumerate_objects(&mut enumator);
+    }
 }
 
 use crate::scheduler::GCWorker;
@@ -245,22 +261,6 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
             treadmill: TreadMill::new(),
             clear_log_bit_on_sweep,
         }
-    }
-
-    pub fn clear_side_log_bits(&self) {
-        let mut enumator = ClosureObjectEnumerator::<_, VM>::new(|object| {
-            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.clear::<VM>(object, Ordering::SeqCst);
-        });
-        self.treadmill.enumerate_objects(&mut enumator);
-    }
-
-    pub fn set_side_log_bits(&self) {
-        debug_assert!(self.treadmill.is_from_space_empty());
-        debug_assert!(self.treadmill.is_nursery_empty());
-        let mut enumator = ClosureObjectEnumerator::<_, VM>::new(|object| {
-            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
-        });
-        self.treadmill.enumerate_objects(&mut enumator);
     }
 
     pub fn prepare(&mut self, full_heap: bool) {

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -181,6 +181,14 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
         enumerator.visit_address_range(self.start, self.start + self.total_bytes);
     }
+
+    fn clear_side_log_bits(&self) {
+        unimplemented!()
+    }
+
+    fn set_side_log_bits(&self) {
+        unimplemented!()
+    }
 }
 
 use crate::plan::{ObjectQueue, VectorObjectQueue};

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -143,6 +143,14 @@ impl<VM: VMBinding> Space<VM> for MarkCompactSpace<VM> {
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
         object_enum::enumerate_blocks_from_monotonic_page_resource(enumerator, &self.pr);
     }
+
+    fn clear_side_log_bits(&self) {
+        unimplemented!()
+    }
+
+    fn set_side_log_bits(&self) {
+        unimplemented!()
+    }
 }
 
 impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for MarkCompactSpace<VM> {

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -241,6 +241,14 @@ impl<VM: VMBinding> Space<VM> for MallocSpace<VM> {
     fn enumerate_objects(&self, _enumerator: &mut dyn ObjectEnumerator) {
         unimplemented!()
     }
+
+    fn clear_side_log_bits(&self) {
+        unimplemented!()
+    }
+
+    fn set_side_log_bits(&self) {
+        unimplemented!()
+    }
 }
 
 use crate::scheduler::GCWorker;

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -406,15 +406,7 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
         self.chunk_map.set_allocated(block.chunk(), true);
     }
 
-    pub fn prepare(&mut self, full_heap: bool) {
-        if self.common.needs_log_bit && full_heap {
-            if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC {
-                for chunk in self.chunk_map.all_chunks() {
-                    side.bzero_metadata(chunk.start(), Chunk::BYTES);
-                }
-            }
-        }
-
+    pub fn prepare(&mut self, _full_heap: bool) {
         #[cfg(debug_assertions)]
         self.abandoned_in_gc.lock().unwrap().assert_empty();
 
@@ -425,6 +417,20 @@ impl<VM: VMBinding> MarkSweepSpace<VM> {
             .generate_tasks(|chunk| Box::new(PrepareChunkMap { space, chunk }));
         self.scheduler.work_buckets[crate::scheduler::WorkBucketStage::Prepare]
             .bulk_add(work_packets);
+    }
+
+    pub fn clear_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        for chunk in self.chunk_map.all_chunks() {
+            log_bit.bzero_metadata(chunk.start(), Chunk::BYTES);
+        }
+    }
+
+    pub fn set_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        for chunk in self.chunk_map.all_chunks() {
+            log_bit.bset_metadata(chunk.start(), Chunk::BYTES);
+        }
     }
 
     pub fn release(&mut self) {

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -433,6 +433,14 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
     /// the execution time.  For LOS, it will be cheaper to enumerate individual objects than
     /// scanning VO bits because it is sparse.
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator);
+
+    /// Clear the side log bits for allocated regions in this space.
+    /// This method is only called if the plan knows the log bits are side metadata.
+    fn clear_side_log_bits(&self);
+
+    /// Set the side log bits for allocated regions in this space.
+    /// This method is only called if the plan knows the log bits are side metadata.
+    fn set_side_log_bits(&self);
 }
 
 /// Print the VM map for a space.

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -524,6 +524,8 @@ pub struct CommonSpace<VM: VMBinding> {
     /// This field equals to needs_log_bit in the plan constraints.
     // TODO: This should be a constant for performance.
     pub needs_log_bit: bool,
+    pub unlog_allocated_object: bool,
+    pub unlog_traced_object: bool,
 
     /// A lock used during acquire() to make sure only one thread can allocate.
     pub acquire_lock: Mutex<()>,
@@ -548,6 +550,8 @@ pub struct PlanCreateSpaceArgs<'a, VM: VMBinding> {
     pub name: &'static str,
     pub zeroed: bool,
     pub permission_exec: bool,
+    pub unlog_allocated_object: bool,
+    pub unlog_traced_object: bool,
     pub vmrequest: VMRequest,
     pub global_side_metadata_specs: Vec<SideMetadataSpec>,
     pub vm_map: &'static dyn VMMap,
@@ -594,6 +598,8 @@ impl<VM: VMBinding> CommonSpace<VM> {
             vm_map: args.plan_args.vm_map,
             mmapper: args.plan_args.mmapper,
             needs_log_bit: args.plan_args.constraints.needs_log_bit,
+            unlog_allocated_object: args.plan_args.unlog_allocated_object,
+            unlog_traced_object: args.plan_args.unlog_traced_object,
             gc_trigger: args.plan_args.gc_trigger,
             metadata: SideMetadataContext {
                 global: args.plan_args.global_side_metadata_specs,

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -61,7 +61,7 @@ impl<VM: VMBinding> SFT for VMSpace<VM> {
     fn initialize_object_metadata(&self, object: ObjectReference, _alloc: bool) {
         self.mark_state
             .on_object_metadata_initialization::<VM>(object);
-        if self.common.needs_log_bit {
+        if self.common.unlog_allocated_object {
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(object, Ordering::SeqCst);
         }
         #[cfg(feature = "vo_bit")]
@@ -271,6 +271,22 @@ impl<VM: VMBinding> VMSpace<VM> {
         self.mark_state.on_global_release::<VM>();
     }
 
+    pub fn clear_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        let external_pages = self.pr.get_external_pages();
+        for ep in external_pages.iter() {
+            log_bit.bzero_metadata(ep.start, ep.end - ep.start);
+        }
+    }
+
+    pub fn set_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        let external_pages = self.pr.get_external_pages();
+        for ep in external_pages.iter() {
+            log_bit.bset_metadata(ep.start, ep.end - ep.start);
+        }
+    }
+
     pub fn trace_object<Q: ObjectQueue>(
         &self,
         queue: &mut Q,
@@ -287,7 +303,7 @@ impl<VM: VMBinding> VMSpace<VM> {
             // Flip the per-object unlogged bits to "unlogged" state for objects inside the
             // bootimage
             #[cfg(feature = "set_unlog_bits_vm_space")]
-            if self.common.needs_log_bit {
+            if self.common.unlog_traced_object {
                 VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.store_atomic::<VM, u8>(
                     object,
                     1,

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -154,6 +154,22 @@ impl<VM: VMBinding> Space<VM> for VMSpace<VM> {
             enumerator.visit_address_range(ep.start, ep.end);
         }
     }
+
+    fn clear_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        let external_pages = self.pr.get_external_pages();
+        for ep in external_pages.iter() {
+            log_bit.bzero_metadata(ep.start, ep.end - ep.start);
+        }
+    }
+
+    fn set_side_log_bits(&self) {
+        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
+        let external_pages = self.pr.get_external_pages();
+        for ep in external_pages.iter() {
+            log_bit.bset_metadata(ep.start, ep.end - ep.start);
+        }
+    }
 }
 
 use crate::scheduler::GCWorker;
@@ -269,22 +285,6 @@ impl<VM: VMBinding> VMSpace<VM> {
 
     pub fn release(&mut self) {
         self.mark_state.on_global_release::<VM>();
-    }
-
-    pub fn clear_side_log_bits(&self) {
-        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
-        let external_pages = self.pr.get_external_pages();
-        for ep in external_pages.iter() {
-            log_bit.bzero_metadata(ep.start, ep.end - ep.start);
-        }
-    }
-
-    pub fn set_side_log_bits(&self) {
-        let log_bit = VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.extract_side_spec();
-        let external_pages = self.pr.get_external_pages();
-        for ep in external_pages.iter() {
-            log_bit.bset_metadata(ep.start, ep.end - ep.start);
-        }
     }
 
     pub fn trace_object<Q: ObjectQueue>(

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -120,7 +120,7 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
             ));
         }
         // If we are copying objects in mature space, we would need to mark the object as mature.
-        if semantics.is_mature() && self.config.constraints.needs_log_bit {
+        if semantics.is_mature() && self.config.constraints.unlog_traced_object {
             // If the plan uses unlogged bit, we set the unlogged bit (the object is unlogged/mature)
             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
                 .mark_byte_as_unlogged::<VM>(object, Ordering::Relaxed);

--- a/src/util/copy/mod.rs
+++ b/src/util/copy/mod.rs
@@ -14,7 +14,6 @@ use crate::util::{Address, ObjectReference};
 use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use crate::MMTK;
-use std::sync::atomic::Ordering;
 
 use enum_map::Enum;
 use enum_map::EnumMap;
@@ -118,12 +117,6 @@ impl<VM: VMBinding> GCWorkerCopyContext<VM> {
             debug_assert!(!object_forwarding::is_forwarded_or_being_forwarded::<VM>(
                 object
             ));
-        }
-        // If we are copying objects in mature space, we would need to mark the object as mature.
-        if semantics.is_mature() && self.config.constraints.unlog_traced_object {
-            // If the plan uses unlogged bit, we set the unlogged bit (the object is unlogged/mature)
-            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
-                .mark_byte_as_unlogged::<VM>(object, Ordering::Relaxed);
         }
         // Policy specific post copy.
         match self.config.copy_mapping[semantics] {


### PR DESCRIPTION
This PR refactors the log bits: the current implementation assumes log bits are used for generational plans, and they carry generation semantics. This PR removes such assumptions.

With this PR, log bits are global metadata, and its semantic is defined by the plans. A plan may directly manipulate log bits, and may tell policies how to deal with log bits. A policy should never assume the semantics of log bits, and they just do whatever they are instructed to.

Some policies assume the log bit may be in the side, and this PR does not try to address this issue.