### PR TITLE
(testing) Update performance history CI for OpenJDK 21

### DIFF
--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -150,7 +150,7 @@ jobs:
       # The tarball should be the standard product tarball from `make product-bundles` (see docs/team/release.md).
       - name: Download canary build
         env:
-          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           rm -rf ${{ env.CANARY_DIR }}
           mkdir -p ${{ env.CANARY_DIR }}


### PR DESCRIPTION
We now use OpenJDK 21 for performance regression test.