### PR TITLE
Add missing prefix pages in MMTk tutorial

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -35,6 +35,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude 'https://dl.acm.org/**'
+            --failIfEmpty false
             './docs/**/*.md'
       - name: On link check failure
         if: failure()

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -35,7 +35,6 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude 'https://dl.acm.org/**'
-            --failIfEmpty false
             './docs/**/*.md'
       - name: On link check failure
         if: failure()

--- a/docs/userguide/src/SUMMARY.md
+++ b/docs/userguide/src/SUMMARY.md
@@ -7,14 +7,14 @@
 # For GC Developers
 
 - [Tutorial: Add a new GC plan to MMTk](tutorial/prefix.md)
-    - [Introduction]()
+    - [Introduction](tutorial/intro/prefix.md)
         - [What is MMTk?](tutorial/intro/what_is_mmtk.md)
         - [What will this tutorial cover?](tutorial/intro/what_will_this_tutorial_cover.md)
         - [Glossary](tutorial/intro/glossary.md)
-    - [Preliminaries]()
+    - [Preliminaries](tutorial/preliminaries/prefix.md)
         - [Set up MMTk and OpenJDK](tutorial/preliminaries/set_up.md)
         - [Test the build](tutorial/preliminaries/test.md)
-    - [MyGC]()
+    - [MyGC](tutorial/mygc/prefix.md)
         - [Create MyGC](tutorial/mygc/create.md)
         - [Building a semispace GC](tutorial/mygc/ss/prefix.md)
             - [Allocation](tutorial/mygc/ss/alloc.md)

--- a/docs/userguide/src/tutorial/intro/prefix.md
+++ b/docs/userguide/src/tutorial/intro/prefix.md
@@ -1,0 +1,7 @@
+# Introduction
+
+In this section, we introduce MMTk and this tutorial. We will cover what
+MMTk is, what this tutorial covers, and a glossary of terms that will be
+used throughout the tutorial. If you are already familiar with MMTk and
+garbage collection terminology, you may skim through this section and move
+on to the [preliminaries](../preliminaries/prefix.md).

--- a/docs/userguide/src/tutorial/mygc/prefix.md
+++ b/docs/userguide/src/tutorial/mygc/prefix.md
@@ -1,0 +1,7 @@
+# MyGC
+
+In this section, we will build a new garbage collector from scratch, called
+`MyGC`. We will start by creating MyGC as a copy of the simple NoGC plan,
+which only allocates memory and never collects. We will then extend it step
+by step into a semispace collector, and finally into a generational copying
+collector.

--- a/docs/userguide/src/tutorial/preliminaries/prefix.md
+++ b/docs/userguide/src/tutorial/preliminaries/prefix.md
@@ -1,0 +1,6 @@
+# Preliminaries
+
+In this section, we set up the environment for the tutorial. We will set up
+MMTk and OpenJDK (the binding used throughout the tutorial), and test the
+build to make sure everything works before moving on to building a new
+collector.


### PR DESCRIPTION
We have empty links in the MMTk tutorial, and the broken link check fails for empty links:
```console
Errors in docs/userguide/src/SUMMARY.md

    [ERROR] error: (at 10:7) | Empty URL found but a URL must not be empty
    [ERROR] error: (at 14:7) | Empty URL found but a URL must not be empty
    [ERROR] error: (at 17:7) | Empty URL found but a URL must not be empty

```

This PR also adds markdown pages for each section and links to the pages properly. `mdbook` seems to use empty links as 'draft chapter', which is not what we intended.