### PR TITLE
Require `Slot` to implement `Sync`.

### DIFF
--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -32,6 +32,22 @@ Notes for the mmtk-core developers:
 
 ## 0.33.0
 
+### `Slot` is required to implement `Sync`
+
+```admonish tldr
+`vm::slot::Slot` now needs to implement `Sync`.
+```
+
+API changes:
+-   module `vm::slot`
+    +   `Slot`: Now required to implement `Sync`
+        *   The provided `SimpleSlot` in mmtk-core already implements `Sync`.  If the VM binding
+            uses it, no change is needed.
+        *   If the VM binding's `Slot` implementation does not include raw pointers (`*const T` and
+            `*mut T`), chance is high that it automatically implements `Sync`.  If this is the case,
+            no change is needed.
+        *   Otherwise, the VM binding should declare `unsafe impl Sync for ...` for the slot type.
+
 ### Thread IDs require `Debug` instead of `Display`
 
 ```admonish tldr

--- a/src/vm/slot.rs
+++ b/src/vm/slot.rs
@@ -105,7 +105,7 @@ use crate::util::{Address, ObjectReference};
 /// This trait only concerns the representation (i.e. the shape) of the slot, not its semantics,
 /// such as whether it holds strong or weak references.  Therefore, one `Slot` implementation can be
 /// used for both slots that hold strong references and slots that hold weak references.
-pub trait Slot: Copy + Send + Debug + PartialEq + Eq + Hash {
+pub trait Slot: Copy + Send + Sync + Debug + PartialEq + Eq + Hash {
     /// Load object reference from the slot.
     ///
     /// If the slot is not holding an object reference (For example, if it is holding NULL or a
@@ -117,6 +117,18 @@ pub trait Slot: Copy + Send + Debug + PartialEq + Eq + Hash {
     fn load(&self) -> Option<ObjectReference>;
 
     /// Store the object reference `object` into the slot.
+    ///
+    /// This method is used during a GC to update a slot so that it holds the updated
+    /// `ObjectReference` which points to the new address of the target object during a moving GC.
+    /// MMTk core may conservatively call this method even if the target object is not moved.
+    ///
+    /// Note that if [`crate::plan::PlanConstraints::may_trace_duplicate_edges`] is true, multiple
+    /// GC worker threads may visit the same slot during tracing, and update it concurrently.  In
+    /// this case, the implementation of [`Slot::store`] must be benign with respect to such a race,
+    /// but doesn't need to be an atomic read-modify-write operation.  Because the new address of a
+    /// moved object is unique during a GC, if such a race occurs, all invocations of `store` will
+    /// receive the same `object` argument.  Storing the same value to the same address is usually
+    /// idempotent.
     ///
     /// If the slot holds an object reference with tag bits, this method must preserve the tag
     /// bits while updating the object reference so that it points to the forwarded object given by
@@ -174,6 +186,7 @@ impl SimpleSlot {
 }
 
 unsafe impl Send for SimpleSlot {}
+unsafe impl Sync for SimpleSlot {}
 
 impl Slot for SimpleSlot {
     fn load(&self) -> Option<ObjectReference> {

--- a/src/vm/tests/mock_tests/mock_test_slots.rs
+++ b/src/vm/tests/mock_tests/mock_test_slots.rs
@@ -68,6 +68,7 @@ mod compressed_oop {
     }
 
     unsafe impl Send for CompressedOopSlot {}
+    unsafe impl Sync for CompressedOopSlot {}
 
     impl CompressedOopSlot {
         pub fn from_address(address: Address) -> Self {
@@ -148,6 +149,7 @@ mod offset_slot {
     }
 
     unsafe impl Send for OffsetSlot {}
+    unsafe impl Sync for OffsetSlot {}
 
     impl OffsetSlot {
         pub fn new_no_offset(address: Address) -> Self {
@@ -183,6 +185,11 @@ mod offset_slot {
         fn store(&self, object: ObjectReference) {
             let begin = object.to_raw_address();
             let middle = begin + self.offset;
+
+            // Note on thread-safety: Because the `OffsetSlot` value itself is immutable,
+            // if multiple GC workers call `store` with the same `object` value,
+            // they always compute to the same `middle` value,
+            // and it is stored via a single atomic store.
             unsafe { (*self.slot_addr).store(middle, atomic::Ordering::Relaxed) }
         }
     }
@@ -242,6 +249,7 @@ mod tagged_slot {
     }
 
     unsafe impl Send for TaggedSlot {}
+    unsafe impl Sync for TaggedSlot {}
 
     impl TaggedSlot {
         // The DummyVM has OBJECT_REF_OFFSET = 4.
@@ -262,6 +270,10 @@ mod tagged_slot {
             ObjectReference::from_raw_address(unsafe { Address::from_usize(untagged) })
         }
 
+        // Note on thread-safety: `TaggedSlot::store` doesn't modify the tag bits.
+        // If multiple GC workers call `store` with the same `object` value,
+        // they will apply the same tag bits, resulting in the same `new_tagged` value.
+        // It is then stored via a single atomic store.
         fn store(&self, object: ObjectReference) {
             let old_tagged = unsafe { (*self.slot_addr).load(atomic::Ordering::Relaxed) };
             let new_untagged = object.to_raw_address().as_usize();
@@ -359,6 +371,7 @@ mod mixed {
     }
 
     unsafe impl Send for DummyVMSlot {}
+    unsafe impl Sync for DummyVMSlot {}
 
     impl Slot for DummyVMSlot {
         fn load(&self) -> Option<ObjectReference> {
@@ -372,6 +385,15 @@ mod mixed {
         }
 
         fn store(&self, object: ObjectReference) {
+            // Note on thread-safety:
+            // A `DummyVMSlot` value is an `enum` with multiple variants,
+            // and an `enum` cannot be updated atomically.
+            // But `DummyVMSlot::store` updates the underlying object slot,
+            // not the `DummyVMSlot` value itself.
+            // In fact, all `Slot` implementations are immutable.
+            // Regardless what variant the enum variant is,
+            // the underlying store is always atomic,
+            // and multiple GC workers always store the same value to the underlying object slot.
             match self {
                 DummyVMSlot::Simple(e) => e.store(object),
                 #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
`Slot` has pointer semantics and is immutable, so there should be no problem if two threads reference the same `Slot` value at the same time.

In the doc comment, we also mention the possibility that two GC workers may update the same slot concurrently during tracing, and require the VM binding to implement `Slot::store` in a way that is benign to such a race.