### PR TITLE
Add mmtk_shutdown API

### DIFF
--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -86,6 +86,13 @@ pub fn mmtk_init<VM: VMBinding>(builder: &MMTKBuilder) -> Box<MMTK<VM>> {
     Box::new(mmtk)
 }
 
+/// Shut down an MMTk instance.
+/// This would asycnronously request GC workers to stop, but it will not be blocked until
+/// the GC workers actually quit. A binding needs to check if all GC workers have quit.
+pub fn mmtk_shutdown<VM: VMBinding>(mmtk: &'static MMTK<VM>) {
+    mmtk.shutdown();
+}
+
 /// Add an externally mmapped region to the VM space. A VM space can be set through MMTk options (`vm_space_start` and `vm_space_size`),
 /// and can also be set through this function call. A VM space can be discontiguous. This function can be called multiple times,
 /// and all the address ranges passed as arguments in the function will be considered as part of the VM space.

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -87,8 +87,7 @@ pub fn mmtk_init<VM: VMBinding>(builder: &MMTKBuilder) -> Box<MMTK<VM>> {
 }
 
 /// Shut down an MMTk instance.
-/// This would asycnronously request GC workers to stop, but it will not be blocked until
-/// the GC workers actually quit. A binding needs to check if all GC workers have quit.
+/// This would asynchronously request GC workers to stop. Bindings need to check if all GC workers have quit in binding-specific ways.
 pub fn mmtk_shutdown<VM: VMBinding>(mmtk: &'static MMTK<VM>) {
     mmtk.shutdown();
 }

--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -264,6 +264,14 @@ impl<VM: VMBinding> MMTK<VM> {
         probe!(mmtk, collection_initialized);
     }
 
+    /// Shut down all GC worker threads.
+    pub fn shutdown(&'static self) {
+        if self.state.is_initialized() {
+            self.scheduler.shutdown_gc_threads();
+            self.state.initialized.store(false, Ordering::SeqCst);
+        }
+    }
+
     /// Prepare an MMTk instance for calling the `fork()` system call.
     ///
     /// The `fork()` system call is available on Linux and some UNIX variants, and may be emulated

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -104,7 +104,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
     pub fn shutdown_gc_threads(self: &Arc<Self>) {
         self.worker_group.prepare_surrender_buffer();
 
-        debug!("A mutator is requesting GC threads to shut down...");
+        info!("A mutator is requesting GC threads to shut down...");
         self.worker_monitor.make_request(WorkerGoal::Shutdown);
     }
 

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -100,6 +100,14 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         self.worker_monitor.make_request(WorkerGoal::StopForFork);
     }
 
+    /// Ask all GC workers to exit permanently.
+    pub fn shutdown_gc_threads(self: &Arc<Self>) {
+        self.worker_group.prepare_surrender_buffer();
+
+        debug!("A mutator is requesting GC threads to shut down...");
+        self.worker_monitor.make_request(WorkerGoal::Shutdown);
+    }
+
     /// Surrender the `GCWorker` struct of a GC worker when it exits.
     pub fn surrender_gc_worker(&self, worker: Box<GCWorker<VM>>) {
         let all_surrendered = self.worker_group.surrender_gc_worker(worker);
@@ -478,7 +486,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                     }
                 }
             }
