### PR TITLE
Log pause time with fractional milliseconds

### DIFF
--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -575,10 +575,10 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         let elapsed = start_time.elapsed();
 
         info!(
-            "End of GC ({}/{} pages, took {} ms)",
+            "End of GC ({}/{} pages, took {:.2} ms)",
             mmtk.get_plan().get_reserved_pages(),
             mmtk.get_plan().get_total_pages(),
-            elapsed.as_millis()
+            elapsed.as_secs_f64() * 1000.0
         );
 
         // USDT tracepoint for the end of GC.


### PR DESCRIPTION
`elapsed.as_millis()` truncates the value down to the nearest integral value (milliseconds). When the pause is short enough, the fractional part becomes significant. This PR switches the log to use floating-point millisecond values so short pauses can be displayed with sub-millisecond precision.