### PR TITLE
Remove ptr/ref to Plan from work packets

### DIFF
--- a/src/plan/compressor/global.rs
+++ b/src/plan/compressor/global.rs
@@ -91,7 +91,7 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
 
         // Prepare global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Prepare]
-            .add(Prepare::<CompressorWorkContext<VM>>::new(self));
+            .add(Prepare::<CompressorWorkContext<VM>>::new());
 
         scheduler.work_buckets[WorkBucketStage::CalculateForwarding].add(GenerateWork::new(
             &self.compressor_space,
@@ -112,7 +112,7 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
 
         // Release global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Release]
-            .add(Release::<CompressorWorkContext<VM>>::new(self));
+            .add(Release::<CompressorWorkContext<VM>>::new());
 
         // Reference processing
         if !*self.base().options.no_reference_types {
@@ -167,7 +167,7 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
         }
         #[cfg(feature = "sanity")]
         scheduler.work_buckets[WorkBucketStage::Final]
-            .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new(self));
+            .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new());
     }
 
     fn current_gc_may_move_object(&self) -> bool {

--- a/src/plan/concurrent/immix/global.rs
+++ b/src/plan/concurrent/immix/global.rs
@@ -376,7 +376,7 @@ impl<VM: VMBinding> ConcurrentImmix<VM> {
         scheduler.work_buckets[WorkBucketStage::Unconstrained]
             .add(StopMutators::<ConcurrentImmixGCWorkContext<VM>>::new());
         scheduler.work_buckets[WorkBucketStage::Prepare]
-            .add(Prepare::<ConcurrentImmixGCWorkContext<VM>>::new(self));
+            .add(Prepare::<ConcurrentImmixGCWorkContext<VM>>::new());
     }
 
     fn schedule_concurrent_marking_final_pause(&'static self, scheduler: &GCWorkScheduler<VM>) {
@@ -387,13 +387,13 @@ impl<VM: VMBinding> ConcurrentImmix<VM> {
             .add(StopMutators::<ConcurrentImmixGCWorkContext<VM>>::new_no_scan_roots());
 
         scheduler.work_buckets[WorkBucketStage::Release]
-            .add(Release::<ConcurrentImmixGCWorkContext<VM>>::new(self));
+            .add(Release::<ConcurrentImmixGCWorkContext<VM>>::new());
 
         // Sanity
         #[cfg(feature = "sanity")]
         {
             use crate::util::sanity::sanity_checker::ScheduleSanityGC;
-            scheduler.work_buckets[WorkBucketStage::Final].add(ScheduleSanityGC::<Self>::new(self));
+            scheduler.work_buckets[WorkBucketStage::Final].add(ScheduleSanityGC::<Self>::new());
         }
 
         // Deal with weak ref and finalizers

--- a/src/plan/gc_work.rs
+++ b/src/plan/gc_work.rs
@@ -1,32 +1,36 @@
 //! This module holds work packets for `CommonPlan` and `BasePlan`, or other work packets not
 //! directly related to scheduling.
 
-use crate::{plan::global::CommonPlan, scheduler::GCWork, vm::VMBinding};
+use std::marker::PhantomData;
 
+use crate::{scheduler::GCWork, vm::VMBinding};
+
+#[derive(Default)]
 pub(super) struct SetCommonPlanUnlogBits<VM: VMBinding> {
-    pub common_plan: &'static CommonPlan<VM>,
+    phantom_data: PhantomData<VM>,
 }
 
 impl<VM: VMBinding> GCWork<VM> for SetCommonPlanUnlogBits<VM> {
     fn do_work(
         &mut self,
         _worker: &mut crate::scheduler::GCWorker<VM>,
-        _mmtk: &'static crate::MMTK<VM>,
+        mmtk: &'static crate::MMTK<VM>,
     ) {
-        self.common_plan.set_side_log_bits();
+        mmtk.get_plan().common().set_side_log_bits();
     }
 }
 
+#[derive(Default)]
 pub(super) struct ClearCommonPlanUnlogBits<VM: VMBinding> {
-    pub common_plan: &'static CommonPlan<VM>,
+    phantom_data: PhantomData<VM>,
 }
 
 impl<VM: VMBinding> GCWork<VM> for ClearCommonPlanUnlogBits<VM> {
     fn do_work(
         &mut self,
         _worker: &mut crate::scheduler::GCWorker<VM>,
-        _mmtk: &'static crate::MMTK<VM>,
+        mmtk: &'static crate::MMTK<VM>,
     ) {
-        self.common_plan.clear_side_log_bits();
+        mmtk.get_plan().common().clear_side_log_bits();
     }
 }

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -758,18 +758,15 @@ impl<VM: VMBinding> CommonPlan<VM> {
 
     pub(crate) fn schedule_unlog_bits_op(&mut self, unlog_bits_op: UnlogBitsOperation) {
         if VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.is_on_side() {
-            // # Safety: CommonPlan reference is always valid within this collection cycle.
-            let common_plan = unsafe { &*(self as *const CommonPlan<VM>) };
-
             match unlog_bits_op {
                 UnlogBitsOperation::NoOp => {}
                 UnlogBitsOperation::BulkSet => {
                     self.base.scheduler.work_buckets[WorkBucketStage::Prepare]
-                        .add(SetCommonPlanUnlogBits { common_plan });
+                        .add(SetCommonPlanUnlogBits::default());
                 }
                 UnlogBitsOperation::BulkClear => {
                     self.base.scheduler.work_buckets[WorkBucketStage::Release]
-                        .add(ClearCommonPlanUnlogBits { common_plan });
+                        .add(ClearCommonPlanUnlogBits::default());
                 }
             }
         }

--- a/src/plan/markcompact/gc_work.rs
+++ b/src/plan/markcompact/gc_work.rs
@@ -31,12 +31,10 @@ impl<VM: VMBinding> CalculateForwardingAddress<VM> {
 
 /// create another round of root scanning work packets
 /// to update object references
+#[derive(Default)]
 pub struct UpdateReferences<VM: VMBinding> {
-    plan: *const MarkCompact<VM>,
     p: PhantomData<VM>,
 }
-
-unsafe impl<VM: VMBinding> Send for UpdateReferences<VM> {}
 
 impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
@@ -44,7 +42,9 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         VM::VMScanning::prepare_for_roots_re_scanning();
         mmtk.state.prepare_for_stack_scanning();
         // Prepare common and base spaces for the 2nd round of transitive closure
-        let plan_mut = unsafe { &mut *(self.plan as *mut MarkCompact<VM>) };
+        let plan_mut = unsafe { mmtk.get_plan_mut() }
+            .downcast_mut::<MarkCompact<VM>>()
+            .unwrap();
         plan_mut.common.release(worker.tls, true);
         plan_mut.common.prepare(worker.tls, true);
         #[cfg(feature = "extreme_assertions")]
@@ -67,11 +67,8 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
 }
 
 impl<VM: VMBinding> UpdateReferences<VM> {
-    pub fn new(plan: &MarkCompact<VM>) -> Self {
-        Self {
-            plan,
-            p: PhantomData,
-        }
+    pub fn new() -> Self {
+        Self { p: PhantomData }
     }
 }
 

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -92,17 +92,17 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
 
         // Prepare global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Prepare]
-            .add(Prepare::<MarkCompactGCWorkContext<VM>>::new(self));
+            .add(Prepare::<MarkCompactGCWorkContext<VM>>::new());
 
         scheduler.work_buckets[WorkBucketStage::CalculateForwarding]
             .add(CalculateForwardingAddress::<VM>::new(&self.mc_space));
         // do another trace to update references
-        scheduler.work_buckets[WorkBucketStage::SecondRoots].add(UpdateReferences::<VM>::new(self));
+        scheduler.work_buckets[WorkBucketStage::SecondRoots].add(UpdateReferences::<VM>::new());
         scheduler.work_buckets[WorkBucketStage::Compact].add(Compact::<VM>::new(&self.mc_space));
 
         // Release global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Release]
-            .add(Release::<MarkCompactGCWorkContext<VM>>::new(self));
+            .add(Release::<MarkCompactGCWorkContext<VM>>::new());
 
         // Reference processing
         if !*self.base().options.no_reference_types {
@@ -157,7 +157,7 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         }
         #[cfg(feature = "sanity")]
         scheduler.work_buckets[WorkBucketStage::Final]
-            .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new(self));
+            .add(crate::util::sanity::sanity_checker::ScheduleSanityGC::<Self>::new());
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -35,15 +35,16 @@ impl<VM: VMBinding> GCWork<VM> for ScheduleCollection {
 /// We assume this work packet is the only running work packet that accesses plan, and there should
 /// be no other concurrent work packet that accesses plan (read or write). Otherwise, there may
 /// be a race condition.
+#[derive(Default)]
 pub struct Prepare<C: GCWorkContext> {
-    pub plan: *const C::PlanType,
+    phantom_data: PhantomData<C>,
 }
 
-unsafe impl<C: GCWorkContext> Send for Prepare<C> {}
-
 impl<C: GCWorkContext> Prepare<C> {
-    pub fn new(plan: *const C::PlanType) -> Self {
-        Self { plan }
+    pub fn new() -> Self {
+        Self {
+            phantom_data: PhantomData,
+        }
     }
 }
 
@@ -51,7 +52,7 @@ impl<C: GCWorkContext> GCWork<C::VM> for Prepare<C> {
     fn do_work(&mut self, worker: &mut GCWorker<C::VM>, mmtk: &'static MMTK<C::VM>) {
         trace!("Prepare Global");
         // We assume this is the only running work packet that accesses plan at the point of execution
-        let plan_mut: &mut C::PlanType = unsafe { &mut *(self.plan as *const _ as *mut _) };
+        let plan_mut = unsafe { mmtk.get_plan_mut() };
         plan_mut.prepare(worker.tls);
 
         if plan_mut.constraints().needs_prepare_mutator {
@@ -112,17 +113,18 @@ impl<VM: VMBinding> GCWork<VM> for PrepareCollector {
 /// We assume this work packet is the only running work packet that accesses plan, and there should
 /// be no other concurrent work packet that accesses plan (read or write). Otherwise, there may
 /// be a race condition.
+#[derive(Default)]
 pub struct Release<C: GCWorkContext> {
-    pub plan: *const C::PlanType,
+    phantom_data: PhantomData<C>,
 }
 
 impl<C: GCWorkContext> Release<C> {
-    pub fn new(plan: *const C::PlanType) -> Self {
-        Self { plan }
+    pub fn new() -> Self {
+        Self {
+            phantom_data: PhantomData,
+        }
     }
 }
-
-unsafe impl<C: GCWorkContext> Send for Release<C> {}
 
 impl<C: GCWorkContext + 'static> GCWork<C::VM> for Release<C> {
     fn do_work(&mut self, worker: &mut GCWorker<C::VM>, mmtk: &'static MMTK<C::VM>) {
@@ -131,7 +133,7 @@ impl<C: GCWorkContext + 'static> GCWork<C::VM> for Release<C> {
         mmtk.gc_trigger.policy.on_gc_release(mmtk);
         // We assume this is the only running work packet that accesses plan at the point of execution
 
-        let plan_mut: &mut C::PlanType = unsafe { &mut *(self.plan as *const _ as *mut _) };
+        let plan_mut = unsafe { mmtk.get_plan_mut() };
         plan_mut.release(worker.tls);
 
         let release_mutator_packets = <C::VM as VMBinding>::VMActivePlan::mutators()

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -145,10 +145,10 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         self.work_buckets[WorkBucketStage::Unconstrained].add(StopMutators::<C>::new());
 
         // Prepare global/collectors/mutators
-        self.work_buckets[WorkBucketStage::Prepare].add(Prepare::<C>::new(plan));
+        self.work_buckets[WorkBucketStage::Prepare].add(Prepare::<C>::new());
 
         // Release global/collectors/mutators
-        self.work_buckets[WorkBucketStage::Release].add(Release::<C>::new(plan));
+        self.work_buckets[WorkBucketStage::Release].add(Release::<C>::new());
 
         // Analysis GC work
         #[cfg(feature = "analysis")]
@@ -162,7 +162,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         {
             use crate::util::sanity::sanity_checker::ScheduleSanityGC;
             self.work_buckets[WorkBucketStage::Final]
-                .add(ScheduleSanityGC::<C::PlanType>::new(plan));
+                .add(ScheduleSanityGC::<C::PlanType>::new());
         }
 
         // Reference processing

--- a/src/util/sanity/sanity_checker.rs
+++ b/src/util/sanity/sanity_checker.rs
@@ -8,6 +8,7 @@ use crate::vm::slot::Slot;
 use crate::vm::{ObjectModel, VMBinding};
 use crate::MMTK;
 use std::collections::HashSet;
+use std::marker::PhantomData;
 
 #[allow(dead_code)]
 pub struct SanityChecker<SL: Slot> {
@@ -54,14 +55,24 @@ impl<SL: Slot> SanityChecker<SL> {
 }
 
 pub struct ScheduleSanityGC<P: Plan> {
-    plan: &'static P,
+    phantom_data: PhantomData<&'static P>,
 }
 
 impl<P: Plan> ScheduleSanityGC<P> {
-    pub fn new(plan: &'static P) -> Self {
-        ScheduleSanityGC { plan }
+    pub fn new() -> Self {
+        Self {
+            phantom_data: PhantomData,
+        }
     }
 }
+
+impl<P: Plan> Default for ScheduleSanityGC<P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+unsafe impl<P: Plan> Send for ScheduleSanityGC<P> {}
 
 impl<P: Plan> GCWork<P::VM> for ScheduleSanityGC<P> {
     fn do_work(&mut self, worker: &mut GCWorker<P::VM>, mmtk: &'static MMTK<P::VM>) {
@@ -76,29 +87,19 @@ impl<P: Plan> GCWork<P::VM> for ScheduleSanityGC<P> {
         mmtk.sanity_begin(); // Stop & scan mutators (mutator scanning can happen before STW)
 
         // Prepare global/collectors/mutators
-        worker.scheduler().work_buckets[WorkBucketStage::Prepare]
-            .add(SanityPrepare::<P>::new(self.plan));
+        worker.scheduler().work_buckets[WorkBucketStage::Prepare].add(SanityPrepare);
         // Do the transitive closure
         worker.scheduler().work_buckets[WorkBucketStage::Closure]
-            .add(SanityClosure::<P>::new(self.plan));
+            .add(SanityClosure::<P>::default());
         // Release global/collectors/mutators
-        worker.scheduler().work_buckets[WorkBucketStage::Release]
-            .add(SanityRelease::<P>::new(self.plan));
+        worker.scheduler().work_buckets[WorkBucketStage::Release].add(SanityRelease);
     }
 }
 
-pub struct SanityPrepare<P: Plan> {
-    pub plan: &'static P,
-}
+pub struct SanityPrepare;
 
-impl<P: Plan> SanityPrepare<P> {
-    pub fn new(plan: &'static P) -> Self {
-        Self { plan }
-    }
-}
-
-impl<P: Plan> GCWork<P::VM> for SanityPrepare<P> {
-    fn do_work(&mut self, _worker: &mut GCWorker<P::VM>, mmtk: &'static MMTK<P::VM>) {
+impl<VM: VMBinding> GCWork<VM> for SanityPrepare {
+    fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
         info!("Sanity GC prepare");
         {
             let mut sanity_checker = mmtk.sanity_checker.lock().unwrap();
@@ -107,18 +108,10 @@ impl<P: Plan> GCWork<P::VM> for SanityPrepare<P> {
     }
 }
 
-pub struct SanityRelease<P: Plan> {
-    pub plan: &'static P,
-}
+pub struct SanityRelease;
 
-impl<P: Plan> SanityRelease<P> {
-    pub fn new(plan: &'static P) -> Self {
-        Self { plan }
-    }
-}
-
-impl<P: Plan> GCWork<P::VM> for SanityRelease<P> {
-    fn do_work(&mut self, _worker: &mut GCWorker<P::VM>, mmtk: &'static MMTK<P::VM>) {
+impl<VM: VMBinding> GCWork<VM> for SanityRelease {
+    fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
         info!("Sanity GC release");
         mmtk.sanity_checker.lock().unwrap().clear_roots_cache();
         mmtk.sanity_end();
@@ -126,19 +119,25 @@ impl<P: Plan> GCWork<P::VM> for SanityRelease<P> {
 }
 
 pub struct SanityClosure<P: Plan> {
-    pub plan: &'static P,
+    phantom_data: PhantomData<&'static P>,
 }
 
-impl<P: Plan> SanityClosure<P> {
-    pub fn new(plan: &'static P) -> Self {
-        Self { plan }
+impl<P: Plan> Default for SanityClosure<P> {
+    fn default() -> Self {
+        Self {
+            phantom_data: PhantomData,
+        }
     }
 }
+
+unsafe impl<P: Plan> Send for SanityClosure<P> {}
 
 impl<P: Plan> GCWork<P::VM> for SanityClosure<P> {
     fn do_work(&mut self, worker: &mut GCWorker<P::VM>, mmtk: &'static MMTK<P::VM>) {
         info!("Sanity GC closure");
         let mut sanity_checker = mmtk.sanity_checker.lock().unwrap();
+
+        let plan = mmtk.get_plan().downcast_ref::<P>().unwrap();
 
         let mut queue = Vec::new();
 
@@ -177,7 +176,7 @@ impl<P: Plan> GCWork<P::VM> for SanityClosure<P> {
 
             // Let plan check object
             assert!(
-                self.plan.sanity_check_object(object),
+                plan.sanity_check_object(object),
                 "plan.sanity_check_object(object) returned false. object: {object}",
             );
 


### PR DESCRIPTION
`GCWork::do_work` has an `mmtk` parameter, and the `MMTK::get_plan()` and `MMTK::get_plan_mut()` methods provide access to the plan instance. It is therefore pointless for a work packet to capture a pointer or reference inside the struct itself.

This PR does not fix the fact that `Plan::prepare` and `Plan::release` have `&mut self` arguments.  Therefore, getting `&mut Plan` from an `MMTK` instance is still unsafe.  See:
https://github.com/mmtk/mmtk-core/issues/852