### PR TITLE
Use ci-perf-kit 0.8.6 (new epoch for CI runner package update on 5th Jan)

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.8.5"
+          ref: "0.8.6"
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.8.5"
+          ref: "0.8.6"
           path: ci-perf-kit
           submodules: true
       # setup
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.8.5"
+          ref: "0.8.6"
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -112,7 +112,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.8.5"
+              ref: "0.8.6"
               path: ci-perf-kit
               submodules: true
           # setup
@@ -223,7 +223,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.8.5"
+                ref: "0.8.6"
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.5"
+          ref: "0.8.6"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.5"
+          ref: "0.8.6"
           path: ci-perf-kit
           submodules: true
       # download canary build
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.5"
+          ref: "0.8.6"
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true


### PR DESCRIPTION
We observed a performance slowdown in CI results recently. The slowdown first appears in the 6th Jan CI run (before the Rust version upgrade which was on 12th Jan): the canary showed a ~3% regression on luindex, and openjdk-stickyimmix showed a similar slowdown. (Other benchmarks also show regressions; luindex is used here as the performance difference for luindex is most obvious)

I also tested 3 builds ([`20251215`](https://github.com/mmtk/mmtk-core/commit/2ad6d36ab3d82be46135a7d76d4fe59cc84620ed), [`20260106`](https://github.com/mmtk/mmtk-core/commit/473fd586a9f532fa85b934fd5955c7e2db8281ff), and [`20260112`](https://github.com/mmtk/mmtk-core/commit/e30d0a0866fe66d352eb09eb7f9e9466dc649172)) with luindex (on a Zen 3 machine, rather than CI runenr's Zen 2), there was no measurable perf difference between those 3 builds. [link](https://squirrel.anu.edu.au/plotty/yilin/mmtk/#0|bear-2026-01-15-Thu-042440&benchmark^build^invocation^iteration&bmtime&|10&iteration^1^1|20&1^invocation|30&1&benchmark&build;jdk-mmtk-251215|41&Histogram%20(with%20CI)^build^benchmark&)

<img width="2179" height="940" alt="ScreenShot_2026-01-15_181157_830" src="https://github.com/user-attachments/assets/3320418e-9033-47c0-8a70-b2e6f2dbfccd" />

@no-defun-allowed confirmed that there was a big update of all the packages for CI runners on 5th Jan. We started to see the difference on the commit in 6th Jan. So the performance difference is unrelated with MMTk moving to Rust 1.92 (which happened on 12th Jan).

This PR updates `ci-perf-kit` to 0.8.6 which will plot 5th Jan as a new epoch.