### PR TITLE
Document supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,30 +136,27 @@ a stable state.
 
 ## Supported platforms
 
-[Like Rust][rustps], supports for different platforms (targets) are organized into three tiers.
+Like [Rust platform support tiers][rustps], supports for MMTk core on different platforms (targets) are organized into three tiers.
 
--   Tier 1 platforms are guaranteed to work.  We do CI tests with the MMTk core and at least one binding.
--   Tier 2 platforms are guaranteed to build.  We do CI tests with the MMTk core.
+-   Tier 1 platforms are guaranteed to work.
+-   Tier 2 platforms are guaranteed to build.
 -   Tier 3 platforms have support in the mmtk-core code base, but we make no guarantee whether they will build or work.
 
 Here is a list of supported platforms.
 
 | Platform                    | Rust tier | MMTk tier | Notes |
 |-----------------------------|-----------|-----------|-------|
-| x86_64-unknown-linux-gnu    | 1         | 1         | (1)   |
-| i686-unknown-linux-gnu      | 1         | 1         | (2)   |
-| x86_64-apple-darwin         | 2         | 2         | (3)   |
-| aarch64-unknown-linux-gnu   | 1         | 3         | (4)   |
-| riscv64gc-unknown-linux-gnu | 2         | 3         | (4)   |
-| aarch64-linux-android       | 2         | 3         | (5)   |
+| x86_64-unknown-linux-gnu    | 1         | 1         |       |
+| i686-unknown-linux-gnu      | 1         | 1         |       |
+| x86_64-apple-darwin         | 2         | 2         | (1)   |
+| aarch64-unknown-linux-gnu   | 1         | 3         |       |
+| riscv64gc-unknown-linux-gnu | 2         | 3         |       |
+| aarch64-linux-android       | 2         | 3         |       |
+| x86_64-linux-android        | 2         | 3         |       |
 
 Notes:
 
-1.  x86_64-unknown-linux-gnu is the most actively supported platform.
-2.  We still test JikesRVM on 32-bit x86, although experimental 64-bit support for JikesRVM exists.
-3.  Rust recently [demoted][x86appledem] x86_64-apple-darwin to Tier 2.  We will replace it with aarch64-apple-darwin in the future.
-4.  We don't test the aarch64 or riscv64gc Linux targets on the CI for now, but they are both known to work with OpenJDK 21.
-5.  An [ART binding][mmtk-art] exists.
+1.  Rust recently [demoted][x86appledem] x86_64-apple-darwin to Tier 2.  We will replace it with aarch64-apple-darwin in the future.
 
 [rustps]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 [x86appledem]: https://github.com/mmtk/mmtk-core/issues/1365


### PR DESCRIPTION
We add a section in README.md and mention the level of support we provide for each platform (target triple) in a similar way the Rust project defines "tiers".

Closes: https://github.com/mmtk/mmtk-core/issues/1430