### PR TITLE
WIP: Make clear distinction between "GC" and "pauses"

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -1,6 +1,6 @@
 use super::work_bucket::WorkBucketStage;
 use super::*;
-use crate::global_state::GcStatus;
+use crate::global_state::PauseState;
 use crate::plan::ObjectsClosure;
 use crate::plan::VectorObjectQueue;
 use crate::util::*;
@@ -26,7 +26,7 @@ impl<VM: VMBinding> GCWork<VM> for ScheduleCollection {
             mmtk.get_plan().notify_emergency_collection();
         }
         // Set to GcPrepare
-        mmtk.set_gc_status(GcStatus::GcPrepare);
+        mmtk.pause_state_transition(PauseState::PauseTriggered);
 
         // Let the plan to schedule collection work
         mmtk.get_plan().schedule_collection(worker.scheduler());
@@ -444,7 +444,7 @@ impl<C: GCWorkContext> GCWork<C::VM> for ScanMutatorRoots<C> {
             <C::VM as VMBinding>::VMScanning::notify_initial_thread_scan_complete(
                 false, worker.tls,
             );
-            mmtk.set_gc_status(GcStatus::GcProper);
+            mmtk.pause_state_transition(PauseState::MutatorsStopped);
         }
     }
 }


### PR DESCRIPTION
Since we introduced concurrent GC, one stop-the-world pause no longer corresponds to one GC, and the distinction between a "GC" and a "pause" becomes important.

We changed `GcStatus` to `PauseState`, and its members `NotInPause`, `PauseTriggered` and `MutatorsStopped` are now used to describe pauses with respect to mutators, instead of GC phases.  We also renamed `set_gc_status` to `pause_state_transition` to emphasize that it is not merely setting the state, but also triggering events.

We changed the statistics output "GC" to "pauses".

TODO:

-   The statistics module should still record the number of GCs in addition to pauses.
-   Methods, such as `GCWorkScheduler::on_gc_finished` and `Plan::end_of_gc`, should be either renamed to `xxx_pause_xxx`, or refactored to ensure that they are called at actual ends of GCs instead of end of pauses.
-   Change VM bindings if any public APIs are changed.