### PR TITLE
Mmap side metadata after space creation

### DIFF
--- a/src/mmtk.rs
+++ b/src/mmtk.rs
@@ -164,14 +164,11 @@ impl<VM: VMBinding> MMTK<VM> {
 
         let stats = Arc::new(Stats::new(&options));
 
-        // Initialize side metadata runtime state and reserve its address range before creating
-        // spaces. Plan/space initialization may map side metadata during setup.
-        crate::util::metadata::side_metadata::initialize_side_metadata::<VM>(&options);
-
         // We need this during creating spaces, but we do not use this once the MMTk instance is created.
         // So we do not save it in MMTK. This may change in the future.
         let mut heap = HeapMeta::new();
 
+        // Create plan and spaces. Note that side metadata is not initialized yet. Plan creation should avoid using it.
         let mut plan = crate::plan::create_plan(
             *options.plan,
             CreateGeneralPlanArgs {
@@ -185,6 +182,9 @@ impl<VM: VMBinding> MMTK<VM> {
                 heap: &mut heap,
             },
         );
+
+        // Initialize side metadata runtime state and reserve its address range after creating spaces.
+        crate::util::metadata::side_metadata::initialize_side_metadata::<VM>(&options);
 
         // We haven't finished creating MMTk. No one is using the GC trigger. We cast the arc into a mutable reference.
         {
@@ -214,6 +214,7 @@ impl<VM: VMBinding> MMTK<VM> {
         );
 
         // The order here is important:
+        plan.initialize_side_metadata();
         // Initialize side metadat sanity first
         plan.verify_side_metadata_sanity();
         // Then intiialize SFT because it may use side metadata

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -69,6 +69,13 @@ pub fn create_mutator<VM: VMBinding>(
     })
 }
 
+/// Create a plan and the spaces for the plan.
+///
+/// It is very important that in the constructor of each plan (including the constructor of each space),
+/// sft and side metadata is not available for access. If a plan or a space needs to initialize sft or side metadata
+/// in its constructor, it needs to postpone the initialization to [`Plan::initialize_sft`], [`Plan::initialize_side_metadata`],
+/// [`Space::initialize_sft`] or [`Space::initialize_side_metadata`].
+/// If a plan or a space tries to access sft or side metadata in its constructor, it may cause undefined behavior.
 pub fn create_plan<VM: VMBinding>(
     plan: PlanSelector,
     args: CreateGeneralPlanArgs<VM>,
@@ -358,6 +365,13 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
             sft_map.notify_space_creation(s.as_sft());
             s.initialize_sft(sft_map);
         });
+    }
+
+    /// Call `space.initialize_side_metadata` for all spaces in this plan.
+    /// This is called after the plan is created in the heap and won't be moved, and after side metadata is initialized.
+    /// If a plan needs to access side metadata during space construction, it can override this method for its own initialization.
+    fn initialize_side_metadata(&self) {
+        self.for_each_space(&mut |s| s.initialize_side_metadata());
     }
 }
 

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -266,7 +266,15 @@ impl<VM: VMBinding> LockFreeImmortalSpace<VM> {
             .prot(crate::util::os::MmapProtection::ReadWrite)
             .replace(false)
             .reserve(true);
-        crate::util::os::OS::dzmmap(start, aligned_total_bytes, strategy, &anno).unwrap();
+        crate::util::os::OS::dzmmap(
+            start,
+            aligned_total_bytes,
+            strategy,
+            &MmapAnnotation::Space {
+                name: space.get_name(),
+            },
+        )
+        .unwrap();
 
         space
     }

--- a/src/policy/lockfreeimmortalspace.rs
+++ b/src/policy/lockfreeimmortalspace.rs
@@ -131,6 +131,15 @@ impl<VM: VMBinding> Space<VM> for LockFreeImmortalSpace<VM> {
         unsafe { sft_map.eager_initialize(self.as_sft(), self.start, self.total_bytes) };
     }
 
+    fn initialize_side_metadata(&self) {
+        self.metadata
+            .try_map_metadata_space(self.start, self.total_bytes, self.get_name())
+            .unwrap_or_else(|e| {
+                // TODO(Javad): handle meta space allocation failure
+                panic!("failed to mmap meta memory: {e}")
+            });
+    }
+
     fn estimate_side_meta_pages(&self, data_pages: usize) -> usize {
         self.metadata.calculate_reserved_pages(data_pages)
     }
@@ -257,22 +266,7 @@ impl<VM: VMBinding> LockFreeImmortalSpace<VM> {
             .prot(crate::util::os::MmapProtection::ReadWrite)
             .replace(false)
             .reserve(true);
-        crate::util::os::OS::dzmmap(
-            start,
-            aligned_total_bytes,
-            strategy,
-            &MmapAnnotation::Space {
-                name: space.get_name(),
-            },
-        )
-        .unwrap();
-        space
-            .metadata
-            .try_map_metadata_space(start, aligned_total_bytes, space.get_name())
-            .unwrap_or_else(|e| {
-                // TODO(Javad): handle meta space allocation failure
-                panic!("failed to mmap meta memory: {e}")
-            });
+        crate::util::os::OS::dzmmap(start, aligned_total_bytes, strategy, &anno).unwrap();
 
         space
     }

--- a/src/policy/space.rs
+++ b/src/policy/space.rs
@@ -54,6 +54,11 @@ pub trait Space<VM: VMBinding>: 'static + SFT + Sync + Downcast {
     /// Currently after we create a boxed plan, spaces in the plan have a non-moving address.
     fn initialize_sft(&self, sft_map: &mut dyn crate::policy::sft_map::SFTMap);
 
