### PR TITLE
Remove dependency on `memoffset`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ jemalloc-sys = { version = "0.5.3", features = ["disable_initial_exec_tls"], opt
 lazy_static = "1.1"
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace"] }
-memoffset = "0.9"
 mimalloc-sys = { version = "0.1.6", optional = true }
 num_cpus = "1.8"
 num-traits = "0.2"

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -356,8 +356,7 @@ impl<VM: VMBinding> Mutator<VM> {
     /// Return the base offset from a mutator pointer to the allocator specified by the selector.
     pub fn get_allocator_base_offset(selector: AllocatorSelector) -> usize {
         use crate::util::alloc::*;
-        use memoffset::offset_of;
-        use std::mem::size_of;
+        use std::mem::{size_of, offset_of};
         offset_of!(Mutator<VM>, allocators)
             + match selector {
                 AllocatorSelector::BumpPointer(index) => {

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -356,7 +356,7 @@ impl<VM: VMBinding> Mutator<VM> {
     /// Return the base offset from a mutator pointer to the allocator specified by the selector.
     pub fn get_allocator_base_offset(selector: AllocatorSelector) -> usize {
         use crate::util::alloc::*;
-        use std::mem::{size_of, offset_of};
+        use std::mem::{offset_of, size_of};
         offset_of!(Mutator<VM>, allocators)
             + match selector {
                 AllocatorSelector::BumpPointer(index) => {

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -1,7 +1,5 @@
-use std::mem::MaybeUninit;
+use std::mem::{MaybeUninit, offset_of};
 use std::sync::Arc;
-
-use memoffset::offset_of;
 
 use crate::policy::largeobjectspace::LargeObjectSpace;
 use crate::policy::marksweepspace::malloc_ms::MallocSpace;

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -1,4 +1,4 @@
-use std::mem::{MaybeUninit, offset_of};
+use std::mem::{offset_of, MaybeUninit};
 use std::sync::Arc;
 
 use crate::policy::largeobjectspace::LargeObjectSpace;


### PR DESCRIPTION
Hi, I may or may not have used your crate but I'd like to say a quick thank you for it anyway!
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77 which I believe is at or below your MSRV.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please check anyway.
I hope we can all enjoy the benefits of one less dependency :)
