### PR TITLE
Fix Clippy 1.89 warnings

### DIFF
--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -410,7 +410,7 @@ impl<VM: VMBinding> CreateSpecificPlanArgs<'_, VM> {
         zeroed: bool,
         permission_exec: bool,
         vmrequest: VMRequest,
-    ) -> PlanCreateSpaceArgs<VM> {
+    ) -> PlanCreateSpaceArgs<'_, VM> {
         PlanCreateSpaceArgs {
             name,
             zeroed,

--- a/src/scheduler/worker.rs
+++ b/src/scheduler/worker.rs
@@ -111,11 +111,11 @@ const STAT_BORROWED_MSG: &str = "GCWorkerShared.stat is already borrowed.  This 
     the mutator calls harness_begin or harness_end while the GC is running.";
 
 impl<VM: VMBinding> GCWorkerShared<VM> {
-    pub fn borrow_stat(&self) -> AtomicRef<WorkerLocalStat<VM>> {
+    pub fn borrow_stat(&self) -> AtomicRef<'_, WorkerLocalStat<VM>> {
         self.stat.try_borrow().expect(STAT_BORROWED_MSG)
     }
 
-    pub fn borrow_stat_mut(&self) -> AtomicRefMut<WorkerLocalStat<VM>> {
+    pub fn borrow_stat_mut(&self) -> AtomicRefMut<'_, WorkerLocalStat<VM>> {
         self.stat.try_borrow_mut().expect(STAT_BORROWED_MSG)
     }
 }

--- a/src/util/heap/externalpageresource.rs
+++ b/src/util/heap/externalpageresource.rs
@@ -77,7 +77,7 @@ impl<VM: VMBinding> ExternalPageResource<VM> {
         lock.push(pages);
     }
 
-    pub fn get_external_pages(&self) -> MutexGuard<Vec<ExternalPages>> {
+    pub fn get_external_pages(&self) -> MutexGuard<'_, Vec<ExternalPages>> {
         self.ranges.lock().unwrap()
     }
 }

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -268,7 +268,7 @@ impl Map32 {
     /// Get a mutable reference to the inner Map32Inner with a lock.
     /// The caller should only use the mutable reference while holding the lock.
     #[allow(clippy::mut_from_ref)]
-    fn mut_self_with_sync(&self) -> (MutexGuard<()>, &mut Map32Inner) {
+    fn mut_self_with_sync(&self) -> (MutexGuard<'_, ()>, &mut Map32Inner) {
         let guard = self.sync.lock().unwrap();
         (guard, unsafe { self.mut_self() })
     }


### PR DESCRIPTION
Clippy 1.89 starts to warn about `mismatched_lifetime_syntaxes`.  We fix our function signatures by adding `'_` in the return types.