### PR TITLE
Use canary binary

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.8.3"
+          ref: "0.8.4"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
+          ref: "0.8.4"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
+          ref: "0.8.4"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -112,7 +112,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.8.3"
+              ref: "0.8.4"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -219,7 +219,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.8.3"
+                ref: "0.8.4"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -8,90 +8,90 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'self-hosted'
+  RESULT_REPO_BRANCH: 'test'
   # Whether we deploy the generated page. Set to true for master.
-  DEPLOY: true
+  DEPLOY: false
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
 
 jobs:
   # JikesRVM
-  jikesrvm-perf-regression:
-    runs-on: [self-hosted, Linux, freq-scaling-off]
-    timeout-minutes: 1440
-    steps:
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v4
-        with:
-          path: mmtk-core
-      - name: Checkout JikesRVM Binding
-        uses: actions/checkout@v4
-        with:
-          repository: mmtk/mmtk-jikesrvm
-          path: mmtk-jikesrvm
-      - name: Checkout JikesRVM
-        working-directory: mmtk-jikesrvm
-        run: |
-          ./.github/scripts/ci-checkout.sh
-      # checkout perf-kit
-      - name: Checkout Perf Kit
-        uses: actions/checkout@v4
-        with:
-          repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
-          path: ci-perf-kit
-          token: ${{ secrets.CI_ACCESS_TOKEN }}
-          submodules: true
-      # setup
-      - name: Overwrite MMTk core in JikesRVM binding
-        run: cp -r mmtk-core mmtk-jikesrvm/repos/
-      - name: Setup Rust Toolchain
-        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-      - name: Setup
-        run: |
-          ./ci-perf-kit/scripts/history-run-setup.sh
-          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-jikesrvm/mmtk/Cargo.toml
-          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-jikesrvm/mmtk/Cargo.toml
-      - id: branch
-        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
-      # run
-      - name: Performance Run
-        run: |
-          export RESULT_REPO=mmtk/ci-perf-result
-          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-          export FROM_DATE=2020-07-10
-          JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
-      # deploy
-      - name: Deploy to Github Page
-        if: ${{ env.DEPLOY == 'true' }}
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-          external_repository: mmtk/ci-perf-result
-          publish_dir: ./reports
-          publish_branch: gh-pages
-          keep_files: true
-      - name: Upload build as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: jikesrvm-regression-build
-          path: ${{ env.CI_PERF_KIT_BUILD }}
-          if-no-files-found: error
-      - name: Upload logs as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: jikesrvm-regression-logs
-          path: ${{ env.CI_PERF_KIT_LOG }}
-          if-no-files-found: error
+  # jikesrvm-perf-regression:
+  #   runs-on: [self-hosted, Linux, freq-scaling-off]
+  #   timeout-minutes: 1440
+  #   steps:
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v4
+  #       with:
+  #         path: mmtk-core
+  #     - name: Checkout JikesRVM Binding
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: mmtk/mmtk-jikesrvm
+  #         path: mmtk-jikesrvm
+  #     - name: Checkout JikesRVM
+  #       working-directory: mmtk-jikesrvm
+  #       run: |
+  #         ./.github/scripts/ci-checkout.sh
+  #     # checkout perf-kit
+  #     - name: Checkout Perf Kit
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: mmtk/ci-perf-kit
+  #         ref: "0.8.3"
+  #         path: ci-perf-kit
+  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         submodules: true
+  #     # setup
+  #     - name: Overwrite MMTk core in JikesRVM binding
+  #       run: cp -r mmtk-core mmtk-jikesrvm/repos/
+  #     - name: Setup Rust Toolchain
+  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+  #     - name: Setup
+  #       run: |
+  #         ./ci-perf-kit/scripts/history-run-setup.sh
+  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-jikesrvm/mmtk/Cargo.toml
+  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-jikesrvm/mmtk/Cargo.toml
+  #     - id: branch
+  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+  #       run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
+  #     # run
+  #     - name: Performance Run
+  #       run: |
+  #         export RESULT_REPO=mmtk/ci-perf-result
+  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+  #         export FROM_DATE=2020-07-10
+  #         JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
+  #     # deploy
+  #     - name: Deploy to Github Page
+  #       if: ${{ env.DEPLOY == 'true' }}
+  #       uses: peaceiris/actions-gh-pages@v4
+  #       with:
+  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         external_repository: mmtk/ci-perf-result
+  #         publish_dir: ./reports
+  #         publish_branch: gh-pages
+  #         keep_files: true
+  #     - name: Upload build as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: jikesrvm-regression-build
+  #         path: ${{ env.CI_PERF_KIT_BUILD }}
+  #         if-no-files-found: error
+  #     - name: Upload logs as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: jikesrvm-regression-logs
+  #         path: ${{ env.CI_PERF_KIT_LOG }}
+  #         if-no-files-found: error
 
   # OpenJDK
   openjdk-perf-regression:
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
+          ref: "use-canary-binary"
           path: ci-perf-kit
           submodules: true
       # download canary build -- assume we have build.zip for the canary version in mmtk-openjdk
