### PR TITLE
Set allocation_success before oom call

### DIFF
--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -254,6 +254,7 @@ pub struct AllocatorContext<VM: VMBinding> {
     alloc_options: AllocationOptionsHolder,
     pub state: Arc<GlobalState>,
     /// Have we thrown an OOM already?
+    /// This value is only set and reset if [`Collection::out_of_memory`] returns.
     pub thrown_oom: AtomicBool,
     pub options: Arc<Options>,
     pub gc_trigger: Arc<GCTrigger<VM>>,
@@ -287,7 +288,7 @@ impl<VM: VMBinding> AllocatorContext<VM> {
     }
 }
 
-fn reset_allocation_state<VM: VMBinding, A: Allocator<VM> + ?Sized>(allocator: &A) {
+fn reset_oom_state<VM: VMBinding, A: Allocator<VM> + ?Sized>(allocator: &A) {
     let context = allocator.get_context();
     // Relaxed store is fine since this is a thread-local boolean.
     context.thrown_oom.store(false, Ordering::Relaxed);
@@ -536,7 +537,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 // the code beyond this point tests OOM conditions and, if not OOM, try to allocate
                 // again.  Since we didn't block for GC, the allocation will fail again if we try
                 // again. So we return null immediately.
-                reset_allocation_state(self);
+                reset_oom_state(self);
                 return Address::ZERO;
             }
 
@@ -545,7 +546,7 @@ pub trait Allocator<VM: VMBinding>: Downcast {
             if self.get_context().thrown_oom.load(Ordering::Relaxed) {
                 // Need to reset the thrown_oom state since we're giving up on this allocation,
                 // that is to say, the thrown_oom state is *per* allocation request
-                reset_allocation_state(self);
+                reset_oom_state(self);
                 return Address::ZERO;
             }
 
@@ -569,21 +570,18 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 if fail_with_oom {
                     // Note that we throw a `HeapOutOfMemory` error here and return a null ptr back to the VM
                     trace!("Throw HeapOutOfMemory!");
-                    // `allocation_success` was swapped to `true` above unconditionally, before
-                    // calling the VM binding's callback. `Collection::out_of_memory` is not
-                    // guaranteed to return (a binding may unwind out of it instead), so we undo
-                    // that swap *before* calling it, rather than after: otherwise, a callback
-                    // that doesn't return would leave `allocation_success` stuck at `true`.
+                    // Undo the swap above *before* the callback: `Collection::out_of_memory`
+                    // may not return (a binding may unwind out of it instead).
                     self.get_context()
                         .state
                         .allocation_success
                         .store(false, Ordering::SeqCst);
+                    // Tell the binding about the OOM. The binding may or may not return from this call.
+                    // TODO: This is subject to change in the future. See https://github.com/mmtk/mmtk-core/issues/1475.
                     self.out_of_memory(tls);
-                    // `thrown_oom` is only ever set (by `out_of_memory`, above) *after* the
-                    // callback returns, so resetting it here is only ever undoing a side effect
-                    // that happened in this same call -- there's nothing to undo if the callback
-                    // didn't return, so it's safe for this reset to stay after the call.
-                    reset_allocation_state(self);
+                    // `thrown_oom` is only set after `out_of_memory` returns, so this reset can
+                    // safely stay after the call.
+                    reset_oom_state(self);
                     return result;
                 }
             }

--- a/src/util/alloc/allocator.rs
+++ b/src/util/alloc/allocator.rs
@@ -569,12 +569,21 @@ pub trait Allocator<VM: VMBinding>: Downcast {
                 if fail_with_oom {
                     // Note that we throw a `HeapOutOfMemory` error here and return a null ptr back to the VM
                     trace!("Throw HeapOutOfMemory!");
-                    self.out_of_memory(tls);
-                    reset_allocation_state(self);
+                    // `allocation_success` was swapped to `true` above unconditionally, before
+                    // calling the VM binding's callback. `Collection::out_of_memory` is not
+                    // guaranteed to return (a binding may unwind out of it instead), so we undo
+                    // that swap *before* calling it, rather than after: otherwise, a callback
+                    // that doesn't return would leave `allocation_success` stuck at `true`.
                     self.get_context()
                         .state
                         .allocation_success
                         .store(false, Ordering::SeqCst);
+                    self.out_of_memory(tls);
+                    // `thrown_oom` is only ever set (by `out_of_memory`, above) *after* the
+                    // callback returns, so resetting it here is only ever undoing a side effect
+                    // that happened in this same call -- there's nothing to undo if the callback
+                    // didn't return, so it's safe for this reset to stay after the call.
+                    reset_allocation_state(self);
                     return result;
                 }
             }

--- a/src/vm/tests/mock_tests/mock_test_allocate_oom_unwind_inconsistent_state.rs
+++ b/src/vm/tests/mock_tests/mock_test_allocate_oom_unwind_inconsistent_state.rs
@@ -22,8 +22,7 @@ pub fn allocate_oom_unwind_leaves_inconsistent_state() {
                 block_for_gc: MockMethod::new_default(),
                 // A callback that never returns.
                 out_of_memory: MockMethod::new_fixed(Box::new(|(_tls, _err)| {
-                    assert!(
-                        false,
+                    panic!(
                         "Collection::out_of_memory was invoked for a real OOM; a real binding \
                          (e.g. mmtk-julia's jl_throw_out_of_memory_error()) may never return \
                          from this call"

--- a/src/vm/tests/mock_tests/mock_test_allocate_oom_unwind_inconsistent_state.rs
+++ b/src/vm/tests/mock_tests/mock_test_allocate_oom_unwind_inconsistent_state.rs
@@ -7,29 +7,20 @@ use crate::AllocationSemantics;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::Ordering;
 
-/// `alloc_slow_inline`'s emergency-collection branch (allocator.rs:559-580) swaps
-/// `GlobalState::allocation_success` to `true` *before* calling `self.out_of_memory(tls)`, then
-/// resets it back to `false` right after. Some bindings never return from that call (e.g.
-/// mmtk-julia's `jl_throw_out_of_memory_error()` is a C `longjmp`), skipping the reset. This test
-/// simulates that with an assertion failure inside the callback, caught via `catch_unwind`
-/// further up (standing in for the VM's own exception handler), then checks whether MMTk's state
-/// was left consistent.
-///
-/// `block_for_gc` is a no-op (never frees memory): it's not how we reach the emergency branch
-/// (we set `GlobalState::emergency_collection` directly, since there's no real GC scheduler
-/// here), but it's still called on every failed allocation, so it must not be left `unimplemented`.
-///
-/// The heap is filled with `at_safepoint: false` allocations, which always return immediately
-/// (success or null, never retrying or calling `block_for_gc` -- see the `!at_safepoint` early
-/// returns in `alloc_slow_inline` and `Space::not_acquiring`). This keeps the test plan-agnostic
-/// and hang-safe, regardless of each plan's allocator type or usable heap fraction.
+/// Some bindings never return from `Collection::out_of_memory` (e.g. mmtk-julia longjmps out of
+/// it), so any cleanup mmtk-core does after the callback is skipped. This test simulates such a
+/// callback with a panic (caught via `catch_unwind`, standing in for the VM's exception handler)
+/// and asserts MMTk's OOM bookkeeping is still consistent afterwards.
 #[test]
 pub fn allocate_oom_unwind_leaves_inconsistent_state() {
     with_mockvm(
         || -> MockVM {
             MockVM {
+                // `block_for_gc` is a no-op, but must be implemented: it's called on every failed allocation.
+                // We reach the emergency-collection branch by setting `emergency_collection` directly instead,
+                // as there's no real GC scheduler here.
                 block_for_gc: MockMethod::new_default(),
-                // Simulates a callback that never returns (see the doc comment above).
+                // A callback that never returns.
                 out_of_memory: MockMethod::new_fixed(Box::new(|(_tls, _err)| {
                     assert!(
                         false,
@@ -49,7 +40,8 @@ pub fn allocate_oom_unwind_leaves_inconsistent_state() {
             let mut fixture = MutatorFixture::create_with_heapsize(HEAP);
             let mmtk = fixture.mmtk();
 
-            // Fill the heap with small, non-retrying allocations until one genuinely fails.
+            // The heap is filled with `at_safepoint: false` allocations, which return immediately (success
+            // or null) without retrying or blocking for GC.
             let no_retry_options = AllocationOptions {
                 at_safepoint: false,
                 ..Default::default()
@@ -74,13 +66,16 @@ pub fn allocate_oom_unwind_leaves_inconsistent_state() {
                 "expected the heap to fill up within the iteration budget"
             );
 
-            // Simulate an emergency collection (see the doc comment above) and reset
-            // `allocation_success` for the new epoch, as a real GC's bookkeeping would.
-            mmtk.state.emergency_collection.store(true, Ordering::Relaxed);
-            mmtk.state.allocation_success.store(false, Ordering::Relaxed);
+            // Simulate an emergency collection, as a real GC's bookkeeping would.
+            mmtk.state
+                .emergency_collection
+                .store(true, Ordering::Relaxed);
+            mmtk.state
+                .allocation_success
+                .store(false, Ordering::Relaxed);
 
-            // The heap is already full, so this retries into the emergency-collection branch and
-            // calls `Collection::out_of_memory`, which we've set up to unwind rather than return.
+            // The heap is full, so this hits the emergency-collection branch and calls
+            // `Collection::out_of_memory`, which unwinds rather than returns.
             let panic_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                 memory_manager::alloc(
                     &mut fixture.mutator,
@@ -96,9 +91,7 @@ pub fn allocate_oom_unwind_leaves_inconsistent_state() {
                 assert!(mock.out_of_memory.is_called());
             });
 
-            // Unlike `allocation_success`, `thrown_oom` is only set *after* the callback returns
-            // (allocator.rs:343), so it's untouched here rather than corrupted -- worth asserting
-            // explicitly to document that contrast.
+            // `thrown_oom` is only set after the callback returns, so it must still be unset.
             let selector =
                 memory_manager::get_allocator_mapping(mmtk, AllocationSemantics::Default);
             let thrown_oom = unsafe { fixture.mutator.allocator(selector) }
@@ -110,17 +103,12 @@ pub fn allocate_oom_unwind_leaves_inconsistent_state() {
                 "thrown_oom should not be left set after a failed OOM handling attempt"
             );
 
-            // BUG: the reset at allocator.rs:573-577 never ran, so `allocation_success` is stuck
-            // `true` -- as if an allocation had succeeded since the last emergency collection.
-            // This breaks the heuristic (`GlobalState::determine_collection_attempts`) that
-            // decides when to declare a genuine OOM: any further unsatisfiable allocation would
-            // find `allocation_success` already `true` and silently retry forever instead (a
-            // livelock) -- which is why this test doesn't itself attempt a further allocation.
+            // `allocation_success` must be reset before the callback (which may not return).
+            // If it were left `true`, no further allocation could ever throw OOM again (a
+            // silent retry livelock).
             assert!(
                 !mmtk.state.allocation_success.load(Ordering::Relaxed),
-                "allocation_success should have been reset to false after handling OOM, but it \
-                 is stuck at true because Collection::out_of_memory did not return normally. \
-                 MMTk's OOM bookkeeping is now inconsistent."
+                "allocation_success should have been reset to false after calling OOM"
             );
         },
         no_cleanup,

--- a/src/vm/tests/mock_tests/mock_test_allocate_oom_unwind_inconsistent_state.rs
+++ b/src/vm/tests/mock_tests/mock_test_allocate_oom_unwind_inconsistent_state.rs
@@ -1,0 +1,128 @@
+// GITHUB-CI: MMTK_PLAN=all
+
+use super::mock_test_prelude::*;
+
+use crate::util::alloc::allocator::AllocationOptions;
+use crate::AllocationSemantics;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::Ordering;
+
+/// `alloc_slow_inline`'s emergency-collection branch (allocator.rs:559-580) swaps
+/// `GlobalState::allocation_success` to `true` *before* calling `self.out_of_memory(tls)`, then
+/// resets it back to `false` right after. Some bindings never return from that call (e.g.
+/// mmtk-julia's `jl_throw_out_of_memory_error()` is a C `longjmp`), skipping the reset. This test
+/// simulates that with an assertion failure inside the callback, caught via `catch_unwind`
+/// further up (standing in for the VM's own exception handler), then checks whether MMTk's state
+/// was left consistent.
+///
+/// `block_for_gc` is a no-op (never frees memory): it's not how we reach the emergency branch
+/// (we set `GlobalState::emergency_collection` directly, since there's no real GC scheduler
+/// here), but it's still called on every failed allocation, so it must not be left `unimplemented`.
+///
+/// The heap is filled with `at_safepoint: false` allocations, which always return immediately
+/// (success or null, never retrying or calling `block_for_gc` -- see the `!at_safepoint` early
+/// returns in `alloc_slow_inline` and `Space::not_acquiring`). This keeps the test plan-agnostic
+/// and hang-safe, regardless of each plan's allocator type or usable heap fraction.
+#[test]
+pub fn allocate_oom_unwind_leaves_inconsistent_state() {
+    with_mockvm(
+        || -> MockVM {
+            MockVM {
+                block_for_gc: MockMethod::new_default(),
+                // Simulates a callback that never returns (see the doc comment above).
+                out_of_memory: MockMethod::new_fixed(Box::new(|(_tls, _err)| {
+                    assert!(
+                        false,
+                        "Collection::out_of_memory was invoked for a real OOM; a real binding \
+                         (e.g. mmtk-julia's jl_throw_out_of_memory_error()) may never return \
+                         from this call"
+                    );
+                })),
+                ..MockVM::default()
+            }
+        },
+        || {
+            const MB: usize = 1024 * 1024;
+            const HEAP: usize = 4 * MB;
+            const CHUNK: usize = 4096;
+
+            let mut fixture = MutatorFixture::create_with_heapsize(HEAP);
+            let mmtk = fixture.mmtk();
+
+            // Fill the heap with small, non-retrying allocations until one genuinely fails.
+            let no_retry_options = AllocationOptions {
+                at_safepoint: false,
+                ..Default::default()
+            };
+            let mut filled = false;
+            for _ in 0..(HEAP / CHUNK + 16) {
+                let addr = memory_manager::alloc_with_options(
+                    &mut fixture.mutator,
+                    CHUNK,
+                    8,
+                    0,
+                    AllocationSemantics::Default,
+                    no_retry_options,
+                );
+                if addr.is_zero() {
+                    filled = true;
+                    break;
+                }
+            }
+            assert!(
+                filled,
+                "expected the heap to fill up within the iteration budget"
+            );
+
+            // Simulate an emergency collection (see the doc comment above) and reset
+            // `allocation_success` for the new epoch, as a real GC's bookkeeping would.
+            mmtk.state.emergency_collection.store(true, Ordering::Relaxed);
+            mmtk.state.allocation_success.store(false, Ordering::Relaxed);
+
+            // The heap is already full, so this retries into the emergency-collection branch and
+            // calls `Collection::out_of_memory`, which we've set up to unwind rather than return.
+            let panic_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                memory_manager::alloc(
+                    &mut fixture.mutator,
+                    CHUNK,
+                    8,
+                    0,
+                    AllocationSemantics::Default,
+                )
+            }));
+
+            assert!(panic_result.is_err());
+            read_mockvm(|mock| {
+                assert!(mock.out_of_memory.is_called());
+            });
+
+            // Unlike `allocation_success`, `thrown_oom` is only set *after* the callback returns
+            // (allocator.rs:343), so it's untouched here rather than corrupted -- worth asserting
+            // explicitly to document that contrast.
+            let selector =
+                memory_manager::get_allocator_mapping(mmtk, AllocationSemantics::Default);
+            let thrown_oom = unsafe { fixture.mutator.allocator(selector) }
+                .get_context()
+                .thrown_oom
+                .load(Ordering::Relaxed);
+            assert!(
+                !thrown_oom,
+                "thrown_oom should not be left set after a failed OOM handling attempt"
+            );
+
+            // BUG: the reset at allocator.rs:573-577 never ran, so `allocation_success` is stuck
+            // `true` -- as if an allocation had succeeded since the last emergency collection.
+            // This breaks the heuristic (`GlobalState::determine_collection_attempts`) that
+            // decides when to declare a genuine OOM: any further unsatisfiable allocation would
+            // find `allocation_success` already `true` and silently retry forever instead (a
+            // livelock) -- which is why this test doesn't itself attempt a further allocation.
+            assert!(
+                !mmtk.state.allocation_success.load(Ordering::Relaxed),
+                "allocation_success should have been reset to false after handling OOM, but it \
+                 is stuck at true because Collection::out_of_memory did not return normally. \
+                 MMTk's OOM bookkeeping is now inconsistent."
+            );
+        },
+        no_cleanup,
+    )
+}

--- a/src/vm/tests/mock_tests/mod.rs
+++ b/src/vm/tests/mock_tests/mod.rs
@@ -29,6 +29,7 @@ mod mock_test_allocate_no_gc_oom_on_acquire_no_oom_call;
 mod mock_test_allocate_no_gc_simple;
 mod mock_test_allocate_no_infinite_loop_if_throw_oom_returns;
 mod mock_test_allocate_nonmoving;
+mod mock_test_allocate_oom_unwind_inconsistent_state;
 mod mock_test_allocate_overcommit;
 mod mock_test_allocate_with_disable_collection;
 mod mock_test_allocate_with_initialize_collection;


### PR DESCRIPTION
This PR fixes a possible infinite loop in allocation. `Collection::out_of_memory` may not return, thus setting `allocation_success` after `out_of_memory` may never be executed. This results in an inconsistent state: MMTk failed an allocation, but `allocation_success` is still recorded as `true`.

Minor edits:
* Rename `reset_allocation_state` to `reset_oom_state`. We can not reset allocation state after the `out_of_memory` call, as it may not return. But we can set oom state, as it is only set and reset after the oom call.

The unit test is written by Claude.