### PR TITLE
Allow retry in get-merged-pr

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,19 +16,18 @@ jobs:
       pr: ${{ steps.get-pr.outputs.pr }}
     steps:
       - id: get-commit-hash
-        run: echo "commit=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-      - name: Check commit hash and PR
         run: |
+          echo "commit=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           echo "Commit hash: ${GITHUB_SHA}"
-          echo "Pull request for the commit is below:"
-          gh pr list --search "${GITHUB_SHA}" --state merged --repo mmtk/mmtk-core
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: get-pr
         run: |
           for n in {1..5}; do
               echo "Wait 30s then try get the pull request number"
               sleep 30
+
+              echo "Pull request for the commit is below:"
+              gh pr list --search "${GITHUB_SHA}" --state merged --repo mmtk/mmtk-core
+              echo "Pull request for the commit is above."
 
               PR_NUMBER=$(gh pr list --search "${GITHUB_SHA}" --state merged --repo mmtk/mmtk-core --json number --jq '.[0].number')
 


### PR DESCRIPTION
This should fix https://github.com/mmtk/mmtk-core/issues/1426. I didn't test it, but the retry pattern is the same as in https://github.com/mmtk/mmtk-core/blob/76ef95a3da8b1f2f1420bfb71122ac37c77761b5/.github/workflows/auto-merge-inner.yml#L98-L103