@@ -200,78 +200,78 @@ jobs:
           path: ${{ env.CI_PERF_KIT_LOG }}
           if-no-files-found: error
 
-  openjdk-mutator-perf:
-    runs-on: [self-hosted, Linux, freq-scaling-off]
-    timeout-minutes: 1440
-    steps:
-      - name: Checkout MMTk Core
-        uses: actions/checkout@v4
-        with:
-          path: mmtk-core
-      - name: Checkout OpenJDK Binding
-        uses: actions/checkout@v4
-        with:
-          repository: mmtk/mmtk-openjdk
-          path: mmtk-openjdk
-      - name: Checkout OpenJDK
-        working-directory: mmtk-openjdk
-        run: |
-          ./.github/scripts/ci-checkout.sh
-      # checkout perf-kit
-      - name: Checkout Perf Kit
-        uses: actions/checkout@v4
-        with:
-          repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
-          path: ci-perf-kit
-          token: ${{ secrets.CI_ACCESS_TOKEN }}
-          submodules: true
-      # setup
-      - name: Overwrite MMTk core in openjdk binding
-        run: cp -r mmtk-core mmtk-openjdk/repos/
-      - name: Setup Rust Toolchain
-        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-      # cleanup previosu build
-      - name: Cleanup previous build
-        run: |
-          rm -rf mmtk-openjdk/repos/openjdk/scratch
-          rm -rf mmtk-openjdk/repos/openjdk/build
-      - id: branch
-        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
-      - name: Setup
-        run: |
-          ./ci-perf-kit/scripts/history-run-setup.sh
-          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
-          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
-      # run
-      - name: Performance Run
-        run: |
-          export RESULT_REPO=mmtk/ci-perf-result
-          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-          export FROM_DATE=2020-08-03
-          export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
-          ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
-      # deploy
-      - name: Deploy to Github Page
-        if: ${{ env.DEPLOY == 'true' }}
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-          external_repository: mmtk/ci-perf-result
-          publish_dir: ./reports
-          publish_branch: gh-pages
-          keep_files: true
-      - name: Upload build as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: mutator-regression-build
-          path: ${{ env.CI_PERF_KIT_BUILD }}
-          if-no-files-found: error
-      - name: Upload logs as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: mutator-regression-logs
-          path: ${{ env.CI_PERF_KIT_LOG }}
-          if-no-files-found: error
+  # openjdk-mutator-perf:
+  #   runs-on: [self-hosted, Linux, freq-scaling-off]
+  #   timeout-minutes: 1440
+  #   steps:
+  #     - name: Checkout MMTk Core
+  #       uses: actions/checkout@v4
+  #       with:
+  #         path: mmtk-core
+  #     - name: Checkout OpenJDK Binding
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: mmtk/mmtk-openjdk
+  #         path: mmtk-openjdk
+  #     - name: Checkout OpenJDK
+  #       working-directory: mmtk-openjdk
+  #       run: |
+  #         ./.github/scripts/ci-checkout.sh
+  #     # checkout perf-kit
+  #     - name: Checkout Perf Kit
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: mmtk/ci-perf-kit
+  #         ref: "0.8.3"
+  #         path: ci-perf-kit
+  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         submodules: true
+  #     # setup
+  #     - name: Overwrite MMTk core in openjdk binding
+  #       run: cp -r mmtk-core mmtk-openjdk/repos/
+  #     - name: Setup Rust Toolchain
+  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+  #     # cleanup previosu build
+  #     - name: Cleanup previous build
+  #       run: |
+  #         rm -rf mmtk-openjdk/repos/openjdk/scratch
+  #         rm -rf mmtk-openjdk/repos/openjdk/build
+  #     - id: branch
+  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+  #       run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
+  #     - name: Setup
+  #       run: |
+  #         ./ci-perf-kit/scripts/history-run-setup.sh
+  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
+  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
+  #     # run
+  #     - name: Performance Run
+  #       run: |
+  #         export RESULT_REPO=mmtk/ci-perf-result
+  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+  #         export FROM_DATE=2020-08-03
+  #         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+  #         ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
+  #     # deploy
+  #     - name: Deploy to Github Page
+  #       if: ${{ env.DEPLOY == 'true' }}
+  #       uses: peaceiris/actions-gh-pages@v4
+  #       with:
+  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+  #         external_repository: mmtk/ci-perf-result
+  #         publish_dir: ./reports
+  #         publish_branch: gh-pages
+  #         keep_files: true
+  #     - name: Upload build as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: mutator-regression-build
+  #         path: ${{ env.CI_PERF_KIT_BUILD }}
+  #         if-no-files-found: error
+  #     - name: Upload logs as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: mutator-regression-logs
+  #         path: ${{ env.CI_PERF_KIT_LOG }}
+  #         if-no-files-found: error

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
+          ref: "0.8.4"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -139,11 +139,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
+          ref: "0.8.4"
           path: ci-perf-kit
           submodules: true
       # download canary build
