### PR TITLE
Move a few misplaced functions about obvious OOM handling

### DIFF
--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -14,7 +14,7 @@ use crate::util::heap::{PageResource, VMRequest};
 use crate::util::options::Options;
 use crate::vm::{ActivePlan, Collection};
 
-use crate::util::constants::{LOG_BYTES_IN_MBYTE, LOG_BYTES_IN_PAGE};
+use crate::util::constants::LOG_BYTES_IN_MBYTE;
 use crate::util::conversions;
 use crate::util::opaque_pointer::*;
 
@@ -54,48 +54,6 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
     /// Currently after we create a boxed plan, spaces in the plan have a non-moving address.
     fn initialize_sft(&self, sft_map: &mut dyn crate::policy::sft_map::SFTMap);
 
-    /// A check for the obvious out-of-memory case: if the requested size is larger than
-    /// the heap size, it is definitely an OOM. We would like to identify that, and
-    /// allows the binding to deal with OOM. Without this check, we will attempt
-    /// to allocate from the page resource. If the requested size is unrealistically large
-    /// (such as `usize::MAX`), it breaks the assumptions of our implementation of
-    /// page resource, vm map, etc. This check prevents that, and allows us to
-    /// handle the OOM case.
-    /// Each allocator that may request an arbitrary size should call this method before
-    /// acquring memory from the space. For example, bump pointer allocator and large object
-    /// allocator need to call this method. On the other hand, allocators that only allocate
-    /// memory in fixed size blocks do not need to call this method.
-    /// An allocator should call this method before doing any computation on the size to
-    /// avoid arithmatic overflow. If we have to do computation in the allocation fastpath and
-    /// overflow happens there, there is nothing we can do about it.
-    /// Return a boolean to indicate if we will be out of memory, determined by the check.
-    fn will_oom_on_acquire(&self, size: usize) -> bool {
-        let max_pages = self.get_gc_trigger().policy.get_max_heap_size_in_pages();
-        let requested_pages = size >> LOG_BYTES_IN_PAGE;
-        requested_pages > max_pages
-    }
-
-    /// Check if the requested `size` is an obvious out-of-memory case using
-    /// [`Self::will_oom_on_acquire`] and, if it is, call `Collection::out_of_memory`.  Return the
-    /// result of `will_oom_on_acquire`.
-    fn handle_obvious_oom_request(
-        &self,
-        tls: VMThread,
-        size: usize,
-        alloc_options: AllocationOptions,
-    ) -> bool {
-        if self.will_oom_on_acquire(size) {
-            if alloc_options.allow_oom_call {
-                VM::VMCollection::out_of_memory(
-                    tls,
-                    crate::util::alloc::AllocationError::HeapOutOfMemory,
-                );
-            }
-            return true;
-        }
-        false
-    }
-
     fn acquire(&self, tls: VMThread, pages: usize, alloc_options: AllocationOptions) -> Address {
         trace!(
             "Space.acquire, tls={:?}, alloc_options={:?}",
@@ -104,7 +62,7 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
         );
 
         debug_assert!(
-            !self.will_oom_on_acquire(pages << LOG_BYTES_IN_PAGE),
+            !self.get_gc_trigger().will_oom_on_alloc(pages << crate::util::constants::LOG_BYTES_IN_PAGE),
             "The requested pages is larger than the max heap size. Is will_go_oom_on_acquire used before acquring memory?"
         );
 

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -302,6 +302,26 @@ pub trait Allocator<VM: VMBinding>: Downcast {
         unimplemented!()
     }
 
+    /// Check if the requested `size` is an obvious out-of-memory case (requested allocation size is larger than the heap size).
+    /// If it is, call `Collection::out_of_memory`.  Return true if the allocation request is an obvious OOM case, and false otherwise.
+    fn handle_obvious_oom_request(&self, tls: VMThread, size: usize) -> bool {
+        if self.get_context().gc_trigger.will_oom_on_alloc(size) {
+            if self
+                .get_context()
+                .alloc_options
+                .get_alloc_options()
+                .allow_oom_call
+            {
+                VM::VMCollection::out_of_memory(
+                    tls,
+                    crate::util::alloc::AllocationError::HeapOutOfMemory,
+                );
+            }
+            return true;
+        }
+        false
+    }
+
     /// An allocation attempt. The implementation of this function depends on the allocator used.
     /// If an allocator supports thread local allocations, then the allocation will be serviced
     /// from its TLAB, otherwise it will default to using the slowpath, i.e. [`alloc_slow`](Allocator::alloc_slow).

--- a/src/util/alloc/bumpallocator.rs
+++ b/src/util/alloc/bumpallocator.rs
@@ -194,11 +194,7 @@ impl<VM: VMBinding> BumpAllocator<VM> {
         offset: usize,
         stress_test: bool,
     ) -> Address {
-        if self.space.handle_obvious_oom_request(
-            self.tls,
-            size,
-            self.get_context().get_alloc_options(),
-        ) {
+        if self.handle_obvious_oom_request(self.tls, size) {
             return Address::ZERO;
         }
 

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -49,11 +49,7 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
     }
 
     fn alloc_slow_once(&mut self, size: usize, align: usize, _offset: usize) -> Address {
-        if self.space.handle_obvious_oom_request(
-            self.tls,
-            size,
-            self.get_context().get_alloc_options(),
-        ) {
+        if self.handle_obvious_oom_request(self.tls, size) {
             return Address::ZERO;
         }
 

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -253,6 +253,27 @@ impl<VM: VMBinding> GCTrigger<VM> {
     pub fn get_min_nursery_pages(&self) -> usize {
         crate::util::conversions::bytes_to_pages_up(self.get_min_nursery_bytes())
     }
+
+    /// A check for the obvious out-of-memory case: if the requested size is larger than
+    /// the heap size, it is definitely an OOM. We would like to identify that, and
+    /// allows the binding to deal with OOM. Without this check, we will attempt
+    /// to allocate from the page resource. If the requested size is unrealistically large
+    /// (such as `usize::MAX`), it breaks the assumptions of our implementation of
+    /// page resource, vm map, etc. This check prevents that, and allows us to
+    /// handle the OOM case.
+    /// Each allocator that may request an arbitrary size should call this method before
+    /// acquring memory from the space. For example, bump pointer allocator and large object
+    /// allocator need to call this method. On the other hand, allocators that only allocate
+    /// memory in fixed size blocks do not need to call this method.
+    /// An allocator should call this method before doing any computation on the size to
+    /// avoid arithmatic overflow. If we have to do computation in the allocation fastpath and
+    /// overflow happens there, there is nothing we can do about it.
+    /// Return a boolean to indicate if we will be out of memory, determined by the check.
+    pub fn will_oom_on_alloc(&self, size: usize) -> bool {
+        let max_pages = self.policy.get_max_heap_size_in_pages();
+        let requested_pages = size >> crate::util::constants::LOG_BYTES_IN_PAGE;
+        requested_pages > max_pages
+    }
 }
 
 /// Provides statistics about the space. This is exposed to bindings, as it is used


### PR DESCRIPTION
These functions are clearly misplaced:
* `will_oom_on_acquire`: this function only needs `GCTrigger`. This PR moves it from `Space` to `GCTrigger`.
* `handle_obvious_oom_request`: this function is only used by `Allocator` and also takes `AllocationOptions` as an argument. This PR moves it from `Space` to `Allocator`.