### PR TITLE
eBPF probes for finalization and reference processing

### DIFF
--- a/src/util/reference_processor.rs
+++ b/src/util/reference_processor.rs
@@ -435,13 +435,7 @@ impl ReferenceProcessor {
             }
         }
 
-        probe!(
-            mmtk,
-            reference_retained,
-            num_refs,
-            num_live,
-            num_retained,
-        );
+        probe!(mmtk, reference_retained, num_refs, num_live, num_retained,);
 
         debug!("Ending ReferenceProcessor.retain({:?})", self.semantics);
     }

--- a/tools/tracing/README.md
+++ b/tools/tracing/README.md
@@ -58,6 +58,18 @@ Currently, the core provides the following tracepoints.
 -   `mmtk:alloc_slow_once_end()`: the allocation slow path ends.
 -   `mmtk:plan_end_of_gc_begin()`: before executing `Plan::end_of_gc`.
 -   `mmtk:plan_end_of_gc_end()`: after executing `Plan::end_of_gc`.
+-   `mmtk:finalization(cb: int, ce: int, rb: int, re: int)`: a `Finalization` work packet.  The
+    arguments are the number of candidates at the beginning and the end of the work packet, and the
+    number of ready-to-finalize objects at the beginning and the end of the work packet.
+-   `mmtk:reference_scanned(semantics: int, old: int, new: int, enqueued: int)`: An invocation of
+    `ReferenceProcessor::scan`.  `semantics` is the semantics.  `old` and `new` are the number of
+    references of this semantics before and other this invocation, and `eneueue` is the number of
+    references enqueued.
+-   `mmtk:reference_retained(num_refs: int, num_live: int, num_retained: int)`: An invocation of
+    `ReferenceProcessor::retain`.  `num_refs` is the total number of reference objects visited.
+    `num_live` is the number of live reference objects, and `num_retained` is the number of
+    referents retained.
+
 
 ## Tracing tools
 

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -124,4 +124,16 @@ usdt:$MMTK:mmtk:sweep_chunk {
     }
 }
 
+usdt:$MMTK:mmtk:finalization {
+    if (@enable_print) {
+        printf("finalization,meta,%d,%lu,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2, arg3);
+    }
+}
+
+usdt:$MMTK:mmtk:reference_scanned {
+    if (@enable_print) {
+        printf("reference_scanned,meta,%d,%lu,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2, arg3);
+    }
+}
+
 // vim: ft=bpftrace ts=4 sw=4 sts=4 et

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -136,4 +136,10 @@ usdt:$MMTK:mmtk:reference_scanned {
     }
 }
 
+usdt:$MMTK:mmtk:reference_retained {
+    if (@enable_print) {
+        printf("reference_retained,meta,%d,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2);
+    }
+}
+
 // vim: ft=bpftrace ts=4 sw=4 sts=4 et

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -277,6 +277,13 @@ class LogProcessor:
                         "num_enqueued": int(args[3]),
                     })
 
+                case "reference_retained":
+                    wp["args"] |= {
+                        "num_refs": int(args[0]),
+                        "num_live": int(args[1]),
+                        "num_retained": int(args[2]),
+                    }
+
                 case _:
                     processed_for_wp = False
         else:

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -17,6 +17,11 @@ class RootsKind(Enum):
     PINNING = 1
     TPINNING = 2
 
+class Semantics(Enum):
+    SOFT = 0
+    WEAK = 1
+    PHANTOM = 2
+
 def get_args():
     parser = argparse.ArgumentParser(
             description="""
@@ -28,6 +33,11 @@ by Perfetto UI.
                         help="path to extra log line handler")
     parser.add_argument("input", type=str, help="Input file"),
     return parser.parse_args()
+
+def begin_end_diff_dict(begin, end, begin_key="begin", end_key="end", diff_key="diff"):
+    """ A convenient method for construct a dict of two values and their difference. """
+    diff = end - begin
+    return {begin_key: begin, end_key: end, diff_key: diff}
 
 class LogProcessor:
     def __init__(self):
@@ -246,6 +256,27 @@ class LogProcessor:
                         "allocated_blocks": int(args[0]),
                     }
 
+                case "finalization":
+                    wp["args"] |= {
+                        "num_candidates": begin_end_diff_dict(int(args[0]), int(args[1])),
+                        "ready_for_finalize": begin_end_diff_dict(int(args[2]), int(args[3])),
+                    }
+
+                case "reference_scanned":
+                    semantics_int = int(args[0])
+                    if semantics_int in Semantics:
+                        semantics_str = Semantics(semantics_int).name
+                    else:
+                        semantics_str = "(Unknown)"
+                    if "reference_scanned" not in wp["args"]:
+                        wp["args"]["reference_scanned"] = []
+                    wp["args"]["reference_scanned"].append({
+                        "semantics": semantics_str,
+                        "num_old": int(args[1]),
+                        "num_new": int(args[2]),
+                        "num_enqueued": int(args[3]),
+                    })
+
                 case _:
                     processed_for_wp = False
         else:
@@ -289,7 +320,6 @@ class LogProcessor:
         print(f"Dumping JSON output to {output_name}")
         with gzip.open(output_name, "wt") as f:
             self.output(f)
-
 
 def main():
     args = get_args()


### PR DESCRIPTION
We add some eBPF probes to show more details of finalization and reference processing in the MMTk core, including the number of finalizable objects processed and the number of references scanned or retained in various work packets.