### PR TITLE
Use u8 for alignment value

### DIFF
--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -126,22 +126,11 @@ pub fn align_allocation_inner<VM: VMBinding>(
 }
 
 /// Fill the specified region with the alignment value.
-pub fn fill_alignment_gap<VM: VMBinding>(immut_start: Address, end: Address) {
-    let mut start = immut_start;
-
-    if VM::MAX_ALIGNMENT - VM::MIN_ALIGNMENT == BYTES_IN_INT {
-        // At most a single hole
-        if end - start != 0 {
-            unsafe {
-                start.store(VM::ALIGNMENT_VALUE);
-            }
-        }
-    } else {
-        while start < end {
-            unsafe {
-                start.store(VM::ALIGNMENT_VALUE);
-            }
-            start += BYTES_IN_INT;
+pub fn fill_alignment_gap<VM: VMBinding>(start: Address, end: Address) {
+    if VM::ALIGNMENT_VALUE != 0 {
+        let start_ptr = start.to_mut_ptr::<u8>();
+        unsafe {
+            std::ptr::write_bytes(start_ptr, VM::ALIGNMENT_VALUE, end - start);
         }
     }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -63,8 +63,8 @@ where
     /// The type of heap memory slice in this VM.
     type VMMemorySlice: slot::MemorySlice<SlotType = Self::VMSlot>;
 
-    /// A value to fill in alignment gaps. This value can be used for debugging.
-    const ALIGNMENT_VALUE: usize = 0xdead_beef;
+    /// A value to fill in alignment gaps. This value can be used for debugging. Set this value to 0 to skip filling alignment gaps.
+    const ALIGNMENT_VALUE: u8 = 0xab;
     /// Allowed minimal alignment in bytes.
     const MIN_ALIGNMENT: usize = 1 << DEFAULT_LOG_MIN_ALIGNMENT;
     /// Allowed maximum alignment in bytes.


### PR DESCRIPTION
The current `fill_alignment_gap` may write beyond the 'alignment gap'. This PR fixes this issue by using a `u8` value as the alignment value, and write the u8 into the alignment gap.