### PR TITLE
Set rust-version and resolver in dummyvm

### DIFF
--- a/docs/dummyvm/Cargo.toml
+++ b/docs/dummyvm/Cargo.toml
@@ -3,6 +3,8 @@ name = "mmtk_dummyvm"
 version = "0.0.1"
 authors = [" <>"]
 edition = "2021"
+rust-version = "1.84"
+resolver = "3"
 
 [lib]
 name = "mmtk_dummyvm"


### PR DESCRIPTION
This lets dummyvm use the same `rust-version` and the MSRV-aware dependency resolver ("3") as the `mmtk` crate itself, fixing an error where Cargo may pull in incompatible dependency versions for the `dummyvm` crate when using Rust 1.84.