+    /// Initialize side metadata for the space. This is called after spaces and the plan are contructued
+    /// and the side metadata has been initialized. If a space needs to access side metadata during its
+    /// construction, it can override this method to initialize side metadata here.  By default, this method does nothing.
+    fn initialize_side_metadata(&self) {}
+
     fn acquire(&self, tls: VMThread, pages: usize, alloc_options: AllocationOptions) -> Address {
         trace!(
             "Space.acquire, tls={:?}, alloc_options={:?}",

--- a/src/policy/vmspace.rs
+++ b/src/policy/vmspace.rs
@@ -126,11 +126,19 @@ impl<VM: VMBinding> Space<VM> for VMSpace<VM> {
                 sft_map.get_checked(start).name(),
                 crate::policy::sft::EMPTY_SFT_NAME
             );
-            // Set SFT
-            assert!(sft_map.has_sft_entry(start), "The VM space start (aligned to {}) does not have a valid SFT entry. Possibly the address range is not in the address range we use.", start);
-            unsafe {
-                sft_map.eager_initialize(self.as_sft(), start, size);
-            }
+            self.set_sft(start, size);
+        }
+    }
+
+    fn initialize_side_metadata(&self) {
+        let vm_regions = self.pr.get_external_pages();
+        for external_pages in vm_regions.iter() {
+            // Chunk align things.
+            let chunk_start = external_pages.start.align_down(BYTES_IN_CHUNK);
+            let chunk_size = external_pages.end.align_up(BYTES_IN_CHUNK) - chunk_start;
+            let raw_start = external_pages.start;
+            let raw_size = external_pages.end - external_pages.start;
+            self.set_side_metadata(chunk_start, chunk_size, raw_start, raw_size);
         }
     }
 
@@ -209,17 +217,17 @@ impl<VM: VMBinding> VMSpace<VM> {
 
         if !vm_space_start.is_zero() {
             // Do not set sft here, as the space may be moved. We do so for those regions in `initialize_sft`.
-            space.set_vm_region_inner(vm_space_start, vm_space_size, false);
+            space.set_vm_region_inner(vm_space_start, vm_space_size, true);
         }
 
         space
     }
 
     pub fn set_vm_region(&mut self, start: Address, size: usize) {
-        self.set_vm_region_inner(start, size, true);
+        self.set_vm_region_inner(start, size, false);
     }
 
-    fn set_vm_region_inner(&self, start: Address, size: usize, set_sft: bool) {
+    fn set_vm_region_inner(&self, start: Address, size: usize, init: bool) {
         assert!(size > 0);
         assert!(!start.is_zero());
 
@@ -244,32 +252,47 @@ impl<VM: VMBinding> VMSpace<VM> {
 
         // Mark as mapped in mmapper
         self.common.mmapper.mark_as_mapped(chunk_start, chunk_size);
-        // Map side metadata
-        self.common
-            .metadata
-            .try_map_metadata_space(chunk_start, chunk_size, self.get_name())
-            .unwrap();
+        // Map side metadata -- we can't access side metadata during initialization. We do it in initialize_side_metadata instead.
+        if !init {
+            self.set_side_metadata(chunk_start, chunk_size, start, size);
+        }
         // Insert to vm map: it would be good if we can make VM map aware of the region. However, the region may be outside what we can map in our VM map implementation.
         // self.common.vm_map.insert(chunk_start, chunk_size, self.common.descriptor);
         // Set SFT if we should
-        if set_sft {
-            assert!(SFT_MAP.has_sft_entry(chunk_start), "The VM space start (aligned to {}) does not have a valid SFT entry. Possibly the address range is not in the address range we use.", chunk_start);
-            unsafe {
-                SFT_MAP.update(self.as_sft(), chunk_start, chunk_size);
-            }
+        if !init {
+            self.set_sft(chunk_start, chunk_size);
         }
 
         self.pr.add_new_external_pages(ExternalPages {
             start: start.align_down(BYTES_IN_PAGE),
             end: end.align_up(BYTES_IN_PAGE),
         });
+    }
 
+    fn set_sft(&self, chunk_start: Address, chunk_size: usize) {
+        assert!(SFT_MAP.has_sft_entry(chunk_start), "The VM space start (aligned to {}) does not have a valid SFT entry. Possibly the address range is not in the address range we use.", chunk_start);
+        unsafe {
+            SFT_MAP.update(self.as_sft(), chunk_start, chunk_size);
+        }
+    }
+
+    fn set_side_metadata(
+        &self,
+        chunk_start: Address,
+        chunk_size: usize,
+        _raw_start: Address,
+        _raw_size: usize,
+    ) {
+        self.common
+            .metadata
+            .try_map_metadata_space(chunk_start, chunk_size, self.get_name())
+            .unwrap();
         #[cfg(feature = "set_unlog_bits_vm_space")]
         if self.common.needs_log_bit {
             // Bulk set unlog bits for all addresses in the VM space. This ensures that any
             // modification to the bootimage is logged
             if let MetadataSpec::OnSide(side) = *VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC {
-                side.bset_metadata(start, size);
+                side.bset_metadata(_raw_start, _raw_size);
             }
         }
     }


### PR DESCRIPTION
This PR changes the initialization order: we create the plan and the spaces first, then do initialization for side metadata. This means within plan/space constructor, we should not use side metadata. Any side metadata initialization is done in `Plan/Space::initialize_side_metadata` and is called after side metadata is initialized.

With this PR and https://github.com/mmtk/mmtk-core/pull/1491, we should not see side metadata using any space address range.