### PR TITLE
Concurrent Immix should do a full collection on user requests

### DIFF
--- a/src/plan/concurrent/immix/global.rs
+++ b/src/plan/concurrent/immix/global.rs
@@ -146,7 +146,11 @@ impl<VM: VMBinding> Plan for ConcurrentImmix<VM> {
             // It is related to defragmentation.  See https://github.com/mmtk/mmtk-core/issues/1357 for more details.
             // We currently force `FinalMark` to happen if the last pause is `InitialMark`.
             Pause::FinalMark
-        } else if self.should_do_full_gc.load(Ordering::SeqCst) {
+        } else if self.should_do_full_gc.load(Ordering::SeqCst)
+            // For user-triggered GCs, we don't want a simple initial pause which reclaims nothing.
+            // We do a full STW collection for user triggered collection instead.
+            || self.base().global_state.is_user_triggered_collection()
+        {
             Pause::Full
         } else {
             Pause::InitialMark


### PR DESCRIPTION
On user collection requests, concurrent Immix should make some efforts on reclaiming memory (either doing a final marking pause, or a full STW pause). Though how we handle user collection requests is totally up to the plan, triggering an initial marking pause on user requested collection does not reclaim anything and is almost unexpected.