### PR TITLE
Remove unsafety for uninitialized allocatr. Initialize with unusable space instead.

### DIFF
--- a/src/plan/compressor/mutator.rs
+++ b/src/plan/compressor/mutator.rs
@@ -61,13 +61,11 @@ pub fn create_compressor_mutator<VM: VMBinding>(
 
 pub fn compressor_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
     // reset the thread-local allocation bump pointer
-    let bump_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<BumpAllocator<VM>>()
-    .unwrap();
+    let bump_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<BumpAllocator<VM>>()
+        .unwrap();
     bump_allocator.reset();
     common_release_func(mutator, tls);
 }

--- a/src/plan/concurrent/immix/mutator.rs
+++ b/src/plan/concurrent/immix/mutator.rs
@@ -30,13 +30,11 @@ pub fn concurrent_immix_mutator_release<VM: VMBinding>(
     let current_pause = mutator.plan.concurrent().unwrap().current_pause().unwrap();
     debug_assert_ne!(current_pause, Pause::InitialMark);
 
-    let immix_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<ImmixAllocator<VM>>()
-    .unwrap();
+    let immix_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<ImmixAllocator<VM>>()
+        .unwrap();
     immix_allocator.reset();
 
     // Deactivate SATB
@@ -58,13 +56,11 @@ pub fn concurent_immix_mutator_prepare<VM: VMBinding>(
     let current_pause = mutator.plan.concurrent().unwrap().current_pause().unwrap();
     debug_assert_ne!(current_pause, Pause::FinalMark);
 
-    let immix_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<ImmixAllocator<VM>>()
-    .unwrap();
+    let immix_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<ImmixAllocator<VM>>()
+        .unwrap();
     immix_allocator.reset();
 
     // Activate SATB

--- a/src/plan/generational/copying/mutator.rs
+++ b/src/plan/generational/copying/mutator.rs
@@ -16,13 +16,11 @@ use crate::MMTK;
 
 pub fn gencopy_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
     // reset nursery allocator
-    let bump_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<BumpAllocator<VM>>()
-    .unwrap();
+    let bump_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<BumpAllocator<VM>>()
+        .unwrap();
     bump_allocator.reset();
 
     common_release_func(mutator, tls);

--- a/src/plan/generational/immix/mutator.rs
+++ b/src/plan/generational/immix/mutator.rs
@@ -16,13 +16,11 @@ use crate::MMTK;
 
 pub fn genimmix_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
     // reset nursery allocator
-    let bump_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<BumpAllocator<VM>>()
-    .unwrap();
+    let bump_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<BumpAllocator<VM>>()
+        .unwrap();
     bump_allocator.reset();
 
     common_release_func(mutator, tls);

--- a/src/plan/immix/mutator.rs
+++ b/src/plan/immix/mutator.rs
@@ -16,13 +16,11 @@ use crate::MMTK;
 use enum_map::EnumMap;
 
 pub fn immix_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
-    let immix_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<ImmixAllocator<VM>>()
-    .unwrap();
+    let immix_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<ImmixAllocator<VM>>()
+        .unwrap();
     immix_allocator.reset();
 
     common_release_func(mutator, tls);

--- a/src/plan/markcompact/mutator.rs
+++ b/src/plan/markcompact/mutator.rs
@@ -49,13 +49,11 @@ pub fn create_markcompact_mutator<VM: VMBinding>(
 
 pub fn markcompact_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
     // reset the thread-local allocation bump pointer
-    let markcompact_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<MarkCompactAllocator<VM>>()
-    .unwrap();
+    let markcompact_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<MarkCompactAllocator<VM>>()
+        .unwrap();
     markcompact_allocator.reset();
 
     common_release_func(mutator, tls);

--- a/src/plan/marksweep/mutator.rs
+++ b/src/plan/marksweep/mutator.rs
@@ -63,13 +63,11 @@ mod native_mark_sweep {
     fn get_freelist_allocator_mut<VM: VMBinding>(
         mutator: &mut Mutator<VM>,
     ) -> &mut FreeListAllocator<VM> {
-        unsafe {
-            mutator
-                .allocators
-                .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-        }
-        .downcast_mut::<FreeListAllocator<VM>>()
-        .unwrap()
+        mutator
+            .allocators
+            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+            .downcast_mut::<FreeListAllocator<VM>>()
+            .unwrap()
     }
 
     // We forward calls to the allocator prepare and release

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -193,10 +193,9 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
         offset: usize,
         allocator: AllocationSemantics,
     ) -> Address {
-        let allocator = unsafe {
-            self.allocators
-                .get_allocator_mut(self.config.allocator_mapping[allocator])
-        };
+        let allocator = self
+            .allocators
+            .get_allocator_mut(self.config.allocator_mapping[allocator]);
         // The value should be default/unset at the beginning of an allocation request.
         debug_assert!(allocator.get_context().get_alloc_options().is_default());
         allocator.alloc(size, align, offset)
@@ -210,10 +209,9 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
         allocator: AllocationSemantics,
         options: AllocationOptions,
     ) -> Address {
-        let allocator = unsafe {
-            self.allocators
-                .get_allocator_mut(self.config.allocator_mapping[allocator])
-        };
+        let allocator = self
+            .allocators
+            .get_allocator_mut(self.config.allocator_mapping[allocator]);
         // The value should be default/unset at the beginning of an allocation request.
         debug_assert!(allocator.get_context().get_alloc_options().is_default());
         allocator.alloc_with_options(size, align, offset, options)
@@ -226,10 +224,9 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
         offset: usize,
         allocator: AllocationSemantics,
     ) -> Address {
-        let allocator = unsafe {
-            self.allocators
-                .get_allocator_mut(self.config.allocator_mapping[allocator])
-        };
+        let allocator = self
+            .allocators
+            .get_allocator_mut(self.config.allocator_mapping[allocator]);
         // The value should be default/unset at the beginning of an allocation request.
         debug_assert!(allocator.get_context().get_alloc_options().is_default());
         allocator.alloc_slow(size, align, offset)
@@ -243,10 +240,9 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
         allocator: AllocationSemantics,
         options: AllocationOptions,
     ) -> Address {
-        let allocator = unsafe {
-            self.allocators
-                .get_allocator_mut(self.config.allocator_mapping[allocator])
-        };
+        let allocator = self
+            .allocators
+            .get_allocator_mut(self.config.allocator_mapping[allocator]);
         // The value should be default/unset at the beginning of an allocation request.
         debug_assert!(allocator.get_context().get_alloc_options().is_default());
         allocator.alloc_slow_with_options(size, align, offset, options)
@@ -259,12 +255,10 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
         _bytes: usize,
         allocator: AllocationSemantics,
     ) {
-        unsafe {
-            self.allocators
-                .get_allocator_mut(self.config.allocator_mapping[allocator])
-        }
-        .get_space()
-        .initialize_object_metadata(refer)
+        self.allocators
+            .get_allocator_mut(self.config.allocator_mapping[allocator])
+            .get_space()
+            .initialize_object_metadata(refer)
     }
 
     fn get_tls(&self) -> VMMutatorThread {
@@ -293,7 +287,9 @@ impl<VM: VMBinding> Mutator<VM> {
     /// Inform each allocator about destroying. Call allocator-specific on destroy methods.
     pub fn on_destroy(&mut self) {
         for selector in self.get_all_allocator_selectors() {
-            unsafe { self.allocators.get_allocator_mut(selector) }.on_mutator_destroy();
+            self.allocators
+                .get_allocator_mut(selector)
+                .on_mutator_destroy();
         }
     }
 

--- a/src/plan/semispace/mutator.rs
+++ b/src/plan/semispace/mutator.rs
@@ -17,13 +17,11 @@ use enum_map::EnumMap;
 
 pub fn ss_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
     // rebind the allocation bump pointer to the appropriate semispace
-    let bump_allocator = unsafe {
-        mutator
-            .allocators
-            .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
-    }
-    .downcast_mut::<BumpAllocator<VM>>()
-    .unwrap();
+    let bump_allocator = mutator
+        .allocators
+        .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
+        .downcast_mut::<BumpAllocator<VM>>()
+        .unwrap();
     bump_allocator.rebind(
         mutator
             .plan

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -1110,7 +1110,7 @@ impl<VM: VMBinding> ImmixCopyContext<VM> {
         space: &'static ImmixSpace<VM>,
     ) -> Self {
         ImmixCopyContext {
-            allocator: ImmixAllocator::new(tls.0, Some(space), context, true),
+            allocator: ImmixAllocator::new(tls.0, space, context, true),
         }
     }
 
@@ -1163,8 +1163,8 @@ impl<VM: VMBinding> ImmixHybridCopyContext<VM> {
         space: &'static ImmixSpace<VM>,
     ) -> Self {
         ImmixHybridCopyContext {
-            copy_allocator: ImmixAllocator::new(tls.0, Some(space), context.clone(), false),
-            defrag_allocator: ImmixAllocator::new(tls.0, Some(space), context, true),
+            copy_allocator: ImmixAllocator::new(tls.0, space, context.clone(), false),
+            defrag_allocator: ImmixAllocator::new(tls.0, space, context, true),
         }
     }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -20,6 +20,7 @@ pub mod copy_context;
 pub mod gc_work;
 pub mod sft;
 pub mod sft_map;
+pub(crate) mod unusable_space;
 
 pub mod compressor;
 pub mod copyspace;

--- a/src/policy/unusable_space.rs
+++ b/src/policy/unusable_space.rs
@@ -1,0 +1,141 @@
+use crate::plan::VectorObjectQueue;
+use crate::policy::sft::{GCWorkerMutRef, SFT};
+use crate::policy::space::{CommonSpace, Space};
+use crate::util::heap::PageResource;
+use crate::util::object_enum::ObjectEnumerator;
+use crate::util::{Address, ObjectReference};
+use crate::vm::VMBinding;
+
+#[derive(Debug)]
+pub(crate) struct UnusableSpace;
+
+pub(crate) static UNUSABLE_SPACE: UnusableSpace = UnusableSpace;
+
+pub(crate) fn unusable_space<VM: VMBinding>() -> &'static dyn Space<VM> {
+    &UNUSABLE_SPACE
+}
+
+#[cold]
+#[track_caller]
+fn panic_unusable_space(method: &str) -> ! {
+    panic!("Called {method} on UnusableSpace. The allocator is not configured for this plan.")
+}
+
+impl SFT for UnusableSpace {
+    fn name(&self) -> &'static str {
+        panic_unusable_space("SFT::name")
+    }
+
+    fn get_forwarded_object(&self, _object: ObjectReference) -> Option<ObjectReference> {
+        panic_unusable_space("SFT::get_forwarded_object")
+    }
+
+    fn is_live(&self, _object: ObjectReference) -> bool {
+        panic_unusable_space("SFT::is_live")
+    }
+
+    fn is_reachable(&self, _object: ObjectReference) -> bool {
+        panic_unusable_space("SFT::is_reachable")
+    }
+
+    #[cfg(feature = "object_pinning")]
+    fn pin_object(&self, _object: ObjectReference) -> bool {
+        panic_unusable_space("SFT::pin_object")
+    }
+
+    #[cfg(feature = "object_pinning")]
+    fn unpin_object(&self, _object: ObjectReference) -> bool {
+        panic_unusable_space("SFT::unpin_object")
+    }
+
+    #[cfg(feature = "object_pinning")]
+    fn is_object_pinned(&self, _object: ObjectReference) -> bool {
+        panic_unusable_space("SFT::is_object_pinned")
+    }
+
+    fn is_movable(&self) -> bool {
+        panic_unusable_space("SFT::is_movable")
+    }
+
+    #[cfg(feature = "sanity")]
+    fn is_sane(&self) -> bool {
+        panic_unusable_space("SFT::is_sane")
+    }
+
+    fn is_in_space(&self, _object: ObjectReference) -> bool {
+        panic_unusable_space("SFT::is_in_space")
+    }
+
+    #[cfg(feature = "vo_bit")]
+    fn is_mmtk_object(&self, _addr: Address) -> Option<ObjectReference> {
+        panic_unusable_space("SFT::is_mmtk_object")
+    }
+
+    #[cfg(feature = "vo_bit")]
+    fn find_object_from_internal_pointer(
+        &self,
+        _ptr: Address,
+        _max_search_bytes: usize,
+    ) -> Option<ObjectReference> {
+        panic_unusable_space("SFT::find_object_from_internal_pointer")
+    }
+
+    fn initialize_object_metadata(&self, _object: ObjectReference) {
+        panic_unusable_space("SFT::initialize_object_metadata")
+    }
+
+    fn sft_trace_object(
+        &self,
+        _queue: &mut VectorObjectQueue,
+        _object: ObjectReference,
+        _worker: GCWorkerMutRef,
+    ) -> ObjectReference {
+        panic_unusable_space("SFT::sft_trace_object")
+    }
+
+    fn debug_print_object_info(&self, _object: ObjectReference) {
+        panic_unusable_space("SFT::debug_print_object_info")
+    }
+}
+
+impl<VM: VMBinding> Space<VM> for UnusableSpace {
+    fn as_space(&self) -> &dyn Space<VM> {
+        panic_unusable_space("Space::as_space")
+    }
+
+    fn as_sft(&self) -> &(dyn SFT + Sync + 'static) {
+        panic_unusable_space("Space::as_sft")
+    }
+
+    fn get_page_resource(&self) -> &dyn PageResource<VM> {
+        panic_unusable_space("Space::get_page_resource")
+    }
+
+    fn maybe_get_page_resource_mut(&mut self) -> Option<&mut dyn PageResource<VM>> {
+        panic_unusable_space("Space::maybe_get_page_resource_mut")
+    }
+
+    fn initialize_sft(&self, _sft_map: &mut dyn crate::policy::sft_map::SFTMap) {
+        panic_unusable_space("Space::initialize_sft")
+    }
+
+    fn common(&self) -> &CommonSpace<VM> {
+        panic_unusable_space("Space::common")
+    }
+
+    fn release_multiple_pages(&mut self, _start: Address) {
+        panic_unusable_space("Space::release_multiple_pages")
+    }
+
+    fn enumerate_objects(&self, _enumerator: &mut dyn ObjectEnumerator) {
+        panic_unusable_space("Space::enumerate_objects")
+    }
+
+    fn clear_side_log_bits(&self) {
+        panic_unusable_space("Space::clear_side_log_bits")
+    }
+
+    fn set_side_log_bits(&self) {
+        panic_unusable_space("Space::set_side_log_bits")
+    }
+}

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -1,12 +1,9 @@
-use std::mem::MaybeUninit;
 use std::sync::Arc;
 
 use memoffset::offset_of;
 
-use crate::policy::largeobjectspace::LargeObjectSpace;
-use crate::policy::marksweepspace::malloc_ms::MallocSpace;
-use crate::policy::marksweepspace::native_ms::MarkSweepSpace;
 use crate::policy::space::Space;
+use crate::policy::unusable_space::unusable_space;
 use crate::util::alloc::LargeObjectAllocator;
 use crate::util::alloc::MallocAllocator;
 use crate::util::alloc::{Allocator, BumpAllocator, ImmixAllocator};
@@ -32,67 +29,44 @@ pub(crate) const MAX_MARK_COMPACT_ALLOCATORS: usize = 1;
 // We are trying to make it fixed-sized so that VM bindings can easily define a Mutator type to have the exact same layout as our Mutator struct.
 #[repr(C)]
 pub struct Allocators<VM: VMBinding> {
-    pub bump_pointer: [MaybeUninit<BumpAllocator<VM>>; MAX_BUMP_ALLOCATORS],
-    pub large_object: [MaybeUninit<LargeObjectAllocator<VM>>; MAX_LARGE_OBJECT_ALLOCATORS],
-    pub malloc: [MaybeUninit<MallocAllocator<VM>>; MAX_MALLOC_ALLOCATORS],
-    pub immix: [MaybeUninit<ImmixAllocator<VM>>; MAX_IMMIX_ALLOCATORS],
-    pub free_list: [MaybeUninit<FreeListAllocator<VM>>; MAX_FREE_LIST_ALLOCATORS],
-    pub markcompact: [MaybeUninit<MarkCompactAllocator<VM>>; MAX_MARK_COMPACT_ALLOCATORS],
+    pub bump_pointer: [BumpAllocator<VM>; MAX_BUMP_ALLOCATORS],
+    pub large_object: [LargeObjectAllocator<VM>; MAX_LARGE_OBJECT_ALLOCATORS],
+    pub malloc: [MallocAllocator<VM>; MAX_MALLOC_ALLOCATORS],
+    pub immix: [ImmixAllocator<VM>; MAX_IMMIX_ALLOCATORS],
+    pub free_list: [FreeListAllocator<VM>; MAX_FREE_LIST_ALLOCATORS],
+    pub markcompact: [MarkCompactAllocator<VM>; MAX_MARK_COMPACT_ALLOCATORS],
 }
 
 impl<VM: VMBinding> Allocators<VM> {
-    /// # Safety
-    /// The selector needs to be valid, and points to an allocator that has been initialized.
-    pub unsafe fn get_allocator(&self, selector: AllocatorSelector) -> &dyn Allocator<VM> {
+    pub fn get_allocator(&self, selector: AllocatorSelector) -> &dyn Allocator<VM> {
         match selector {
-            AllocatorSelector::BumpPointer(index) => {
-                self.bump_pointer[index as usize].assume_init_ref()
-            }
-            AllocatorSelector::LargeObject(index) => {
-                self.large_object[index as usize].assume_init_ref()
-            }
-            AllocatorSelector::Malloc(index) => self.malloc[index as usize].assume_init_ref(),
-            AllocatorSelector::Immix(index) => self.immix[index as usize].assume_init_ref(),
-            AllocatorSelector::FreeList(index) => self.free_list[index as usize].assume_init_ref(),
-            AllocatorSelector::MarkCompact(index) => {
-                self.markcompact[index as usize].assume_init_ref()
-            }
+            AllocatorSelector::BumpPointer(index) => &self.bump_pointer[index as usize],
+            AllocatorSelector::LargeObject(index) => &self.large_object[index as usize],
+            AllocatorSelector::Malloc(index) => &self.malloc[index as usize],
+            AllocatorSelector::Immix(index) => &self.immix[index as usize],
+            AllocatorSelector::FreeList(index) => &self.free_list[index as usize],
+            AllocatorSelector::MarkCompact(index) => &self.markcompact[index as usize],
             AllocatorSelector::None => panic!("Allocator mapping is not initialized"),
         }
     }
 
-    /// # Safety
-    /// The selector needs to be valid, and points to an allocator that has been initialized.
-    pub unsafe fn get_typed_allocator<T: Allocator<VM>>(&self, selector: AllocatorSelector) -> &T {
+    pub fn get_typed_allocator<T: Allocator<VM>>(&self, selector: AllocatorSelector) -> &T {
         self.get_allocator(selector).downcast_ref().unwrap()
     }
 
-    /// # Safety
-    /// The selector needs to be valid, and points to an allocator that has been initialized.
-    pub unsafe fn get_allocator_mut(
-        &mut self,
-        selector: AllocatorSelector,
-    ) -> &mut dyn Allocator<VM> {
+    pub fn get_allocator_mut(&mut self, selector: AllocatorSelector) -> &mut dyn Allocator<VM> {
         match selector {
-            AllocatorSelector::BumpPointer(index) => {
-                self.bump_pointer[index as usize].assume_init_mut()
-            }
-            AllocatorSelector::LargeObject(index) => {
-                self.large_object[index as usize].assume_init_mut()
-            }
-            AllocatorSelector::Malloc(index) => self.malloc[index as usize].assume_init_mut(),
-            AllocatorSelector::Immix(index) => self.immix[index as usize].assume_init_mut(),
-            AllocatorSelector::FreeList(index) => self.free_list[index as usize].assume_init_mut(),
-            AllocatorSelector::MarkCompact(index) => {
-                self.markcompact[index as usize].assume_init_mut()
-            }
+            AllocatorSelector::BumpPointer(index) => &mut self.bump_pointer[index as usize],
+            AllocatorSelector::LargeObject(index) => &mut self.large_object[index as usize],
+            AllocatorSelector::Malloc(index) => &mut self.malloc[index as usize],
+            AllocatorSelector::Immix(index) => &mut self.immix[index as usize],
+            AllocatorSelector::FreeList(index) => &mut self.free_list[index as usize],
+            AllocatorSelector::MarkCompact(index) => &mut self.markcompact[index as usize],
             AllocatorSelector::None => panic!("Allocator mapping is not initialized"),
         }
     }
 
-    /// # Safety
-    /// The selector needs to be valid, and points to an allocator that has been initialized.
-    pub unsafe fn get_typed_allocator_mut<T: Allocator<VM>>(
+    pub fn get_typed_allocator_mut<T: Allocator<VM>>(
         &mut self,
         selector: AllocatorSelector,
     ) -> &mut T {
@@ -104,60 +78,53 @@ impl<VM: VMBinding> Allocators<VM> {
         mmtk: &MMTK<VM>,
         space_mapping: &[(AllocatorSelector, &'static dyn Space<VM>)],
     ) -> Self {
-        let mut ret = Allocators {
-            bump_pointer: unsafe { MaybeUninit::uninit().assume_init() },
-            large_object: unsafe { MaybeUninit::uninit().assume_init() },
-            malloc: unsafe { MaybeUninit::uninit().assume_init() },
-            immix: unsafe { MaybeUninit::uninit().assume_init() },
-            free_list: unsafe { MaybeUninit::uninit().assume_init() },
-            markcompact: unsafe { MaybeUninit::uninit().assume_init() },
-        };
         let context = Arc::new(AllocatorContext::new(mmtk));
+        let mut ret = Allocators {
+            bump_pointer: std::array::from_fn(|_| {
+                BumpAllocator::new(mutator_tls.0, unusable_space(), context.clone())
+            }),
+            large_object: std::array::from_fn(|_| {
+                LargeObjectAllocator::new(mutator_tls.0, unusable_space(), context.clone())
+            }),
+            malloc: std::array::from_fn(|_| {
+                MallocAllocator::new(mutator_tls.0, unusable_space(), context.clone())
+            }),
+            immix: std::array::from_fn(|_| {
+                ImmixAllocator::new(mutator_tls.0, unusable_space(), context.clone(), false)
+            }),
+            free_list: std::array::from_fn(|_| {
+                FreeListAllocator::new(mutator_tls.0, unusable_space(), context.clone())
+            }),
+            markcompact: std::array::from_fn(|_| {
+                MarkCompactAllocator::new(mutator_tls.0, unusable_space(), context.clone())
+            }),
+        };
 
         for &(selector, space) in space_mapping.iter() {
             match selector {
                 AllocatorSelector::BumpPointer(index) => {
-                    ret.bump_pointer[index as usize].write(BumpAllocator::new(
-                        mutator_tls.0,
-                        space,
-                        context.clone(),
-                    ));
+                    ret.bump_pointer[index as usize] =
+                        BumpAllocator::new(mutator_tls.0, space, context.clone());
                 }
                 AllocatorSelector::LargeObject(index) => {
-                    ret.large_object[index as usize].write(LargeObjectAllocator::new(
-                        mutator_tls.0,
-                        space.downcast_ref::<LargeObjectSpace<VM>>().unwrap(),
-                        context.clone(),
-                    ));
+                    ret.large_object[index as usize] =
+                        LargeObjectAllocator::new(mutator_tls.0, space, context.clone());
                 }
                 AllocatorSelector::Malloc(index) => {
-                    ret.malloc[index as usize].write(MallocAllocator::new(
-                        mutator_tls.0,
-                        space.downcast_ref::<MallocSpace<VM>>().unwrap(),
-                        context.clone(),
-                    ));
+                    ret.malloc[index as usize] =
+                        MallocAllocator::new(mutator_tls.0, space, context.clone());
                 }
                 AllocatorSelector::Immix(index) => {
-                    ret.immix[index as usize].write(ImmixAllocator::new(
-                        mutator_tls.0,
-                        Some(space),
-                        context.clone(),
-                        false,
-                    ));
+                    ret.immix[index as usize] =
+                        ImmixAllocator::new(mutator_tls.0, space, context.clone(), false);
                 }
                 AllocatorSelector::FreeList(index) => {
-                    ret.free_list[index as usize].write(FreeListAllocator::new(
-                        mutator_tls.0,
-                        space.downcast_ref::<MarkSweepSpace<VM>>().unwrap(),
-                        context.clone(),
-                    ));
+                    ret.free_list[index as usize] =
+                        FreeListAllocator::new(mutator_tls.0, space, context.clone());
                 }
                 AllocatorSelector::MarkCompact(index) => {
-                    ret.markcompact[index as usize].write(MarkCompactAllocator::new(
-                        mutator_tls.0,
-                        space,
-                        context.clone(),
-                    ));
+                    ret.markcompact[index as usize] =
+                        MarkCompactAllocator::new(mutator_tls.0, space, context.clone());
                 }
                 AllocatorSelector::None => panic!("Allocator mapping is not initialized"),
             }

--- a/src/util/alloc/free_list_allocator.rs
+++ b/src/util/alloc/free_list_allocator.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use super::allocator::AllocatorContext;
 use crate::policy::marksweepspace::native_ms::*;
+use crate::policy::space::Space;
 use crate::util::alloc::allocator;
 use crate::util::alloc::Allocator;
 use crate::util::linear_scan::Region;
@@ -16,7 +17,7 @@ use crate::vm::VMBinding;
 pub struct FreeListAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
-    space: &'static MarkSweepSpace<VM>,
+    space: &'static dyn Space<VM>,
     context: Arc<AllocatorContext<VM>>,
     /// blocks with free space
     pub available_blocks: BlockLists,
@@ -37,7 +38,7 @@ impl<VM: VMBinding> Allocator<VM> for FreeListAllocator<VM> {
         self.tls
     }
 
-    fn get_space(&self) -> &'static dyn crate::policy::space::Space<VM> {
+    fn get_space(&self) -> &'static dyn Space<VM> {
         self.space
     }
 
@@ -122,7 +123,11 @@ impl<VM: VMBinding> Allocator<VM> for FreeListAllocator<VM> {
     }
 
     fn on_mutator_destroy(&mut self) {
-        let mut global = self.space.get_abandoned_block_lists().lock().unwrap();
+        let mut global = self
+            .mark_sweep_space()
+            .get_abandoned_block_lists()
+            .lock()
+            .unwrap();
         self.abandon_blocks(&mut global);
     }
 }
@@ -131,7 +136,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
     // New free list allcoator
     pub(crate) fn new(
         tls: VMThread,
-        space: &'static MarkSweepSpace<VM>,
+        space: &'static dyn Space<VM>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         FreeListAllocator {
@@ -143,6 +148,13 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
             unswept_blocks: new_empty_block_lists(),
             consumed_blocks: new_empty_block_lists(),
         }
+    }
+
+    #[track_caller]
+    fn mark_sweep_space(&self) -> &'static MarkSweepSpace<VM> {
+        self.space
+            .downcast_ref::<MarkSweepSpace<VM>>()
+            .expect("FreeListAllocator is backed by UnusableSpace")
     }
 
     // Find a free cell within a given block
@@ -295,7 +307,12 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
     ) -> Option<Block> {
         let bin = mi_bin::<VM>(size, align);
         loop {
-            match self.space.acquire_block(self.tls, size, align, self.get_context().get_alloc_options()) {
+            match self.mark_sweep_space().acquire_block(
+                self.tls,
+                size,
+                align,
+                self.get_context().get_alloc_options(),
+            ) {
                 crate::policy::marksweepspace::native_ms::BlockAcquireResult::Exhausted => {
                     debug!("Acquire global block: None");
                     // GC
@@ -338,7 +355,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
 
     fn init_block(&self, block: Block, cell_size: usize) {
         debug_assert_ne!(cell_size, 0);
-        self.space.record_new_block(block);
+        self.mark_sweep_space().record_new_block(block);
 
         // construct free list
         let block_end = block.start() + Block::BYTES;
@@ -417,6 +434,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
     pub(crate) fn prepare(&mut self) {}
 
     pub(crate) fn release(&mut self) {
+        let space = self.mark_sweep_space();
         for bin in 0..MI_BIN_FULL {
             let unswept = self.unswept_blocks.get_mut(bin).unwrap();
 
@@ -425,7 +443,7 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
             debug_assert!(unswept.is_empty());
 
             let mut sweep_later = |list: &mut BlockList| {
-                list.release_blocks(self.space);
+                list.release_blocks(space);
 
                 // For eager sweeping, that's it.  We just release unmarked blocks, and leave marked
                 // blocks to be swept later in the `SweepChunk` work packet.
@@ -445,11 +463,15 @@ impl<VM: VMBinding> FreeListAllocator<VM> {
         // We abandon block lists immediately.  Otherwise, some mutators will hold lots of blocks
         // locally and prevent other mutators to use.
         {
-            let mut global = self.space.get_abandoned_block_lists_in_gc().lock().unwrap();
+            let mut global = self
+                .mark_sweep_space()
+                .get_abandoned_block_lists_in_gc()
+                .lock()
+                .unwrap();
             self.abandon_blocks(&mut global);
         }
 
-        self.space.release_packet_done();
+        self.mark_sweep_space().release_packet_done();
     }
 
     fn abandon_blocks(&mut self, global: &mut AbandonedBlockLists) {

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -22,7 +22,7 @@ pub struct ImmixAllocator<VM: VMBinding> {
     /// The fastpath bump pointer.
     pub bump_pointer: BumpPointer,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
-    space: &'static ImmixSpace<VM>,
+    space: &'static dyn Space<VM>,
     context: Arc<AllocatorContext<VM>>,
     /// *unused*
     hot: bool,
@@ -47,7 +47,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
 
 impl<VM: VMBinding> Allocator<VM> for ImmixAllocator<VM> {
     fn get_space(&self) -> &'static dyn Space<VM> {
-        self.space as _
+        self.space
     }
 
     fn get_context(&self) -> &AllocatorContext<VM> {
@@ -169,13 +169,13 @@ impl<VM: VMBinding> Allocator<VM> for ImmixAllocator<VM> {
 impl<VM: VMBinding> ImmixAllocator<VM> {
     pub(crate) fn new(
         tls: VMThread,
-        space: Option<&'static dyn Space<VM>>,
+        space: &'static dyn Space<VM>,
         context: Arc<AllocatorContext<VM>>,
         copy: bool,
     ) -> Self {
         ImmixAllocator {
             tls,
-            space: space.unwrap().downcast_ref::<ImmixSpace<VM>>().unwrap(),
+            space,
             context,
             bump_pointer: BumpPointer::default(),
             hot: false,
@@ -186,8 +186,11 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
         }
     }
 
+    #[track_caller]
     pub(crate) fn immix_space(&self) -> &'static ImmixSpace<VM> {
         self.space
+            .downcast_ref::<ImmixSpace<VM>>()
+            .expect("ImmixAllocator is backed by UnusableSpace")
     }
 
     /// Large-object (larger than a line) bump allocation.
@@ -268,7 +271,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                 };
                 // mark objects if concurrent marking is active
                 if self.immix_space().should_allocate_as_live() {
-                    let state = self.space.line_mark_state.load(Ordering::Acquire);
+                    let state = self.immix_space().line_mark_state.load(Ordering::Acquire);
                     Line::eager_mark_lines::<VM>(state, start_line..end_line);
                 }
                 return true;
@@ -313,7 +316,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     .bzero_metadata(block.start(), crate::policy::immix::block::Block::BYTES);
                 // mark objects if concurrent marking is active
                 if self.immix_space().should_allocate_as_live() {
-                    let state = self.space.line_mark_state.load(Ordering::Acquire);
+                    let state = self.immix_space().line_mark_state.load(Ordering::Acquire);
                     Line::eager_mark_lines::<VM>(state, block.start_line()..block.end_line());
                 }
                 if self.request_for_large {

--- a/src/util/alloc/large_object_allocator.rs
+++ b/src/util/alloc/large_object_allocator.rs
@@ -16,7 +16,7 @@ pub struct LargeObjectAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
-    space: &'static LargeObjectSpace<VM>,
+    space: &'static dyn Space<VM>,
     context: Arc<AllocatorContext<VM>>,
 }
 
@@ -30,8 +30,7 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
     }
 
     fn get_space(&self) -> &'static dyn Space<VM> {
-        // Casting the interior of the Option: from &LargeObjectSpace to &dyn Space
-        self.space as &'static dyn Space<VM>
+        self.space
     }
 
     fn does_thread_local_allocation(&self) -> bool {
@@ -59,15 +58,18 @@ impl<VM: VMBinding> Allocator<VM> for LargeObjectAllocator<VM> {
             return Address::ZERO;
         }
 
-        self.space
-            .allocate_pages(self.tls, pages, self.get_context().get_alloc_options())
+        self.large_object_space().allocate_pages(
+            self.tls,
+            pages,
+            self.get_context().get_alloc_options(),
+        )
     }
 }
 
 impl<VM: VMBinding> LargeObjectAllocator<VM> {
     pub(crate) fn new(
         tls: VMThread,
-        space: &'static LargeObjectSpace<VM>,
+        space: &'static dyn Space<VM>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         LargeObjectAllocator {
@@ -75,5 +77,12 @@ impl<VM: VMBinding> LargeObjectAllocator<VM> {
             space,
             context,
         }
+    }
+
+    #[track_caller]
+    fn large_object_space(&self) -> &'static LargeObjectSpace<VM> {
+        self.space
+            .downcast_ref::<LargeObjectSpace<VM>>()
+            .expect("LargeObjectAllocator is backed by UnusableSpace")
     }
 }

--- a/src/util/alloc/malloc_allocator.rs
+++ b/src/util/alloc/malloc_allocator.rs
@@ -16,13 +16,13 @@ pub struct MallocAllocator<VM: VMBinding> {
     /// [`VMThread`] associated with this allocator instance
     pub tls: VMThread,
     /// [`Space`](src/policy/space/Space) instance associated with this allocator instance.
-    space: &'static MallocSpace<VM>,
+    space: &'static dyn Space<VM>,
     context: Arc<AllocatorContext<VM>>,
 }
 
 impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
     fn get_space(&self) -> &'static dyn Space<VM> {
-        self.space as &'static dyn Space<VM>
+        self.space
     }
 
     fn get_context(&self) -> &AllocatorContext<VM> {
@@ -42,14 +42,14 @@ impl<VM: VMBinding> Allocator<VM> for MallocAllocator<VM> {
     }
 
     fn alloc_slow_once(&mut self, size: usize, align: usize, offset: usize) -> Address {
-        self.space.alloc(self.tls, size, align, offset)
+        self.malloc_space().alloc(self.tls, size, align, offset)
     }
 }
 
 impl<VM: VMBinding> MallocAllocator<VM> {
     pub(crate) fn new(
         tls: VMThread,
-        space: &'static MallocSpace<VM>,
+        space: &'static dyn Space<VM>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
         MallocAllocator {
@@ -57,5 +57,12 @@ impl<VM: VMBinding> MallocAllocator<VM> {
             space,
             context,
         }
+    }
+
+    #[track_caller]
+    fn malloc_space(&self) -> &'static MallocSpace<VM> {
+        self.space
+            .downcast_ref::<MallocSpace<VM>>()
+            .expect("MallocAllocator is backed by UnusableSpace")
     }
 }


### PR DESCRIPTION
Inspired by https://github.com/mmtk/mmtk-core/pull/1483.
* Initialize all the allocators with unusable space first.
* Then initialize the allocators that a plan may use with proper spaces.
* Refactor allocators so all allocators reference a `&dyn Space`. This requires changing bindings, as the layout of allocators are changed.