### PR TITLE
Fix LargeObjectSpace::initialize_object_metadata

### DIFF
--- a/src/policy/sft.rs
+++ b/src/policy/sft.rs
@@ -86,6 +86,13 @@ pub trait SFT {
     ) -> Option<ObjectReference>;
 
     /// Initialize object metadata (in the header, or in the side metadata).
+    ///
+    /// Arguments:
+    ///
+    /// * `object`: The object to initialize metadata.
+    /// * `alloc`: `true` if this method is called in `post_alloc` when a mutator is allocating new
+    ///   object using an MMTk allocator. `false` when initializing metadata for objects in the VM
+    ///   space.
     fn initialize_object_metadata(&self, object: ObjectReference, alloc: bool);
 
     /// Trace objects through SFT. This along with [`SFTProcessEdges`](mmtk/scheduler/gc_work/SFTProcessEdges)


### PR DESCRIPTION
It did not set the VO bit when allocating as live (by ConcurrentImmix). We fixed that.  It's always set as long as VO bit is enabled.

We simplified the logic for setting the mark/nursery bits.  We no longer load from the bits.

We always assert the global unlog bit is unset as long as the LOS needs unlog bits.