### PR TITLE
Draft: clarify/change ScanMutatorRoots interface

### DIFF
--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -195,7 +195,11 @@ pub struct StopMutators<C: GCWorkContext> {
     /// If this is true, we skip creating root-scanning work packets.
     /// By default, this is false.
     skip_roots: bool,
-    /// Flush mutators once they are stopped. By default this is false. [`ScanMutatorRoots`] will flush mutators.
+    /// Flush mutators once they are stopped. By default this is false.
+    /// Use it via [`StopMutators::new_no_scan_roots`] to flush mutators when
+    /// no root scan is run. When a root scan is run, the binding's
+    /// [`crate::vm::Scanning::scan_roots_in_mutator_thread`] is responsible
+    /// for flushing the mutator (see contract on that method).
     flush_mutator: bool,
     phantom: PhantomData<C>,
 }
@@ -442,7 +446,6 @@ impl<C: GCWorkContext> GCWork<C::VM> for ScanMutatorRoots<C> {
             unsafe { &mut *(self.0 as *mut _) },
             factory,
         );
-        self.0.flush();
 
         if mmtk.state.inform_stack_scanned(mutators) {
             <C::VM as VMBinding>::VMScanning::notify_initial_thread_scan_complete(

--- a/src/vm/scanning.rs
+++ b/src/vm/scanning.rs
@@ -246,6 +246,14 @@ pub trait Scanning<VM: VMBinding> {
     /// The `memory_manager::is_mmtk_object` function can be used in this function if
     /// -   the "vo_bit" feature is enabled.
     ///
+    /// Implementors must call `mutator.flush()` before this method returns,
+    /// after publishing roots to the factory. The flush drains per-mutator
+    /// barrier/remset buffers and is required for correctness in plans that
+    /// use them (e.g. SATB, generational remsets). MMTk core no longer flushes
+    /// on the binding's behalf; this gives bindings full control over the
+    /// per-mutator scan window, enabling per-mutator early release in plans
+    /// that want it.
+    ///
     /// Arguments:
     /// * `tls`: The GC thread that is performing this scanning.
     /// * `mutator`: The reference to the mutator whose roots will be scanned.


### PR DESCRIPTION
pairs with https://github.com/mmtk/mmtk-julia/pull/308. I think this is needed for lazily scanning tasks.