### PR TITLE
Pin the dep home to 0.5.5

### DIFF
--- a/.github/scripts/ci-common.sh
+++ b/.github/scripts/ci-common.sh
@@ -11,6 +11,7 @@ dummyvm_toml=$project_root/docs/dummyvm/Cargo.toml
 
 # Pin certain deps for our MSRV
 cargo update -p home@0.5.11 --precise 0.5.5 # This can be removed once we move to Rust 1.81 or newer
+cargo update -p home@0.5.12 --precise 0.5.5 # This requires Rust edition 2024
 
 # Repeat a command for all the features. Requires the command as one argument (with double quotes)
 for_all_features() {


### PR DESCRIPTION
This PR works around the build issues we saw with the CI about the `home` crate.