### PR TITLE
Fix infinite loop if we return from `Collection::out_of_memory`

### DIFF
--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -472,11 +472,6 @@ pub trait Allocator<VM: VMBinding>: Downcast {
             if !is_mutator {
                 debug_assert!(!result.is_zero());
                 debug_assert!(!self.get_context().thrown_oom.load(Ordering::Relaxed));
-                debug_assert!(!self
-                    .get_context()
-                    .state
-                    .allocation_success
-                    .load(Ordering::Relaxed));
                 return result;
             }
 

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -248,7 +248,8 @@ pub(crate) fn assert_allocation_args<VM: VMBinding>(size: usize, align: usize, o
 /// used as `Arc<AllocatorContext>` inside all allocator implementations since
 /// we need the entire struct to be `Send`.
 ///
-/// See here for more information: https://github.com/mmtk/mmtk-core/issues/1474
+/// See doc comment on `impl Sync` for `AllocationOptionsHolder` above.
+/// See here for more information: <https://github.com/mmtk/mmtk-core/issues/1474>
 pub struct AllocatorContext<VM: VMBinding> {
     alloc_options: AllocationOptionsHolder,
     pub state: Arc<GlobalState>,

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -287,6 +287,16 @@ impl<VM: VMBinding> AllocatorContext<VM> {
     }
 }
 
+macro_rules! reset_allocation_state {
+    ($receiver:expr) => {
+        {
+            let context = $receiver.get_context();
+            // Relaxed store is fine since this is a thread-local boolean.
+            context.thrown_oom.store(false, Ordering::Relaxed);
+        }
+    };
+}
+
 /// A trait which implements allocation routines. Every allocator needs to implements this trait.
 pub trait Allocator<VM: VMBinding>: Downcast {
     /// Return the [`VMThread`] associated with this allocator instance.
@@ -330,6 +340,12 @@ pub trait Allocator<VM: VMBinding>: Downcast {
             return true;
         }
         false
+    }
+
+    fn out_of_memory(&self, tls: VMThread) {
+        VM::VMCollection::out_of_memory(tls, AllocationError::HeapOutOfMemory);
+        // Relaxed store is fine since this is a thread-local boolean.
+        self.get_context().thrown_oom.store(true, Ordering::Relaxed);
     }
 
     /// An allocation attempt. The implementation of this function depends on the allocator used.
@@ -430,6 +446,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
         let tls = self.get_tls();
         let is_mutator = VM::VMActivePlan::is_mutator(tls);
         let stress_test = self.get_context().options.is_stress_test_gc_enabled();
+        assert!(!self.get_context().thrown_oom.load(Ordering::Relaxed), "We should not enter alloc_slow_inline if we have already thrown OOM for this allocation request.");
 
         // Information about the previous collection.
         let mut emergency_collection = false;
@@ -457,16 +474,14 @@ pub trait Allocator<VM: VMBinding>: Downcast {
 
             if !is_mutator {
                 debug_assert!(!result.is_zero());
+                debug_assert!(!self.get_context().thrown_oom.load(Ordering::Relaxed));
+                debug_assert!(!self.get_context().state.allocation_success.load(Ordering::Relaxed));
                 return result;
             }
 
             if !result.is_zero() {
                 // Report allocation success to assist OutOfMemory handling.
-                // Relaxed storing is fine since this is a thread-local boolean.
-                self.get_context()
-                    .thrown_oom
-                    .store(false, Ordering::Relaxed);
-                if !self
+				if !self
                     .get_context()
                     .state
                     .allocation_success
@@ -477,6 +492,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                         .allocation_success
                         .store(true, Ordering::SeqCst);
                 }
+                reset_allocation_state!(self);
 
                 // Only update the allocation bytes if we haven't failed a previous allocation in this loop
                 if stress_test && self.get_context().state.is_initialized() && !previous_result_zero
@@ -526,6 +542,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 // the code beyond this point tests OOM conditions and, if not OOM, try to allocate
                 // again.  Since we didn't block for GC, the allocation will fail again if we try
                 // again. So we return null immediately.
+                reset_allocation_state!(self);
                 return Address::ZERO;
             }
 
@@ -534,9 +551,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
             if self.get_context().thrown_oom.load(Ordering::Relaxed) {
                 // Need to reset the thrown_oom state since we're giving up on this allocation,
                 // that is to say, the thrown_oom state is *per* allocation request
-                self.get_context()
-                    .thrown_oom
-                    .store(false, Ordering::Relaxed);
+                reset_allocation_state!(self);
                 return Address::ZERO;
             }
 
@@ -560,9 +575,8 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 if fail_with_oom {
                     // Note that we throw a `HeapOutOfMemory` error here and return a null ptr back to the VM
                     trace!("Throw HeapOutOfMemory!");
-                    VM::VMCollection::out_of_memory(tls, AllocationError::HeapOutOfMemory);
-                    // Relaxed store is fine since this is a thread-local boolean.
-                    self.get_context().thrown_oom.store(true, Ordering::Relaxed);
+                    self.out_of_memory(tls);
+                    reset_allocation_state!(self);
                     self.get_context()
                         .state
                         .allocation_success

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -288,13 +288,11 @@ impl<VM: VMBinding> AllocatorContext<VM> {
 }
 
 macro_rules! reset_allocation_state {
-    ($receiver:expr) => {
-        {
-            let context = $receiver.get_context();
-            // Relaxed store is fine since this is a thread-local boolean.
-            context.thrown_oom.store(false, Ordering::Relaxed);
-        }
-    };
+    ($receiver:expr) => {{
+        let context = $receiver.get_context();
+        // Relaxed store is fine since this is a thread-local boolean.
+        context.thrown_oom.store(false, Ordering::Relaxed);
+    }};
 }
 
 /// A trait which implements allocation routines. Every allocator needs to implements this trait.
@@ -475,13 +473,17 @@ pub trait Allocator<VM: VMBinding>: Downcast {
             if !is_mutator {
                 debug_assert!(!result.is_zero());
                 debug_assert!(!self.get_context().thrown_oom.load(Ordering::Relaxed));
-                debug_assert!(!self.get_context().state.allocation_success.load(Ordering::Relaxed));
+                debug_assert!(!self
+                    .get_context()
+                    .state
+                    .allocation_success
+                    .load(Ordering::Relaxed));
                 return result;
             }
 
             if !result.is_zero() {
                 // Report allocation success to assist OutOfMemory handling.
-				if !self
+                if !self
                     .get_context()
                     .state
                     .allocation_success

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -7,7 +7,7 @@ use crate::util::options::Options;
 use crate::MMTK;
 
 use std::cell::RefCell;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::policy::space::Space;
@@ -246,6 +246,7 @@ pub(crate) fn assert_allocation_args<VM: VMBinding>(size: usize, align: usize, o
 pub struct AllocatorContext<VM: VMBinding> {
     alloc_options: AllocationOptionsHolder,
     pub state: Arc<GlobalState>,
+    pub thrown_oom: AtomicBool,
     pub options: Arc<Options>,
     pub gc_trigger: Arc<GCTrigger<VM>>,
     #[cfg(feature = "analysis")]
@@ -257,6 +258,7 @@ impl<VM: VMBinding> AllocatorContext<VM> {
         Self {
             alloc_options: AllocationOptionsHolder::new(AllocationOptions::default()),
             state: mmtk.state.clone(),
+            thrown_oom: AtomicBool::new(false),
             options: mmtk.options.clone(),
             gc_trigger: mmtk.gc_trigger.clone(),
             #[cfg(feature = "analysis")]
@@ -452,6 +454,10 @@ pub trait Allocator<VM: VMBinding>: Downcast {
 
             if !result.is_zero() {
                 // Report allocation success to assist OutOfMemory handling.
+                // Relaxed storing is fine since this is a thread-local boolean.
+                self.get_context()
+                    .thrown_oom
+                    .store(false, Ordering::Relaxed);
                 if !self
                     .get_context()
                     .state
@@ -515,6 +521,17 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 return Address::ZERO;
             }
 
+            // If we have already thrown an OOM for this allocation then return a zero.
+            // Relaxed load and store is fine given this is a thread-local boolean.
+            if self.get_context().thrown_oom.load(Ordering::Relaxed) {
+                // Need to reset the thrown_oom state since we're giving up on this allocation,
+                // that is to say, the thrown_oom state is *per* allocation request
+                self.get_context()
+                    .thrown_oom
+                    .store(false, Ordering::Relaxed);
+                return Address::ZERO;
+            }
+
             // It is possible to have cases where a thread is blocked for another GC (non emergency)
             // immediately after being blocked for a GC (emergency) (e.g. in stress test), that is saying
             // the thread does not leave this loop between the two GCs. The local var 'emergency_collection'
@@ -536,6 +553,8 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                     // Note that we throw a `HeapOutOfMemory` error here and return a null ptr back to the VM
                     trace!("Throw HeapOutOfMemory!");
                     VM::VMCollection::out_of_memory(tls, AllocationError::HeapOutOfMemory);
+                    // Relaxed store is fine since this is a thread-local boolean.
+                    self.get_context().thrown_oom.store(true, Ordering::Relaxed);
                     self.get_context()
                         .state
                         .allocation_success

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -287,12 +287,10 @@ impl<VM: VMBinding> AllocatorContext<VM> {
     }
 }
 
-macro_rules! reset_allocation_state {
-    ($receiver:expr) => {{
-        let context = $receiver.get_context();
-        // Relaxed store is fine since this is a thread-local boolean.
-        context.thrown_oom.store(false, Ordering::Relaxed);
-    }};
+fn reset_allocation_state<VM: VMBinding, A: Allocator<VM> + ?Sized>(allocator: &A) {
+    let context = allocator.get_context();
+    // Relaxed store is fine since this is a thread-local boolean.
+    context.thrown_oom.store(false, Ordering::Relaxed);
 }
 
 /// A trait which implements allocation routines. Every allocator needs to implements this trait.
@@ -488,7 +486,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                         .allocation_success
                         .store(true, Ordering::SeqCst);
                 }
-                reset_allocation_state!(self);
+                reset_allocation_state(self);
 
                 // Only update the allocation bytes if we haven't failed a previous allocation in this loop
                 if stress_test && self.get_context().state.is_initialized() && !previous_result_zero
@@ -538,7 +536,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 // the code beyond this point tests OOM conditions and, if not OOM, try to allocate
                 // again.  Since we didn't block for GC, the allocation will fail again if we try
                 // again. So we return null immediately.
-                reset_allocation_state!(self);
+                reset_allocation_state(self);
                 return Address::ZERO;
             }
 
@@ -547,7 +545,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
             if self.get_context().thrown_oom.load(Ordering::Relaxed) {
                 // Need to reset the thrown_oom state since we're giving up on this allocation,
                 // that is to say, the thrown_oom state is *per* allocation request
-                reset_allocation_state!(self);
+                reset_allocation_state(self);
                 return Address::ZERO;
             }
 
@@ -572,7 +570,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                     // Note that we throw a `HeapOutOfMemory` error here and return a null ptr back to the VM
                     trace!("Throw HeapOutOfMemory!");
                     self.out_of_memory(tls);
-                    reset_allocation_state!(self);
+                    reset_allocation_state(self);
                     self.get_context()
                         .state
                         .allocation_success

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -243,9 +243,16 @@ pub(crate) fn assert_allocation_args<VM: VMBinding>(size: usize, align: usize, o
 }
 
 /// The context an allocator needs to access in order to perform allocation.
+///
+/// **Note:** An `AllocatorContext` is a thread-local struct, however, it is
+/// used as `Arc<AllocatorContext>` inside all allocator implementations since
+/// we need the entire struct to be `Send`.
+///
+/// See here for more information: https://github.com/mmtk/mmtk-core/issues/1474
 pub struct AllocatorContext<VM: VMBinding> {
     alloc_options: AllocationOptionsHolder,
     pub state: Arc<GlobalState>,
+    /// Have we thrown an OOM already?
     pub thrown_oom: AtomicBool,
     pub options: Arc<Options>,
     pub gc_trigger: Arc<GCTrigger<VM>>,

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -330,16 +330,15 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 .get_alloc_options()
                 .allow_oom_call
             {
-                VM::VMCollection::out_of_memory(
-                    tls,
-                    crate::util::alloc::AllocationError::HeapOutOfMemory,
-                );
+                self.out_of_memory(tls);
             }
             return true;
         }
         false
     }
 
+    /// Wrapper around [`Collection::out_of_memory`]. Used to set up relevant state and signal out
+    /// of memory errors.
     fn out_of_memory(&self, tls: VMThread) {
         VM::VMCollection::out_of_memory(tls, AllocationError::HeapOutOfMemory);
         // Relaxed store is fine since this is a thread-local boolean.

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -486,7 +486,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                         .allocation_success
                         .store(true, Ordering::SeqCst);
                 }
-                reset_allocation_state(self);
+                debug_assert!(!self.get_context().thrown_oom.load(Ordering::Relaxed));
 
                 // Only update the allocation bytes if we haven't failed a previous allocation in this loop
                 if stress_test && self.get_context().state.is_initialized() && !previous_result_zero

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -195,10 +195,6 @@ impl<VM: VMBinding> BumpAllocator<VM> {
         stress_test: bool,
     ) -> Address {
         if self.handle_obvious_oom_request(self.tls, size) {
-            // Relaxed store is fine since this is a thread-local boolean.
-            self.get_context()
-                .thrown_oom
-                .store(true, std::sync::atomic::Ordering::Relaxed);
             return Address::ZERO;
         }
 

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -195,6 +195,10 @@ impl<VM: VMBinding> BumpAllocator<VM> {
         stress_test: bool,
     ) -> Address {
         if self.handle_obvious_oom_request(self.tls, size) {
+            // Relaxed store is fine since this is a thread-local boolean.
+            self.get_context()
+                .thrown_oom
+                .store(true, std::sync::atomic::Ordering::Relaxed);
             return Address::ZERO;
         }
 

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -56,10 +56,6 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
             self.tls,
             pages << crate::util::constants::LOG_BYTES_IN_PAGE,
         ) {
-            // Relaxed store is fine since this is a thread-local boolean.
-            self.get_context()
-                .thrown_oom
-                .store(true, std::sync::atomic::Ordering::Relaxed);
             return Address::ZERO;
         }
 

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -49,12 +49,20 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
     }
 
     fn alloc_slow_once(&mut self, size: usize, align: usize, _offset: usize) -> Address {
-        if self.handle_obvious_oom_request(self.tls, size) {
+        let maxbytes = allocator::get_maximum_aligned_size::<VM>(size, align);
+        let pages = crate::util::conversions::bytes_to_pages_up(maxbytes);
+
+        if self.handle_obvious_oom_request(
+            self.tls,
+            pages << crate::util::constants::LOG_BYTES_IN_PAGE,
+        ) {
+            // Relaxed store is fine since this is a thread-local boolean.
+            self.get_context()
+                .thrown_oom
+                .store(true, std::sync::atomic::Ordering::Relaxed);
             return Address::ZERO;
         }
 
-        let maxbytes = allocator::get_maximum_aligned_size::<VM>(size, align);
-        let pages = crate::util::conversions::bytes_to_pages_up(maxbytes);
         self.space
             .allocate_pages(self.tls, pages, self.get_context().get_alloc_options())
     }

--- a/src/vm/tests/mock_tests/mock_test_allocate_no_infinite_loop_if_throw_oom_returns.rs
+++ b/src/vm/tests/mock_tests/mock_test_allocate_no_infinite_loop_if_throw_oom_returns.rs
@@ -1,0 +1,38 @@
+use super::mock_test_prelude::*;
+
+use crate::AllocationSemantics;
+
+/// This test will allocate an object that is larger than the heap size. This should
+/// not be an infinite loop. It should call `Collection::out_of_memory` and return null.
+#[test]
+pub fn allocate_no_infinite_loop_if_throw_oom_returns() {
+    // 1MB heap
+    with_mockvm(
+        || -> MockVM {
+            MockVM {
+                out_of_memory: MockMethod::new_default(),
+                ..MockVM::default()
+            }
+        },
+        || {
+            const KB: usize = 1024;
+            let mut fixture = MutatorFixture::create_with_heapsize(KB);
+
+            // Attempt to allocate an object that is larger than the heap size.
+            let addr = memory_manager::alloc(
+                &mut fixture.mutator,
+                1024 * 1024,
+                8,
+                0,
+                AllocationSemantics::Default,
+            );
+            // We should get zero.
+            assert!(addr.is_zero());
+            // out_of_memory should be called.
+            read_mockvm(|mock| {
+                assert!(mock.out_of_memory.is_called());
+            });
+        },
+        no_cleanup,
+    )
+}

--- a/src/vm/tests/mock_tests/mock_test_issue867_allocate_unrealistically_large_object.rs
+++ b/src/vm/tests/mock_tests/mock_test_issue867_allocate_unrealistically_large_object.rs
@@ -37,7 +37,13 @@ pub fn allocate_max_size_object() {
     with_mockvm(
         default_setup,
         || {
-            let (size, align) = (usize::MAX, 8);
+            use crate::util::constants::BYTES_IN_PAGE;
+
+            let align = 8;
+            // Maximum size we allow for allocation is usize::MAX - BYTES_IN_PAGE aligned down to
+            // page size. This will panic with an 'attempt to add with overflow' otherwise.
+            let size =
+                crate::util::conversions::raw_align_down(usize::MAX - BYTES_IN_PAGE, BYTES_IN_PAGE);
 
             MUTATOR.with_fixture_mut(|fixture| {
                 alloc_default_or_large(

--- a/src/vm/tests/mock_tests/mod.rs
+++ b/src/vm/tests/mock_tests/mod.rs
@@ -27,6 +27,7 @@ mod mock_test_allocate_align_offset;
 mod mock_test_allocate_no_gc_oom_on_acquire_allow_oom_call;
 mod mock_test_allocate_no_gc_oom_on_acquire_no_oom_call;
 mod mock_test_allocate_no_gc_simple;
+mod mock_test_allocate_no_infinite_loop_if_throw_oom_returns;
 mod mock_test_allocate_nonmoving;
 mod mock_test_allocate_overcommit;
 mod mock_test_allocate_with_disable_collection;


### PR DESCRIPTION
This commit also fixes a minor issue wherein we were using the unaligned object size when checking for OOM in the large object allocator.