### PR TITLE
Fix links that disallow robot access

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -39,8 +39,7 @@ jobs:
       - name: On link check failure
         if: failure()
         run: |
-          echo "Summary:"
-          cat lychee/out.md
+          echo "Link check failed.  Please read the summary in the last step."
           if grep -q 403 lychee/out.md; then
             echo "Some links received reply code 403 Forbidden:"
             grep 403 lychee/out.md

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -34,9 +34,19 @@ jobs:
             --no-progress
             --cache
             --max-cache-age 1d
-            --exclude 'https://users.cecs.anu.edu.au/~steveb/pubs/papers/**'
             --exclude 'https://dl.acm.org/**'
             './docs/**/*.md'
+      - name: On link check failure
+        if: failure()
+        run: |
+          echo "Summary:"
+          cat lychee/out.md
+          if grep -q 403 lychee/out.md; then
+            echo "Some links received reply code 403 Forbidden:"
+            grep 403 lychee/out.md
+            echo "If the server disallows robot access,"
+            echo "please exclude affected web sites in .github/workflows/link-check.yml"
+          fi
       - name: Save lychee cache
         uses: actions/cache/save@v4
         if: always()

--- a/docs/userguide/src/portingguide/howto/nogc.md
+++ b/docs/userguide/src/portingguide/howto/nogc.md
@@ -124,7 +124,7 @@ in object fields, the VM binding can deal with the encoding and the decoding in 
 [`Slot`][slot-trait] implementation, and always present plain `ObjectReference`s to MMTk. See [this
 test] for some `Slot` implementation examples.
 
-[FBC09]: https://users.cecs.anu.edu.au/~steveb/pubs/papers/vmmagic-vee-2009.pdf
+[FBC09]: https://www.steveblackburn.org/pubs/papers/vmmagic-vee-2009.pdf
 [jikesrvm-objref]: https://github.com/mmtk/mmtk-jikesrvm/issues/178
 [slot-trait]: https://docs.mmtk.io/api/mmtk/vm/slot/trait.Slot.html
 [slot-test]: https://github.com/mmtk/mmtk-core/blob/master/src/vm/tests/mock_tests/mock_test_slots.rs

--- a/docs/userguide/src/tutorial/further_reading.md
+++ b/docs/userguide/src/tutorial/further_reading.md
@@ -4,6 +4,5 @@
 - Original MMTk papers:
   - [*Oil and Water? High Performance Garbage Collection in Java with MMTk*](https://www.mmtk.io/assets/pubs/mmtk-icse-2004.pdf) (Blackburn, Cheng, McKinley, 2004)
   - [*Myths and realities: The performance impact of garbage collection*](https://www.mmtk.io/assets/pubs/mmtk-sigmetrics-2004.pdf) (Blackburn, Cheng, McKinley, 2004)
-- [*The Garbage Collection Handbook*](https://learning.oreilly.com/library/view/the-garbage-collection/9781315388007) (Jones, Hosking, Moss, 2016)
 - [*The Garbage Collection Handbook*](https://gchandbook.org/) (Jones, Hosking, Moss, 2016)
 - Videos: [MPLR 2020 Keynote](https://www.youtube.com/watch?v=3L6XEVaYAmU), [Deconstructing the Garbage-First Collector](https://www.youtube.com/watch?v=MAk6RdApGLs)

--- a/docs/userguide/src/tutorial/further_reading.md
+++ b/docs/userguide/src/tutorial/further_reading.md
@@ -5,4 +5,5 @@
   - [*Oil and Water? High Performance Garbage Collection in Java with MMTk*](https://www.mmtk.io/assets/pubs/mmtk-icse-2004.pdf) (Blackburn, Cheng, McKinley, 2004)
   - [*Myths and realities: The performance impact of garbage collection*](https://www.mmtk.io/assets/pubs/mmtk-sigmetrics-2004.pdf) (Blackburn, Cheng, McKinley, 2004)
 - [*The Garbage Collection Handbook*](https://learning.oreilly.com/library/view/the-garbage-collection/9781315388007) (Jones, Hosking, Moss, 2016)
+- [*The Garbage Collection Handbook*](https://gchandbook.org/) (Jones, Hosking, Moss, 2016)
 - Videos: [MPLR 2020 Keynote](https://www.youtube.com/watch?v=3L6XEVaYAmU), [Deconstructing the Garbage-First Collector](https://www.youtube.com/watch?v=MAk6RdApGLs)


### PR DESCRIPTION
Some web sites do not allow robot access.  We modified links and the Lychee checking options to respect the policies of the web sites.

The GC Handbook now links to https://gchandbook.org/

We no longer exclude the host `users.cecs.anu.edu.au`.  Although the server no longer blocks our Lychee checker now, we modified one affected URL to directly link to https://www.steveblackburn.org/ because it will be redirected anyway.

The link-check workflow now notifies the user about 403 and suggests excluding the affected URLs.