### PR TITLE
Remove vim modeline, move current_pause_determined to gc

### DIFF
--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -170,5 +170,3 @@ usdt:$MMTK:mmtk:reference_retained {
         printf("reference_retained,meta,%d,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2);
     }
 }
-
-// vim: ft=bpftrace ts=4 sw=4 sts=4 et

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -206,6 +206,17 @@ class LogProcessor:
                         "immix_is_defrag_gc": bool(int(args[0])),
                     }
 
+                case "concurrent_pause_determined":
+                    pause_int = int(args[0])
+                    try:
+                        pause = Pause(pause_int).name   # will raise ValueError if not valid
+                    except ValueError:
+                        pause = f"(Unknown:{pause_int})"
+
+                    gc["args"] |= {
+                        "pause": pause,
+                    }
+
                 case _:
                     processed_for_gc = False
         else:
@@ -272,17 +283,6 @@ class LogProcessor:
                             "total_objects": total_objects,
                             "iterations": iterations,
                         }
-                    }
-
-                case "concurrent_pause_determined":
-                    pause_int = int(args[0])
-                    if pause_int in Pause:
-                        pause = Pause(pause_int).name
-                    else:
-                        pause = f"(Unknown:{pause_int})"
-
-                    gc["args"] |= {
-                        "pause": pause,
                     }
 
                 case "sweep_chunk":


### PR DESCRIPTION
Minor fixes to the tracing scripts:
* Remove vim modeline at the end of the bt file. Otherwise I got an error. 
  ```
  ERROR: syntax error, unexpected end predicate, expecting {
  // vim: ft=bpftrace ts=4 sw=4 sts=4 et
  ~
  ```
* Move `concurrent_pause_determined` in `enrich_metadata` from `wp` to `gc`. It should add args for GCs, not work packets.