-      # The tar ball should be the standard release tar ball from `make product-bundles`.
+      # The tarball should be the standard product tarball from `make product-bundles` (see docs/team/release.md).
       - name: Download canary build
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
@@ -230,7 +230,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.3"
+          ref: "0.8.4"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -8,90 +8,90 @@ on:
   # READ BEFORE ENABLING THE TRIGGER BELOW
   # This trigger is only used when testing the scripts in a branch, and should be commented out in other cases.
   # If this trigger is used, please change the following env: RESULT_REPO_BRANCH -> 'test' (MUST), DEPLOY -> 'false' (optional)
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 env:
   # The branch to save run data and plot graph from. Use 'self-hosted' for master, use 'test' or anything else for testing in a branch.
-  RESULT_REPO_BRANCH: 'test'
+  RESULT_REPO_BRANCH: 'self-hosted'
   # Whether we deploy the generated page. Set to true for master.
-  DEPLOY: false
+  DEPLOY: true
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
 
 jobs:
   # JikesRVM
-  # jikesrvm-perf-regression:
-  #   runs-on: [self-hosted, Linux, freq-scaling-off]
-  #   timeout-minutes: 1440
-  #   steps:
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v4
-  #       with:
-  #         path: mmtk-core
-  #     - name: Checkout JikesRVM Binding
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: mmtk/mmtk-jikesrvm
-  #         path: mmtk-jikesrvm
-  #     - name: Checkout JikesRVM
-  #       working-directory: mmtk-jikesrvm
-  #       run: |
-  #         ./.github/scripts/ci-checkout.sh
-  #     # checkout perf-kit
-  #     - name: Checkout Perf Kit
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: mmtk/ci-perf-kit
-  #         ref: "0.8.3"
-  #         path: ci-perf-kit
-  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         submodules: true
-  #     # setup
-  #     - name: Overwrite MMTk core in JikesRVM binding
-  #       run: cp -r mmtk-core mmtk-jikesrvm/repos/
-  #     - name: Setup Rust Toolchain
-  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-  #     - name: Setup
-  #       run: |
-  #         ./ci-perf-kit/scripts/history-run-setup.sh
-  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-jikesrvm/mmtk/Cargo.toml
-  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-jikesrvm/mmtk/Cargo.toml
-  #     - id: branch
-  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-  #       run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
-  #     # run
-  #     - name: Performance Run
-  #       run: |
-  #         export RESULT_REPO=mmtk/ci-perf-result
-  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-  #         export FROM_DATE=2020-07-10
-  #         JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
-  #     # deploy
-  #     - name: Deploy to Github Page
-  #       if: ${{ env.DEPLOY == 'true' }}
-  #       uses: peaceiris/actions-gh-pages@v4
-  #       with:
-  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         external_repository: mmtk/ci-perf-result
-  #         publish_dir: ./reports
-  #         publish_branch: gh-pages
-  #         keep_files: true
-  #     - name: Upload build as artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: jikesrvm-regression-build
-  #         path: ${{ env.CI_PERF_KIT_BUILD }}
-  #         if-no-files-found: error
-  #     - name: Upload logs as artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: jikesrvm-regression-logs
-  #         path: ${{ env.CI_PERF_KIT_LOG }}
-  #         if-no-files-found: error
+  jikesrvm-perf-regression:
+    runs-on: [self-hosted, Linux, freq-scaling-off]
+    timeout-minutes: 1440
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v4
+        with:
+          path: mmtk-core
+      - name: Checkout JikesRVM Binding
+        uses: actions/checkout@v4
+        with:
+          repository: mmtk/mmtk-jikesrvm
+          path: mmtk-jikesrvm
+      - name: Checkout JikesRVM
+        working-directory: mmtk-jikesrvm
+        run: |
+          ./.github/scripts/ci-checkout.sh
+      # checkout perf-kit
+      - name: Checkout Perf Kit
+        uses: actions/checkout@v4
+        with:
+          repository: mmtk/ci-perf-kit
+          ref: "0.8.3"
+          path: ci-perf-kit
+          token: ${{ secrets.CI_ACCESS_TOKEN }}
+          submodules: true
+      # setup
+      - name: Overwrite MMTk core in JikesRVM binding
+        run: cp -r mmtk-core mmtk-jikesrvm/repos/
+      - name: Setup Rust Toolchain
+        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+      - name: Setup
+        run: |
+          ./ci-perf-kit/scripts/history-run-setup.sh
+          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-jikesrvm/mmtk/Cargo.toml
+          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-jikesrvm/mmtk/Cargo.toml
+      - id: branch
+        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
+      # run
+      - name: Performance Run
+        run: |
+          export RESULT_REPO=mmtk/ci-perf-result
+          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+          export FROM_DATE=2020-07-10
+          JAVA_HOME=/opt/jdk1.6.0_45/ PATH=/opt/apache-ant-1.9.16/bin/:/opt/jdk1.6.0_45/bin/:$PATH ./ci-perf-kit/scripts/jikesrvm-history-run.sh ./mmtk-jikesrvm ./reports/${{ steps.branch.outputs.branch_name }}
+      # deploy
+      - name: Deploy to Github Page
+        if: ${{ env.DEPLOY == 'true' }}
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+          external_repository: mmtk/ci-perf-result
+          publish_dir: ./reports
+          publish_branch: gh-pages
+          keep_files: true
+      - name: Upload build as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jikesrvm-regression-build
+          path: ${{ env.CI_PERF_KIT_BUILD }}
+          if-no-files-found: error
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jikesrvm-regression-logs
+          path: ${{ env.CI_PERF_KIT_LOG }}
+          if-no-files-found: error
 
   # OpenJDK
   openjdk-perf-regression:
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "use-canary-binary"
+          ref: "0.8.3"
           path: ci-perf-kit
           submodules: true
       # download canary build
