### PR TITLE
fix(linux): support musl builds

### DIFF
--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -32,21 +32,20 @@ Notes for the mmtk-core developers:
 
 ## 0.33.0
 
-### Linux thread IDs use `libc::pid_t`
+### Thread IDs require `Debug` instead of `Display`
 
 ```admonish tldr
-On Linux, `mmtk::util::os::OS::ThreadIDType` is now `libc::pid_t` instead of
-`libc::pthread_t`.
+`mmtk::util::os::OS::ThreadIDType` now needs to implement `Debug` instead of `Display`.
 ```
 
 API changes:
 
 -   module `util::os`
-    +   `OS::ThreadIDType`: On Linux, this is now `libc::pid_t` instead of `libc::pthread_t`.
-        *   On common Linux targets, this changes the concrete public type from `u64` to `i32`.
-        *   Bindings that name this associated type or store thread IDs returned by
-            `OSProcess::get_thread_id` should use `OS::ThreadIDType` or `libc::pid_t` rather than
-            assuming an unsigned 64-bit integer.
+    +   `OS::ThreadIDType`: This associated type now requires `Debug` instead of `Display`.
+        *   This allows platforms where the native thread ID type does not implement `Display`,
+            such as `libc::pthread_t` on musl.
+        *   Bindings that provide an OS implementation should derive or implement `Debug` for
+            their thread ID type.
 
 ### The `<'w>` lifetime in `ObjectTracerContext`
 

--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -32,6 +32,22 @@ Notes for the mmtk-core developers:
 
 ## 0.33.0
 
+### Linux thread IDs use `libc::pid_t`
+
+```admonish tldr
+On Linux, `mmtk::util::os::OS::ThreadIDType` is now `libc::pid_t` instead of
+`libc::pthread_t`.
+```
+
+API changes:
+
+-   module `util::os`
+    +   `OS::ThreadIDType`: On Linux, this is now `libc::pid_t` instead of `libc::pthread_t`.
+        *   On common Linux targets, this changes the concrete public type from `u64` to `i32`.
+        *   Bindings that name this associated type or store thread IDs returned by
+            `OSProcess::get_thread_id` should use `OS::ThreadIDType` or `libc::pid_t` rather than
+            assuming an unsigned 64-bit integer.
+
 ### The `<'w>` lifetime in `ObjectTracerContext`
 
 ```admonish tldr

--- a/src/util/os/imp/unix_like/linux_like/linux.rs
+++ b/src/util/os/imp/unix_like/linux_like/linux.rs
@@ -56,7 +56,7 @@ impl OSMemory for Linux {
 
 impl OSProcess for Linux {
     type ProcessIDType = unix_common::ProcessIDType;
-    type ThreadIDType = unix_common::ThreadIDType;
+    type ThreadIDType = libc::pid_t;
 
     fn get_process_memory_maps() -> Result<String> {
         linux_common::get_process_memory_maps()
@@ -67,7 +67,12 @@ impl OSProcess for Linux {
     }
 
     fn get_thread_id() -> Result<Self::ThreadIDType> {
-        unix_common::get_thread_id()
+        let tid = unsafe { libc::syscall(libc::SYS_gettid) };
+        if tid == -1 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(tid as libc::pid_t)
+        }
     }
 
     fn get_total_num_cpus() -> CoreNum {

--- a/src/util/os/imp/unix_like/linux_like/linux.rs
+++ b/src/util/os/imp/unix_like/linux_like/linux.rs
@@ -56,7 +56,7 @@ impl OSMemory for Linux {
 
 impl OSProcess for Linux {
     type ProcessIDType = unix_common::ProcessIDType;
-    type ThreadIDType = libc::pid_t;
+    type ThreadIDType = unix_common::ThreadIDType;
 
     fn get_process_memory_maps() -> Result<String> {
         linux_common::get_process_memory_maps()
@@ -67,12 +67,7 @@ impl OSProcess for Linux {
     }
 
     fn get_thread_id() -> Result<Self::ThreadIDType> {
-        let tid = unsafe { libc::syscall(libc::SYS_gettid) };
-        if tid == -1 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(tid as libc::pid_t)
-        }
+        unix_common::get_thread_id()
     }
 
     fn get_total_num_cpus() -> CoreNum {

--- a/src/util/os/process.rs
+++ b/src/util/os/process.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 use std::io::Result;
 
 /// Representation of a CPU core identifier.
@@ -11,7 +11,7 @@ pub trait OSProcess {
     /// The process ID type for the OS.
     type ProcessIDType: Display + Eq + Copy;
     /// The thread ID type for the OS.
-    type ThreadIDType: Display + Eq + Copy;
+    type ThreadIDType: Debug + Eq + Copy;
 
     /// Get the memory maps for the process. The returned string is a multi-line string.
     /// Fallback: This is only used for debugging. For unimplemented cases, this function can return a placeholder Ok value.

--- a/src/util/rust_util/mod.rs
+++ b/src/util/rust_util/mod.rs
@@ -112,7 +112,10 @@ pub fn debug_process_thread_id() -> String {
     format!(
         "PID: {}, TID: {}",
         OS::get_process_id().map_or("(Failed to get PID)".to_string(), |pid| format!("{}", pid)),
-        OS::get_thread_id().map_or("(Failed to get TID)".to_string(), |tid| format!("{}", tid)),
+        OS::get_thread_id().map_or("(Failed to get TID)".to_string(), |tid| format!(
+            "{:?}",
+            tid
+        )),
     )
 }
 


### PR DESCRIPTION
On musl ThreadIDType is not Display and is just `*mut c_void`, I updated the helper to return libc::pid_t directly. 