### PR TITLE
Fix Clippy 1.90 warning

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -690,6 +690,7 @@ impl<E: ProcessEdgesWork> GCWork<E::VM> for E {
 /// performance overheads for using this general trace type. In such cases, they implement their
 /// specific [`ProcessEdgesWork`] instances.
 // TODO: This is not used any more. Should we remove it?
+#[allow(dead_code)]
 pub struct SFTProcessEdges<VM: VMBinding> {
     pub base: ProcessEdgesBase<VM>,
 }

--- a/src/util/opaque_pointer.rs
+++ b/src/util/opaque_pointer.rs
@@ -20,7 +20,7 @@ impl Default for OpaquePointer {
 
 impl OpaquePointer {
     /// Represents an uninitialized value for [`OpaquePointer`].
-    pub const UNINITIALIZED: Self = Self(0 as *mut c_void);
+    pub const UNINITIALIZED: Self = Self(std::ptr::null_mut::<c_void>());
 
     /// Cast an [`Address`] type to an [`OpaquePointer`].
     pub fn from_address(addr: Address) -> Self {


### PR DESCRIPTION
It now warns that `SFTProcessEdges` is unused.  But we still provide the `SFTProcessEdges` work packet so that in the future we can create other plans that use it.

We now define `OpaquePointer::UNINITIALIZED` using `std::ptr::null_mut::<c_void>()`.