@@ -208,78 +208,78 @@ jobs:
           path: ${{ env.CI_PERF_KIT_LOG }}
           if-no-files-found: error
 
-  # openjdk-mutator-perf:
-  #   runs-on: [self-hosted, Linux, freq-scaling-off]
-  #   timeout-minutes: 1440
-  #   steps:
-  #     - name: Checkout MMTk Core
-  #       uses: actions/checkout@v4
-  #       with:
-  #         path: mmtk-core
-  #     - name: Checkout OpenJDK Binding
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: mmtk/mmtk-openjdk
-  #         path: mmtk-openjdk
-  #     - name: Checkout OpenJDK
-  #       working-directory: mmtk-openjdk
-  #       run: |
-  #         ./.github/scripts/ci-checkout.sh
-  #     # checkout perf-kit
-  #     - name: Checkout Perf Kit
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: mmtk/ci-perf-kit
-  #         ref: "0.8.3"
-  #         path: ci-perf-kit
-  #         token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         submodules: true
-  #     # setup
-  #     - name: Overwrite MMTk core in openjdk binding
-  #       run: cp -r mmtk-core mmtk-openjdk/repos/
-  #     - name: Setup Rust Toolchain
-  #       run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
-  #     # cleanup previosu build
-  #     - name: Cleanup previous build
-  #       run: |
-  #         rm -rf mmtk-openjdk/repos/openjdk/scratch
-  #         rm -rf mmtk-openjdk/repos/openjdk/build
-  #     - id: branch
-  #       # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
-  #       run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
-  #     - name: Setup
-  #       run: |
-  #         ./ci-perf-kit/scripts/history-run-setup.sh
-  #         sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
-  #         sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
-  #     # run
-  #     - name: Performance Run
-  #       run: |
-  #         export RESULT_REPO=mmtk/ci-perf-result
-  #         export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
-  #         export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
-  #         export FROM_DATE=2020-08-03
-  #         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
-  #         ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
-  #     # deploy
-  #     - name: Deploy to Github Page
-  #       if: ${{ env.DEPLOY == 'true' }}
-  #       uses: peaceiris/actions-gh-pages@v4
-  #       with:
-  #         personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
-  #         external_repository: mmtk/ci-perf-result
-  #         publish_dir: ./reports
-  #         publish_branch: gh-pages
-  #         keep_files: true
-  #     - name: Upload build as artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: mutator-regression-build
-  #         path: ${{ env.CI_PERF_KIT_BUILD }}
-  #         if-no-files-found: error
-  #     - name: Upload logs as artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: mutator-regression-logs
-  #         path: ${{ env.CI_PERF_KIT_LOG }}
-  #         if-no-files-found: error
+  openjdk-mutator-perf:
+    runs-on: [self-hosted, Linux, freq-scaling-off]
+    timeout-minutes: 1440
+    steps:
+      - name: Checkout MMTk Core
+        uses: actions/checkout@v4
+        with:
+          path: mmtk-core
+      - name: Checkout OpenJDK Binding
+        uses: actions/checkout@v4
+        with:
+          repository: mmtk/mmtk-openjdk
+          path: mmtk-openjdk
+      - name: Checkout OpenJDK
+        working-directory: mmtk-openjdk
+        run: |
+          ./.github/scripts/ci-checkout.sh
+      # checkout perf-kit
+      - name: Checkout Perf Kit
+        uses: actions/checkout@v4
+        with:
+          repository: mmtk/ci-perf-kit
+          ref: "0.8.3"
+          path: ci-perf-kit
+          token: ${{ secrets.CI_ACCESS_TOKEN }}
+          submodules: true
+      # setup
+      - name: Overwrite MMTk core in openjdk binding
+        run: cp -r mmtk-core mmtk-openjdk/repos/
+      - name: Setup Rust Toolchain
+        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
+      # cleanup previosu build
+      - name: Cleanup previous build
+        run: |
+          rm -rf mmtk-openjdk/repos/openjdk/scratch
+          rm -rf mmtk-openjdk/repos/openjdk/build
+      - id: branch
+        # we cannot use env vars in action input (the deploy step). So put the env var to this step's outputs.
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_OUTPUT
+      - name: Setup
+        run: |
+          ./ci-perf-kit/scripts/history-run-setup.sh
+          sed -i 's/^mmtk[[:space:]]=/#ci:mmtk=/g' mmtk-openjdk/mmtk/Cargo.toml
+          sed -i 's/^#[[:space:]]mmtk/mmtk/g' mmtk-openjdk/mmtk/Cargo.toml
+      # run
+      - name: Performance Run
+        run: |
+          export RESULT_REPO=mmtk/ci-perf-result
+          export RESULT_REPO_BRANCH=${{ env.RESULT_REPO_BRANCH }}
+          export RESULT_REPO_ACCESS_TOKEN=${{ secrets.CI_ACCESS_TOKEN }}
+          export FROM_DATE=2020-08-03
+          export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+          ./ci-perf-kit/scripts/mutator-history-run.sh ./mmtk-openjdk ./reports/${{ steps.branch.outputs.branch_name }}
+      # deploy
+      - name: Deploy to Github Page
+        if: ${{ env.DEPLOY == 'true' }}
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.CI_ACCESS_TOKEN }}
+          external_repository: mmtk/ci-perf-result
+          publish_dir: ./reports
+          publish_branch: gh-pages
+          keep_files: true
+      - name: Upload build as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutator-regression-build
+          path: ${{ env.CI_PERF_KIT_BUILD }}
+          if-no-files-found: error
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutator-regression-logs
+          path: ${{ env.CI_PERF_KIT_LOG }}
+          if-no-files-found: error

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -139,26 +139,18 @@ jobs:
           ref: "0.8.3"
           path: ci-perf-kit
           submodules: true
