### PR TITLE
Update ci-perf-kit to 0.8.8. New epoch.

### DIFF
--- a/.github/workflows/micro-bm.yml
+++ b/.github/workflows/micro-bm.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_PERF_KIT_VERSION: 0.8.7
+  CI_PERF_KIT_VERSION: 0.8.8
 
 jobs:
   openjdk-microbm:

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -19,7 +19,7 @@ env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
-  CI_PERF_KIT_VERSION: 0.8.7
+  CI_PERF_KIT_VERSION: 0.8.8
 
 jobs:
   jikesrvm-baseline:

--- a/.github/workflows/perf-compare-ci.yml
+++ b/.github/workflows/perf-compare-ci.yml
@@ -20,7 +20,7 @@ env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
-  CI_PERF_KIT_VERSION: 0.8.7
+  CI_PERF_KIT_VERSION: 0.8.8
 
 jobs:
     # Figure out binding PRs.

--- a/.github/workflows/perf-regression-ci.yml
+++ b/.github/workflows/perf-regression-ci.yml
@@ -20,7 +20,7 @@ env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
-  CI_PERF_KIT_VERSION: 0.8.7
+  CI_PERF_KIT_VERSION: 0.8.8
 
 jobs:
   # JikesRVM


### PR DESCRIPTION
Update ci-perf-kit to https://github.com/mmtk/ci-perf-kit/releases/tag/0.8.8.