### PR TITLE
Use ci-perf-kit 0.8.7. Mutator perf runs with jdk-11

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  CI_PERF_KIT_VERSION: 0.8.7
+
 jobs:
   openjdk-microbm:
     runs-on: [self-hosted, Linux, freq-scaling-off]
@@ -69,7 +72,7 @@ jobs:
         with:
           repository: mmtk/ci-perf-kit
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: "0.8.6"
+          ref: ${{ env.CI_PERF_KIT_VERSION }}
           path: ci-perf-kit
           submodules: true
       # Use rust-toolchain in the trunk (it doesnt matter much - if the toolchains defined in the trunk and the branch are different, we cant run anyway)

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -19,6 +19,7 @@ env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
+  CI_PERF_KIT_VERSION: 0.8.7
 
 jobs:
   jikesrvm-baseline:
@@ -42,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.8.6"
+          ref: ${{ env.CI_PERF_KIT_VERSION }}
           path: ci-perf-kit
           submodules: true
       # setup
@@ -94,7 +95,7 @@ jobs:
         with:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           repository: mmtk/ci-perf-kit
-          ref: "0.8.6"
+          ref: ${{ env.CI_PERF_KIT_VERSION }}
           path: ci-perf-kit
           submodules: true
       # setup

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -20,6 +20,7 @@ env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
+  CI_PERF_KIT_VERSION: 0.8.7
 
 jobs:
     # Figure out binding PRs.
@@ -112,7 +113,7 @@ jobs:
             with:
               repository: mmtk/ci-perf-kit
               token: ${{ secrets.CI_ACCESS_TOKEN }}
-              ref: "0.8.6"
+              ref: ${{ env.CI_PERF_KIT_VERSION }}
               path: ci-perf-kit
               submodules: true
           # setup
@@ -223,7 +224,7 @@ jobs:
               with:
                 repository: mmtk/ci-perf-kit
                 token: ${{ secrets.CI_ACCESS_TOKEN }}
-                ref: "0.8.6"
+                ref: ${{ env.CI_PERF_KIT_VERSION }}
                 path: ci-perf-kit
                 submodules: true
             # setup

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -20,6 +20,7 @@ env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
+  CI_PERF_KIT_VERSION: 0.8.7
 
 jobs:
   # JikesRVM
@@ -45,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.6"
+          ref: ${{ env.CI_PERF_KIT_VERSION }}
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
@@ -142,7 +143,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.6"
+          ref: ${{ env.CI_PERF_KIT_VERSION }}
           path: ci-perf-kit
           submodules: true
       # download canary build
@@ -223,6 +224,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
+          # TODO: We currently use OpenJDK 11 for performance comparison.
+          # We should switch to OpenJDK 21 when we are ready, and start a new epoch.
+          ref: jdk-11
           path: mmtk-openjdk
       - name: Checkout OpenJDK
         working-directory: mmtk-openjdk
@@ -233,7 +237,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mmtk/ci-perf-kit
-          ref: "0.8.6"
+          ref: ${{ env.CI_PERF_KIT_VERSION }}
           path: ci-perf-kit
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true


### PR DESCRIPTION
1. Use https://github.com/mmtk/ci-perf-kit/releases/tag/0.8.7
2. Change the binding branch for mutator perf. Fix https://github.com/mmtk/mmtk-core/issues/1463.