-      # checkout canary versions.
-      - name: Checkout MMTk Core (canary)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.CANARY_VERSION }}
-          path: canary/mmtk-core
-      - name: Checkout OpenJDK Binding (canary)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.CANARY_VERSION }}
-          repository: mmtk/mmtk-openjdk
-          path: canary/mmtk-openjdk
-      - name: Checkout OpenJDK (canary)
-        working-directory: canary/mmtk-openjdk
+      # download canary build -- assume we have build.zip for the canary version in mmtk-openjdk
+      # build.zip should include all the directories of a build dir, and should be extracted to a list of directories like bin, conf, include, etc.
+      - name: Download canary build
         run: |
-          ./.github/scripts/ci-checkout.sh
+          mkdir -p ./canary
+          gh release download ${{ env.CANARY_VERSION }} --repo mmtk/mmtk-openjdk --pattern "build.zip" --dir ./canary
+          unzip ./canary/build.zip -d ./canary
+          rm ./canary/build.zip
       # setup
       - name: Setup directory structures
         run: |
-          for BASE_DIR in ./latest ./canary; do
+          for BASE_DIR in ./latest; do
             pushd $BASE_DIR
               # replace dependency
               # Note that ci-replace-mmtk-dep.sh will apply `realpath()` to the `--mmtk-core-path` option.
