### PR TITLE
Remove unused methods and types related to memory mapping

### DIFF
--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -339,22 +339,6 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         }
     }
 
-    /// Ensure this space is marked as mapped -- used when the space is already
-    /// mapped (e.g. for a vm image which is externally mmapped.)
-    fn ensure_mapped(&self) {
-        self.common()
-            .metadata
-            .try_map_metadata_space(self.common().start, self.common().extent, self.get_name())
-            .unwrap_or_else(|e| {
-                // TODO(Javad): handle meta space allocation failure
-                panic!("failed to mmap meta memory: {e}");
-            });
-
-        self.common()
-            .mmapper
-            .mark_as_mapped(self.common().start, self.common().extent);
-    }
-
     /// Estimate the amount of side metadata memory needed for a give data memory size in pages. The
     /// result will over-estimate the amount of metadata pages needed, with at least one page per
     /// side metadata.  This relatively accurately describes the number of side metadata pages the

--- a/src/util/heap/freelistpageresource.rs
+++ b/src/util/heap/freelistpageresource.rs
@@ -219,8 +219,6 @@ impl<VM: VMBinding> FreeListPageResource<VM> {
         // > (e.g., read versus read/write protection) exceeding the
         // > allowed maximum.
         assert!(self.protect_memory_on_release.is_some());
-        // We are not using mmapper.protect(). mmapper.protect() protects the whole chunk and
-        // may protect memory that is still in use.
         if let Err(e) = memory::mprotect(start, conversions::pages_to_bytes(pages)) {
             panic!(
                 "Failed at protecting memory (starting at {}): {:?}",

--- a/src/util/heap/layout/mmapper/mod.rs
+++ b/src/util/heap/layout/mmapper/mod.rs
@@ -15,10 +15,10 @@ pub mod csm;
 /// [`Mmapper::granularity()`].  Methods that take memory ranges as arguments will round the range
 /// to the overlapping chunks.
 ///
-/// Memory ranges managed by `Mmapper` has three states: Unmapped, Quarantined, and Mapped.  The
-/// state transition graph is:
+/// From the perspective of the `Mmapper`, each memory range can be in one of the three states:
+/// Unmapped, Quarantined, and Mapped.  The state transition graph is:
 ///
-/// ```
+/// ```text
 /// ┌────────┐  ensure_mapped / mark_as_mapped    ┌──────┐
 /// │Unmapped├────────────────────────────────────►Mapped│
 /// └───┬────┘                                    └───▲──┘
@@ -26,6 +26,13 @@ pub mod csm;
 ///     └───────────────►Quarantined├─────────────────┘
 ///         quarantine  └───────────┘  ensure_mapped
 /// ```
+///
+/// -   **Unmapped** means the memory is not mapped by the `Mmapper`, and may be mapped by other
+///     components of the process.
+/// -   **Quarantined** means the `Mmapper` has reserved the memory for MMTk, usually by using
+///     `mmap` with `PROT_NONE`.
+/// -   **Mapped** means `Mmapper` has mapped the memory, and the memory can be read and written by
+///     MMTk.
 pub trait Mmapper: Sync {
     /// The logarithm of granularity of this `Mmapper`, in bytes.  Must be at least
     /// [`LOG_BYTES_IN_PAGE`].


### PR DESCRIPTION
We remove the `protect` method and the `Mmapper::Protected` state.  This is because Mmapper cannot protect the memory at the granularity desired by its users.  Spaces that wish to protect pages of memory should directly call `mprotect` while the space still owns the memory.

We also remove the unused `eagerly_mmap_all_spaces` method.  It has never been implemented or used since it was added to JikesRVM MMTk.

We also remove `Space::ensure_mapped`.  It was used for the boot image back in JikesRVM.  We now use the `VMSpace` for boot images, and it can call `MMAPPER.mark_as_mapped` to mark the memory as mapped in the `Mmapper` without actually calling `mmap`, assuming the VM has already mapped the memory.  So we remove the redundant `Space::ensure_mapped` method.

Fixes: https://github.com/mmtk/mmtk-core/issues/1348