### PR TITLE
Add bytes parameter to initialize_object_metadata

### DIFF
--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -23,6 +23,8 @@ use crate::util::sanity::sanity_checker::SanityChecker;
 #[cfg(feature = "extreme_assertions")]
 use crate::util::slot_logger::SlotLogger;
 use crate::util::statistics::stats::Stats;
+#[cfg(feature = "vm_space")]
+use crate::vm::object_model::ObjectModel;
 use crate::vm::ReferenceGlue;
 use crate::vm::VMBinding;
 use std::cell::UnsafeCell;

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -577,10 +577,11 @@ impl<VM: VMBinding> MMTK<VM> {
     #[cfg(feature = "vm_space")]
     pub fn initialize_vm_space_object(&self, object: crate::util::ObjectReference) {
         use crate::policy::sft::SFT;
+        let bytes = VM::VMObjectModel::get_current_size(object);
         self.get_plan()
             .base()
             .vm_space
-            .initialize_object_metadata(object)
+            .initialize_object_metadata(object, bytes)
     }
 }
 

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -253,18 +253,13 @@ impl<VM: VMBinding> MutatorContext<VM> for Mutator<VM> {
     }
 
     // Note that this method is slow, and we expect VM bindings that care about performance to implement allocation fastpath sequence in their bindings.