@@ -183,7 +175,7 @@ jobs:
           export FROM_DATE=2020-07-10
           ./ci-perf-kit/scripts/openjdk-history-run.sh \
             ./latest/mmtk-openjdk \
-            ./canary/mmtk-openjdk \
+            ./canary \
             ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -116,6 +116,9 @@ jobs:
       # available.  Then we may change to another release version and mark the change of canary on
       # the timeline, or introduce a mechanism to dynamically choose the canary version.
       CANARY_VERSION: "v0.28.0"
+      CANARY_RELEASE_BINARY_NAME: "jdk-11.0.19-internal+0_linux-x64_bin.tar.gz"
+      CANARY_JDK_NAME: "jdk-11.0.19"
+      CANARY_DIR: "canary"
     steps:
       # checkout latest versions
       - name: Checkout MMTk Core (latest)
@@ -139,16 +142,19 @@ jobs:
           ref: "use-canary-binary"
           path: ci-perf-kit
           submodules: true
-      # download canary build -- assume we have build.zip for the canary version in mmtk-openjdk
-      # build.zip should include all the directories of a build dir, and should be extracted to a list of directories like bin, conf, include, etc.
+      # download canary build
+      # The tar ball should be the standard release tar ball from `make product-bundles`.
       - name: Download canary build
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          mkdir -p ./canary
-          gh release download ${{ env.CANARY_VERSION }} --repo mmtk/mmtk-openjdk --pattern "build.zip" --dir ./canary
-          unzip ./canary/build.zip -d ./canary
-          rm ./canary/build.zip
+          rm -rf ${{ env.CANARY_DIR }}
+          mkdir -p ${{ env.CANARY_DIR }}
+          gh release download ${{ env.CANARY_VERSION }} --repo mmtk/mmtk-openjdk --pattern "${{ env.CANARY_RELEASE_BINARY_NAME }}" --dir ${{ env.CANARY_DIR }}/images
+          cd ${{ env.CANARY_DIR}}/images
+          tar -xvzf ${{ env.CANARY_RELEASE_BINARY_NAME }}
+          mv ${{ env.CANARY_JDK_NAME }} jdk
+          rm ${{ env.CANARY_RELEASE_BINARY_NAME }}
       # setup
       - name: Setup directory structures
         run: |
