### PR TITLE
Do not scan any root in FinalMark

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -192,9 +192,9 @@ impl<VM: VMBinding> GCWork<VM> for ReleaseCollector {
 /// TODO: Smaller work granularity
 #[derive(Default)]
 pub struct StopMutators<C: GCWorkContext> {
-    /// If this is true, we skip creating [`ScanMutatorRoots`] work packets for mutators.
+    /// If this is true, we skip creating root-scanning work packets.
     /// By default, this is false.
-    skip_mutator_roots: bool,
+    skip_roots: bool,
     /// Flush mutators once they are stopped. By default this is false. [`ScanMutatorRoots`] will flush mutators.
     flush_mutator: bool,
     phantom: PhantomData<C>,
@@ -203,16 +203,16 @@ pub struct StopMutators<C: GCWorkContext> {
 impl<C: GCWorkContext> StopMutators<C> {
     pub fn new() -> Self {
         Self {
-            skip_mutator_roots: false,
+            skip_roots: false,
             flush_mutator: false,
             phantom: PhantomData,
         }
     }
 
-    /// Create a `StopMutators` work packet that does not create `ScanMutatorRoots` work packets for mutators, and will simply flush mutators.
+    /// Create a `StopMutators` work packet that does not create any root-scanning work packets, and will simply flush mutators.
     pub fn new_no_scan_roots() -> Self {
         Self {
-            skip_mutator_roots: true,
+            skip_roots: true,
             flush_mutator: true,
             phantom: PhantomData,
         }
@@ -230,7 +230,7 @@ impl<C: GCWorkContext> GCWork<C::VM> for StopMutators<C> {
             if self.flush_mutator {
                 mutator.flush();
             }
-            if !self.skip_mutator_roots {
+            if !self.skip_roots {
                 mmtk.scheduler.work_buckets[WorkBucketStage::Prepare]
                     .add(ScanMutatorRoots::<C>(mutator));
             }
@@ -238,7 +238,10 @@ impl<C: GCWorkContext> GCWork<C::VM> for StopMutators<C> {
         trace!("stop_all_mutators end");
         mmtk.get_plan().notify_mutators_paused(&mmtk.scheduler);
         mmtk.scheduler.notify_mutators_paused(mmtk);
-        mmtk.scheduler.work_buckets[WorkBucketStage::Prepare].add(ScanVMSpecificRoots::<C>::new());
+        if !self.skip_roots {
+            mmtk.scheduler.work_buckets[WorkBucketStage::Prepare]
+                .add(ScanVMSpecificRoots::<C>::new());
+        }
     }
 }
 

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -35,15 +35,18 @@ impl<SL: Slot> SanityChecker<SL> {
 
     /// Cache a list of root slots to the sanity checker.
     pub fn add_root_slots(&mut self, roots: Vec<SL>) {
+        debug!("Added {} root slots", roots.len());
         self.root_slots.push(roots)
     }
 
     pub fn add_root_nodes(&mut self, roots: Vec<ObjectReference>) {
+        debug!("Added {} root nodes", roots.len());
         self.root_nodes.push(roots)
     }
 
     /// Reset roots cache at the end of the sanity gc.
     fn clear_roots_cache(&mut self) {
+        debug!("Cleared roots cache");
         self.root_slots.clear();
         self.root_nodes.clear();
     }


### PR DESCRIPTION
We no longer scan any roots during the FinalMark pause of ConcurrentImmix.  This fixes two things.

Firstly, the SATB barrier ensures that all objects reachable in the InitialMark pause will be reached from either the roots or the modbuf, and survive the current GC.  Therefore, root scanning during FinalMark is redundant according to the algorithm.

Secondly, when the "sanity" feature is enabled, root scanning will register roots into the `SanityChecker`.  Since we currently don't do sanity check during concurrent GC, the root cache will not be cleared at the end of a GC, either.  Consequently, invalid root slots will be carried to the next STW GC, and the sanity checker will attempt to load from invalid slots.  After this change, FinalMark will no longer register any roots to the sanity checker.  This *mitigates* the problem and allow us to do sanity check during STW GC.  (Note that during InitialMark, `concurrent_marking_work::ProcessRootSlots` drains its slot list, leaving no slots to register to the sanity checker, and hiding the problem.)  We still need to refactor the sanity checker to properly register roots for concurrent GC, and allow sanity check for concurrent GC.

Fixes: https://github.com/mmtk/mmtk-core/issues/1469