### PR TITLE
Remove mod mygc before ci-doc.sh quits

### DIFF
--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -20,7 +20,8 @@ cp -r $tutorial_code_dir $project_root/src/plan/mygc
 if ! cat $project_root/src/plan/mod.rs | grep -q "pub mod mygc;"; then
     echo "pub mod mygc;" >> $project_root/src/plan/mod.rs
     # Undo this on exit (success, failure, or early abort) so the working tree is always left clean
-    trap 'sed -i "/^pub mod mygc;\$/d" $project_root/src/plan/mod.rs' EXIT
+    # Use -i.bak (portable across GNU and BSD/macOS sed) and remove the backup file it leaves behind
+    trap 'sed -i.bak "/^pub mod mygc;\$/d" $project_root/src/plan/mod.rs && rm -f $project_root/src/plan/mod.rs.bak' EXIT
 fi
 cargo build
 

--- a/.github/scripts/ci-doc.sh
+++ b/.github/scripts/ci-doc.sh
@@ -19,6 +19,8 @@ cp -r $tutorial_code_dir $project_root/src/plan/mygc
 # If we havent appended the mod line, append it
 if ! cat $project_root/src/plan/mod.rs | grep -q "pub mod mygc;"; then
     echo "pub mod mygc;" >> $project_root/src/plan/mod.rs
+    # Undo this on exit (success, failure, or early abort) so the working tree is always left clean
+    trap 'sed -i "/^pub mod mygc;\$/d" $project_root/src/plan/mod.rs' EXIT
 fi
 cargo build
 


### PR DESCRIPTION
`ci-doc.sh` will add `pub mod mygc` to test the tutorial code (the `mygc` module). This PR adds a clean up to remove the line before the script quits.