@@ -177,7 +183,7 @@ jobs:
           export FROM_DATE=2020-07-10
           ./ci-perf-kit/scripts/openjdk-history-run.sh \
             ./latest/mmtk-openjdk \
-            ./canary \
+            ${{ env.CANARY_DIR }} \
             ./reports/${{ steps.branch.outputs.branch_name }}
       # deploy
       - name: Deploy to Github Page

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -142,6 +142,8 @@ jobs:
       # download canary build -- assume we have build.zip for the canary version in mmtk-openjdk
       # build.zip should include all the directories of a build dir, and should be extracted to a list of directories like bin, conf, include, etc.
       - name: Download canary build
+        env:
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
           mkdir -p ./canary
           gh release download ${{ env.CANARY_VERSION }} --repo mmtk/mmtk-openjdk --pattern "build.zip" --dir ./canary

--- a/docs/team/release.md
+++ b/docs/team/release.md
@@ -72,6 +72,14 @@ Once the PRs are merged, we can tag releases on Github.
 5. Tick 'Set as a pre-release'.
 6. Click 'Publish release'.
 
+#### OpenJDK Binary Release
+
+The OpenJDK binding release should also include the compiled binary packaged as a tarball.
+This tarball is used for the canary build in the performance CI. See [Regression Test Canary](https://github.com/mmtk/mmtk-core/blob/master/docs/team/ci.md#regression-test-canary).
+
+You can generate the tarball using OpenJDK’s `make product-bundles` command (with MMTk).
+Among the generated files, the one with the `*_bin.tar.gz` suffix should be included in the release.
+
 ### Post release checklist
 
 1. Keep an eye on the badges in [README](https://github.com/mmtk/mmtk-core#mmtk)


### PR DESCRIPTION
This PR updates MMTk core CI to use `ci-perf-kit 0.8.4` (https://github.com/mmtk/ci-perf-kit/pull/49). It uses a binary build of our OpenJDK binding releases, as the canary build.