### PR TITLE
`ObjectBarrier::object_is_unlogged` should be atomic

### DIFF
--- a/src/plan/barriers.rs
+++ b/src/plan/barriers.rs
@@ -192,10 +192,9 @@ impl<S: BarrierSemantics> ObjectBarrier<S> {
         Self { semantics }
     }
 
-    /// Attempt to atomically log an object.
-    /// Returns true if the object is not logged previously.
+    /// Returns true if the object is not logged.
     fn object_is_unlogged(&self, object: ObjectReference) -> bool {
-        unsafe { S::UNLOG_BIT_SPEC.load::<S::VM, u8>(object, None) != 0 }
+        S::UNLOG_BIT_SPEC.load_atomic::<S::VM, u8>(object, None, Ordering::SeqCst) != 0
     }
 
     /// Attempt to atomically log an object.


### PR DESCRIPTION
This change fixes a probable soundness bug in this code, and updates the doc comment which appears to have been copied from `log_object` and was incorrect for this given function.

I believe this is a soundness bug because this function is called in the fastpath of ObjectBarrier, which amounts to (when expanded):
```rs
if self.object_is_unlogged(src) {
  if self.log_object(src) {
    ...snip...
  }
}
```

`log_object` is atomic, but `object_is_unlogged` is **not**. Interleaving atomic and non-atomic operations like this, as well as using non-atomic accesses concurrently when this metadata bit may be modified concurrently, [is unsound][1].

This bug does not affect SATBBarrier, as it already uses proper atomic operations in both the `object_is_unlogged` and `log_object` cases.

[1]: https://doc.rust-lang.org/stable/std/sync/atomic/index.html#memory-model-for-atomic-accesses

I have used `SeqCst` here even though I believe another ordering may be more apt, as I think those changes should be in a different PR as part of #840, and I am not entirely sure of this due to the prevalent usage of `SeqCst` within the MMTk codebase already. You may refer to [my thoughts on this that I posted on the Zulip][2].

[2]: https://mmtk.zulipchat.com/#narrow/channel/262673-mmtk-core/topic/Extending.20atomics.20audit.20.28.23840.29.20to.20usage.20of.20SeqCst/near/596237532