-            WorkerGoal::StopForFork => {
+            WorkerGoal::StopForFork | WorkerGoal::Shutdown => {
                 panic!(
                     "Worker {} parked again when it is asked to exit.",
                     worker.ordinal
@@ -517,8 +525,8 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                 self.add_schedule_collection_packet();
                 LastParkedResult::WakeSelf
             }
-            WorkerGoal::StopForFork => {
-                trace!("A mutator wanted to fork.");
+            WorkerGoal::StopForFork | WorkerGoal::Shutdown => {
+                trace!("A mutator requested {:?}", goal);
                 LastParkedResult::WakeAll
             }
         }

--- a/src/scheduler/worker_goals.rs
+++ b/src/scheduler/worker_goals.rs
@@ -31,6 +31,8 @@ pub(crate) struct WorkerGoals {
 pub(crate) enum WorkerGoal {
     /// Do a garbage collection.
     Gc,
+    /// Stop all GC threads permanently.
+    Shutdown,
     /// Stop all GC threads so that the VM can call `fork()`.
     StopForFork,
 }

--- a/src/scheduler/worker_monitor.rs
+++ b/src/scheduler/worker_monitor.rs
@@ -230,8 +230,11 @@ impl WorkerMonitor {
             sync.parker.worker_count,
         );
 
-        // If the current goal is `StopForFork`, the worker thread should exit.
-        if matches!(sync.goals.current(), Some(WorkerGoal::StopForFork)) {
+        // If the current goal is an exit goal, the worker thread should exit.
+        if matches!(
+            sync.goals.current(),
+            Some(WorkerGoal::Shutdown | WorkerGoal::StopForFork)
+        ) {
             return Err(WorkerShouldExit);
         }
 

--- a/src/vm/tests/mock_tests/mock_test_shutdown.rs
+++ b/src/vm/tests/mock_tests/mock_test_shutdown.rs
@@ -1,0 +1,125 @@
+use std::{
+    sync::{Condvar, Mutex, MutexGuard},
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use super::mock_test_prelude::*;
+use crate::{
+    util::{options::GCTriggerSelector, Address, OpaquePointer, VMThread, VMWorkerThread},
+    MMTKBuilder, MMTK,
+};
+
+#[derive(Default)]
+struct ShutdownTestShared {
+    sync: Mutex<ShutdownTestSync>,
+    all_threads_spawned: Condvar,
+    all_threads_exited: Condvar,
+}
+
+#[derive(Default)]
+struct ShutdownTestSync {
+    join_handles: Vec<JoinHandle<()>>,
+    spawned_threads: usize,
+    exited_threads: usize,
+}
+
+lazy_static! {
+    static ref SHARED: ShutdownTestShared = ShutdownTestShared::default();
+}
+
+const NUM_WORKER_THREADS: usize = 4;
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+fn wait_timeout_while<'a, T, F>(
+    guard: MutexGuard<'a, T>,
+    condvar: &Condvar,
+    condition: F,
+) -> MutexGuard<'a, T>
+where
+    F: FnMut(&mut T) -> bool,
+{
+    let (guard, timeout_result) = condvar
+        .wait_timeout_while(guard, TIMEOUT, condition)
+        .unwrap();
+    assert!(!timeout_result.timed_out());
+    guard
+}
+
+fn simple_spawn_gc_thread(
+    _vm_thread: VMThread,
+    context: GCThreadContext<MockVM>,
+    mmtk: &'static MMTK<MockVM>,
+) {
+    let GCThreadContext::Worker(worker) = context;
+    let join_handle = std::thread::spawn(move || {
+        let ordinal = worker.ordinal;
+        println!("GC thread starting. Ordinal: {ordinal}");
+
+        let gc_thread_tls = VMWorkerThread(VMThread(OpaquePointer::from_address(Address::ZERO)));
+        memory_manager::start_worker(mmtk, gc_thread_tls, worker);
+
+        let mut sync = SHARED.sync.lock().unwrap();
+        sync.exited_threads += 1;
+        if sync.exited_threads == NUM_WORKER_THREADS {
+            SHARED.all_threads_exited.notify_all();
+        }
+
+        println!("GC thread stopped. Ordinal: {ordinal}");
+    });
+
+    let mut sync = SHARED.sync.lock().unwrap();
+    sync.join_handles.push(join_handle);
+    sync.spawned_threads += 1;
+    if sync.spawned_threads == NUM_WORKER_THREADS {
+        SHARED.all_threads_spawned.notify_all();
+    }
+}
+
+#[test]
+pub fn test_shutdown_stops_gc_threads() {
+    let mut builder = MMTKBuilder::new();
+    let trigger = GCTriggerSelector::FixedHeapSize(1024 * 1024);
+    builder.options.gc_trigger.set(trigger);
+    builder.options.threads.set(NUM_WORKER_THREADS);
+    let mmtk: &'static mut MMTK<MockVM> = Box::leak(Box::new(builder.build::<MockVM>()));
+
+    let mock_vm = MockVM {
+        spawn_gc_thread: MockMethod::new_fixed(Box::new(|(vm_thread, context)| {
+            simple_spawn_gc_thread(vm_thread, context, mmtk)
+        })),
+        ..Default::default()
+    };
+    write_mockvm(move |mock_vm_ref| *mock_vm_ref = mock_vm);
+
+    let test_thread_tls = VMThread(OpaquePointer::from_address(Address::ZERO));
+    mmtk.initialize_collection(test_thread_tls);
+
+    let join_handles = {
+        let sync = SHARED.sync.lock().unwrap();
+        let mut sync = wait_timeout_while(sync, &SHARED.all_threads_spawned, |sync| {
+            sync.spawned_threads < NUM_WORKER_THREADS
+        });
+        std::mem::take(&mut sync.join_handles)
+    };
+
+    assert_eq!(join_handles.len(), NUM_WORKER_THREADS);
+
+    memory_manager::mmtk_shutdown(mmtk);
+
+    println!("Waiting for GC worker threads to stop");
+
+    {
+        let sync = SHARED.sync.lock().unwrap();
+        let sync = wait_timeout_while(sync, &SHARED.all_threads_exited, |sync| {
+            sync.exited_threads < NUM_WORKER_THREADS
+        });
+        assert_eq!(sync.exited_threads, NUM_WORKER_THREADS);
+    }
+
+    assert!(!mmtk.state.is_initialized());
+
+    for join_handle in join_handles {
+        join_handle.join().unwrap();
+    }
+}

--- a/src/vm/tests/mock_tests/mod.rs
+++ b/src/vm/tests/mock_tests/mod.rs
@@ -65,6 +65,7 @@ mod mock_test_malloc_ms;
 mod mock_test_mmtk_julia_pr_143;
 #[cfg(feature = "nogc_lock_free")]
 mod mock_test_nogc_lock_free;
+mod mock_test_shutdown;
 mod mock_test_slots;
 #[cfg(target_pointer_width = "64")]
 mod mock_test_vm_layout_compressed_pointer;


### PR DESCRIPTION
This PR adds `mmtk_shutdown`. It requests all GC workers to stop (similar to `prepare_to_fork`).