### PR TITLE
Fix Clippy 1.91 warnings.

### DIFF
--- a/src/plan/concurrent/mod.rs
+++ b/src/plan/concurrent/mod.rs
@@ -10,12 +10,13 @@ use bytemuck::NoUninit;
 // TODO: This is probably not be general enough for all the concurrent plans.
 // TODO: We could consider moving this to specific plans later.
 #[repr(u8)]
-#[derive(Debug, PartialEq, Eq, Copy, Clone, NoUninit)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, NoUninit, Default)]
 pub enum Pause {
     /// A whole GC (including root scanning, closure, releasing, etc.) happening in a single pause.
     ///
     /// Don't be confused with "full-heap" GC in generational collectors.  `Pause::Full` can also
     /// refer to a nursery GC that happens in a single pause.
+    #[default]
     Full = 1,
     /// The initial pause before concurrent marking.
     InitialMark,
@@ -26,9 +27,3 @@ pub enum Pause {
 unsafe impl bytemuck::ZeroableInOption for Pause {}
 
 unsafe impl bytemuck::PodInOption for Pause {}
-
-impl Default for Pause {
-    fn default() -> Self {
-        Self::Full
-    }
-}

--- a/src/policy/sft_map.rs
+++ b/src/policy/sft_map.rs
@@ -139,7 +139,14 @@ impl SFTRefStorage {
     // Load with the acquire ordering.
     pub fn load(&self) -> &dyn SFT {
         let val = self.0.load(Ordering::Acquire);
-        unsafe { std::mem::transmute(val) }
+        // Provenance-related APIs were stabilized in Rust 1.84.
+        // Rust 1.91 introduced the warn-by-default lint `integer_to_ptr_transmutes`.
+        // Since our MSRV is still 1.74.1, we can't fix it until bumping MSRV.
+        #[allow(unknown_lints)]
+        #[allow(integer_to_ptr_transmutes)]
+        unsafe {
+            std::mem::transmute(val)
+        }
     }
 
     // Store a raw SFT pointer with the release ordering.

--- a/src/util/erase_vm.rs
+++ b/src/util/erase_vm.rs
@@ -21,7 +21,14 @@ macro_rules! define_erased_vm_mut_ref {
                 Self(worker_as_usize, PhantomData)
             }
             pub fn into_mut<VM: VMBinding>(self) -> &'a mut $orig_type {
-                unsafe { std::mem::transmute(self.0) }
+                // Provenance-related APIs were stabilized in Rust 1.84.
+                // Rust 1.91 introduced the warn-by-default lint `integer_to_ptr_transmutes`.
+                // Since our MSRV is still 1.74.1, we can't fix it until bumping MSRV.
+                #[allow(unknown_lints)]
+                #[allow(integer_to_ptr_transmutes)]
+                unsafe {
+                    std::mem::transmute(self.0)
+                }
             }
         }
     };


### PR DESCRIPTION
We now implement the `Default` trait for `enum Pause` using annotation.

We silenced the `integer_to_ptr_transmutes` lint (newly introduced in Rust 1.91) in two places because the proper fix requires Rust 1.84, while our MSRV is still 1.74.1.