### PR TITLE
Use `bytemuck::Zeroable` for zeroable types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 atomic = "0.6.0"
 atomic_refcell = "0.1.7"
 atomic-traits = "0.4.0"
-bytemuck = { version = "1.14.0", features = ["derive"] }
+bytemuck = { version = "1.14.0", features = ["derive", "zeroable_maybe_uninit"] }
 bytemuck_derive = "=1.8.1" # We can remove this dependency when we use MSRV 1.84+
 cfg-if = "1.0"
 crossbeam = "0.8.1"

--- a/src/util/heap/blockpageresource.rs
+++ b/src/util/heap/blockpageresource.rs
@@ -198,7 +198,7 @@ struct BlockQueue<B: Region> {
 impl<B: Region> BlockQueue<B> {
     /// Create an array
     fn new() -> Self {
-        let zeroed_vec = unsafe { new_zeroed_vec(Self::CAPACITY) };
+        let zeroed_vec = new_zeroed_vec(Self::CAPACITY);
         let boxed_slice = zeroed_vec.into_boxed_slice();
         let data = UnsafeCell::new(boxed_slice);
         Self {

--- a/src/util/heap/layout/map32.rs
+++ b/src/util/heap/layout/map32.rs
@@ -7,6 +7,7 @@ use crate::util::heap::layout::heap_parameters::*;
 use crate::util::heap::layout::vm_layout::*;
 use crate::util::heap::space_descriptor::SpaceDescriptor;
 use crate::util::int_array_freelist::IntArrayFreeList;
+use crate::util::rust_util::zeroed_alloc::new_zeroed_vec;
 use crate::util::Address;
 use std::cell::UnsafeCell;
 use std::sync::{Mutex, MutexGuard};
@@ -43,7 +44,8 @@ impl Map32 {
                 shared_discontig_fl_count: 0,
                 total_available_discontiguous_chunks: 0,
                 finalized: false,
-                descriptor_map: vec![SpaceDescriptor::UNINITIALIZED; max_chunks],
+                // This can be big on 64-bit machines.  Use `new_zeroed_vec`.
+                descriptor_map: new_zeroed_vec(max_chunks),
             }),
             sync: Mutex::new(()),
         }

--- a/src/util/heap/layout/two_level_mmapper.rs
+++ b/src/util/heap/layout/two_level_mmapper.rs
@@ -10,6 +10,7 @@ use crate::util::conversions;
 use crate::util::heap::layout::vm_layout::*;
 use crate::util::memory::{MmapAnnotation, MmapStrategy};
 use crate::util::rust_util::atomic_box::OnceOptionBox;
+use crate::util::rust_util::zeroed_alloc::new_zeroed_vec;
 use crate::util::Address;
 use atomic::{Atomic, Ordering};
 use std::fmt;
@@ -248,7 +249,7 @@ impl TwoLevelMmapper {
     pub fn new() -> Self {
         Self {
             transition_lock: Default::default(),
-            slabs: unsafe { crate::util::rust_util::zeroed_alloc::new_zeroed_vec(MAX_SLABS) },
+            slabs: new_zeroed_vec(MAX_SLABS),
         }
     }
 

--- a/src/util/heap/space_descriptor.rs
+++ b/src/util/heap/space_descriptor.rs
@@ -1,3 +1,5 @@
+use bytemuck::Zeroable;
+
 use crate::util::constants::*;
 use crate::util::heap::layout::vm_layout::{self, vm_layout};
 use crate::util::Address;
@@ -26,7 +28,10 @@ static DISCONTIGUOUS_SPACE_INDEX: AtomicUsize = AtomicUsize::new(DISCONTIG_INDEX
 const DISCONTIG_INDEX_INCREMENT: usize = 1 << TYPE_BITS;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(transparent)]
 pub struct SpaceDescriptor(usize);
+
+unsafe impl Zeroable for SpaceDescriptor {}
 
 impl SpaceDescriptor {
     pub const UNINITIALIZED: Self = SpaceDescriptor(0);

--- a/src/util/rust_util/atomic_box.rs
+++ b/src/util/rust_util/atomic_box.rs
@@ -1,5 +1,7 @@
 use std::sync::atomic::{AtomicPtr, Ordering};
 
+use bytemuck::Zeroable;
+
 /// A lazily initialized box.  Similar to an `Option<Box<T>>`, but can be initialized atomically.
 ///
 /// It is designed for implementing shared data.  Therefore, methods with `&self`, namely
@@ -81,6 +83,8 @@ impl<T> Drop for OnceOptionBox<T> {
         }
     }
 }
+
+unsafe impl<T> Zeroable for OnceOptionBox<T> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/util/rust_util/zeroed_alloc.rs
+++ b/src/util/rust_util/zeroed_alloc.rs
@@ -1,12 +1,16 @@
 //! This module is for allocating large arrays or vectors with initial zero values.
 //!
+//! Currently we use the [`Zeroable`] trait from the `bytemuck` crate to label types that are safe
+//! for zero initialization.  If one day Rust provides a standard way to optimize for zeroed
+//! allocation of vectors of composite types, we can switch to the standard mechanism.
+//!
 //! Note: The standard library uses the `IsZero` trait to specialize the intialization of `Vec<T>`
 //! if the initial element values are zero.  Primitive type, such as `i8`, `usize`, `f32`, as well
-//! as types with known representations such as `Option<NonZeroUsize>` implement the `IsZero`
-//! trait.  However, it has several limitations.
+//! as types with known representations such as `Option<NonZeroUsize>` implement the `IsZero` trait.
+//! However, it has several limitations.
 //!
-//! 1.  Composite types, such as `SpaceDescriptor(usize)`, doesn't implement the `IsZero` trait,
-//!     even if it has the `#[repr(transparent)]` annotation.
+//! 1.  Composite types, such as `SpaceDescriptor(usize)`, don't implement the `IsZero` trait, even
+//!     if they have the `#[repr(transparent)]` annotation.
 //! 2.  The `IsZero` trait is private to the `std` module, and we cannot use it.
 //!
 //! Therefore, `vec![0usize; 33554432]` takes only 4 **microseconds**, while
@@ -14,22 +18,19 @@
 //! If such an allocation happens during start-up, the delay will be noticeable to light-weight
 //! scripting languages, such as Ruby.
 //!
-//! *(Note: We no longer allocate such large vecs at start-up.  We keep this module in case we need
-//! to allocate large vectors in the future.)*
-//!
-//! We implement our own fast allocation of large zeroed vectors in this module.  If one day Rust
-//! provides a standard way to optimize for zeroed allocation of vectors of composite types, we
-//! can switch to the standard mechanism.
-use std::alloc::{alloc_zeroed, Layout};
+//! The [`new_zeroed_vec`] function in this module can allocate zeroed vectors as fast as `vec![0;
+//! LEN]`;
+use std::alloc::{alloc_zeroed, handle_alloc_error, Layout};
 
-/// Allocate a `Vec<T>` of all-zero values.
+use bytemuck::Zeroable;
+
+/// Allocate a `Vec<T>` of all-zero values.  `T` must implement [`bytemuck::Zeroable`].
 ///
 /// This intends to be a faster alternative to `vec![T(0), size]`.  It will allocate pre-zeroed
 /// buffer, and not store zero values to its elements as part of initialization.
 ///
 /// It is useful when creating large (hundreds of megabytes) Vecs when the execution time is
 /// critical (such as during start-up, where a 100ms delay is obvious to small applications.)
-/// However, because of its unsafe nature, it should only be used when necessary.
 ///
 /// Arguments:
 ///
@@ -37,13 +38,11 @@ use std::alloc::{alloc_zeroed, Layout};
 /// -   `size`: The length and capacity of the created vector.
 ///
 /// Returns the created vector.
-///
-/// # Unsafe
-///
-/// This function is unsafe.  It will not call any constructor of `T`.  The user must ensure
-/// that a value with all bits being zero is meaningful for type `T`.
-pub(crate) unsafe fn new_zeroed_vec<T>(size: usize) -> Vec<T> {
+pub(crate) fn new_zeroed_vec<T: Zeroable>(size: usize) -> Vec<T> {
     let layout = Layout::array::<T>(size).unwrap();
-    let ptr = alloc_zeroed(layout) as *mut T;
-    Vec::from_raw_parts(ptr, size, size)
+    let ptr = unsafe { alloc_zeroed(layout) } as *mut T;
+    if ptr.is_null() {
+        handle_alloc_error(layout);
+    }
+    unsafe { Vec::from_raw_parts(ptr, size, size) }
 }


### PR DESCRIPTION
Our utility function `zeroed_alloc::new_zeroed_vec<T>` now requires the element type `<T>` to implement `bytemuck::Zeroable`, a marker trait which means the type can be safely initialized with all zero bits. `new_zeroed_vec` is no longer `unsafe`.

`SpaceDescriptor` now implements `Zeroable` because a zero value represents `SpaceDescriptor::UNINITIALIZED`.

`Map32` now uses `new_zeroed_vec` for allocating the `descriptor_map` because when used on 64-bit machines (usually with compressed pointers), the number of chunks can still be large.