-    fn post_alloc(
-        &mut self,
-        refer: ObjectReference,
-        _bytes: usize,
-        allocator: AllocationSemantics,
-    ) {
+    fn post_alloc(&mut self, refer: ObjectReference, bytes: usize, allocator: AllocationSemantics) {
         unsafe {
             self.allocators
                 .get_allocator_mut(self.config.allocator_mapping[allocator])
         }
         .get_space()
-        .initialize_object_metadata(refer)
+        .initialize_object_metadata(refer, bytes)
     }
 
     fn get_tls(&self) -> VMMutatorThread {

--- a/src/policy/compressor/compressorspace.rs
+++ b/src/policy/compressor/compressorspace.rs
@@ -86,7 +86,7 @@ impl<VM: VMBinding> SFT for CompressorSpace<VM> {
         true
     }
 
-    fn initialize_object_metadata(&self, _object: ObjectReference) {
+    fn initialize_object_metadata(&self, _object: ObjectReference, _bytes: usize) {
         #[cfg(feature = "vo_bit")]
         crate::util::metadata::vo_bit::set_vo_bit(_object);
     }

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -57,7 +57,7 @@ impl<VM: VMBinding> SFT for CopySpace<VM> {
         !self.is_from_space()
     }
 
-    fn initialize_object_metadata(&self, _object: ObjectReference) {
+    fn initialize_object_metadata(&self, _object: ObjectReference, _bytes: usize) {
         #[cfg(feature = "vo_bit")]
         crate::util::metadata::vo_bit::set_vo_bit(_object);
     }

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -125,7 +125,7 @@ impl<VM: VMBinding> SFT for ImmixSpace<VM> {
     fn is_sane(&self) -> bool {
         true
     }
-    fn initialize_object_metadata(&self, _object: ObjectReference) {
+    fn initialize_object_metadata(&self, _object: ObjectReference, _bytes: usize) {
         #[cfg(feature = "vo_bit")]
         crate::util::metadata::vo_bit::set_vo_bit(_object);
     }

--- a/src/policy/immortalspace.rs
+++ b/src/policy/immortalspace.rs
@@ -53,7 +53,7 @@ impl<VM: VMBinding> SFT for ImmortalSpace<VM> {
     fn is_sane(&self) -> bool {
         true
     }
-    fn initialize_object_metadata(&self, object: ObjectReference) {
+    fn initialize_object_metadata(&self, object: ObjectReference, _bytes: usize) {
         self.mark_state
             .on_object_metadata_initialization::<VM>(object);
         if self.common.unlog_allocated_object {

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -61,7 +61,7 @@ impl<VM: VMBinding> SFT for LargeObjectSpace<VM> {
         true
     }
 
-    fn initialize_object_metadata(&self, object: ObjectReference) {
+    fn initialize_object_metadata(&self, object: ObjectReference, _bytes: usize) {
         // VO bit: Set for all objects.
         #[cfg(feature = "vo_bit")]
         crate::util::metadata::vo_bit::set_vo_bit(object);

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -71,7 +71,7 @@ impl<VM: VMBinding> SFT for LockFreeImmortalSpace<VM> {
     fn is_sane(&self) -> bool {
         unimplemented!()
     }
-    fn initialize_object_metadata(&self, _object: ObjectReference) {
+    fn initialize_object_metadata(&self, _object: ObjectReference, _bytes: usize) {
         #[cfg(feature = "vo_bit")]
         crate::util::metadata::vo_bit::set_vo_bit(_object);
     }

--- a/src/policy/markcompactspace.rs
+++ b/src/policy/markcompactspace.rs
@@ -64,7 +64,7 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
         true
     }
 
-    fn initialize_object_metadata(&self, object: ObjectReference) {
+    fn initialize_object_metadata(&self, object: ObjectReference, _bytes: usize) {
         crate::util::metadata::vo_bit::set_vo_bit(object);
     }
 

--- a/src/policy/marksweepspace/malloc_ms/global.rs
+++ b/src/policy/marksweepspace/malloc_ms/global.rs
@@ -125,7 +125,7 @@ impl<VM: VMBinding> SFT for MallocSpace<VM> {
         )
     }
 
-    fn initialize_object_metadata(&self, object: ObjectReference) {
+    fn initialize_object_metadata(&self, object: ObjectReference, _bytes: usize) {
         trace!("initialize_object_metadata for object {}", object);
         set_vo_bit(object);
     }

--- a/src/policy/marksweepspace/native_ms/global.rs
+++ b/src/policy/marksweepspace/native_ms/global.rs
@@ -191,7 +191,7 @@ impl<VM: VMBinding> SFT for MarkSweepSpace<VM> {
         true
     }
 
-    fn initialize_object_metadata(&self, _object: crate::util::ObjectReference) {
+    fn initialize_object_metadata(&self, _object: crate::util::ObjectReference, _bytes: usize) {
         #[cfg(feature = "vo_bit")]
         crate::util::metadata::vo_bit::set_vo_bit(_object);
     }

--- a/src/policy/sft.rs
+++ b/src/policy/sft.rs
@@ -92,7 +92,7 @@ pub trait SFT {
     ///     to set the metadata for the VM space.
     /// -   Objects in other spaces are allocated by mutators using an MMTk allocator.
     ///     `Mutator::post_alloc` will call this method after allocation.
-    fn initialize_object_metadata(&self, object: ObjectReference);
+    fn initialize_object_metadata(&self, object: ObjectReference, _bytes: usize);
 
     /// Trace objects through SFT. This along with [`SFTProcessEdges`](mmtk/scheduler/gc_work/SFTProcessEdges)
     /// provides an easy way for most plans to trace objects without the need to implement any plan-specific
@@ -185,7 +185,7 @@ impl SFT for EmptySpaceSFT {
         None
     }
 
-    fn initialize_object_metadata(&self, object: ObjectReference) {
+    fn initialize_object_metadata(&self, object: ObjectReference, _bytes: usize) {
         panic!(
             "Called initialize_object_metadata() on {:x}, which maps to an empty space",
             object

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -58,7 +58,7 @@ impl<VM: VMBinding> SFT for VMSpace<VM> {
     fn is_sane(&self) -> bool {
         true
     }
-    fn initialize_object_metadata(&self, object: ObjectReference) {
+    fn initialize_object_metadata(&self, object: ObjectReference, _bytes: usize) {
         self.mark_state
             .on_object_metadata_initialization::<VM>(object);
         if self.common.unlog_allocated_object {


### PR DESCRIPTION
Pass the object allocation size to `initialize_object_metadata` so that spaces can initialize metadata for the object's entire address range. For example, LXR uses it to initialize per-page side metadata for LOS objects.