### PR TITLE
Rename on_gc_start/end to on_pause_start/end. Call on_pause_start after all threads stop

### DIFF
--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -32,6 +32,31 @@ Notes for the mmtk-core developers:
 
 ## 0.33.0
 
+### `GCTriggerPolicy::on_gc_start`/`on_gc_end` renamed, and `on_pause_start` now fires after mutators stop
+
+```admonish tldr
+`GCTriggerPolicy::on_gc_start` and `on_gc_end` are renamed to `on_pause_start` and `on_pause_end`.
+In addition, `on_pause_start` is now called after all mutators have stopped, instead of at the very
+start of GC scheduling before mutators are asked to stop.
+```
+
+API changes:
+
+-   trait `util::heap::GCTriggerPolicy`
+    +   `on_gc_start`: Renamed to `on_pause_start`.
+        *   Previously called when GC was scheduled, before mutators were told to stop.
+        *   Now called after all mutators have stopped (i.e. once the world is actually stopped for
+            the pause). Implementations that only use this hook to record a timestamp or the
+            reserved-page count for computing GC time/space overhead should still work correctly,
+            but the recorded time will now reflect the start of the actual pause rather than the
+            start of GC scheduling (which also includes time spent waiting for mutators to reach a
+            safepoint).
+    +   `on_gc_end`: Renamed to `on_pause_end`.
+        *   No change to timing, only the name.
+
+This only affects VM bindings that provide a custom `GCTriggerPolicy` (via
+`Collection::create_gc_trigger`).
+
 ### Collection enabling/disabling is now managed by MMTk instead of the VM binding
 
 ```admonish tldr

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -9,9 +9,6 @@ pub struct ScheduleCollection;
 
 impl<VM: VMBinding> GCWork<VM> for ScheduleCollection {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
-        // Tell GC trigger that GC started.
-        mmtk.gc_trigger.policy.on_gc_start(mmtk);
-
         // Determine collection kind
         let is_emergency = mmtk.state.set_collection_kind(
             mmtk.get_plan().last_collection_was_exhaustive(),
@@ -236,6 +233,8 @@ impl<C: GCWorkContext> GCWork<C::VM> for StopMutators<C> {
         trace!("stop_all_mutators end");
         mmtk.get_plan().notify_mutators_paused(&mmtk.scheduler);
         mmtk.scheduler.notify_mutators_paused(mmtk);
+        // Tell GC trigger that the pause started.
+        mmtk.gc_trigger.policy.on_pause_start(mmtk);
         if !self.skip_roots {
             mmtk.scheduler.work_buckets[WorkBucketStage::Prepare]
                 .add(ScanVMSpecificRoots::<C>::new());

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -569,7 +569,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         let mmtk = worker.mmtk;
 
         // Tell GC trigger that GC ended - this happens before we resume mutators.
-        mmtk.gc_trigger.policy.on_gc_end(mmtk);
+        mmtk.gc_trigger.policy.on_pause_end(mmtk);
 
         // All other workers are parked, so it is safe to access the Plan instance mutably.
         probe!(mmtk, plan_end_of_gc_begin);

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -333,15 +333,15 @@ pub trait GCTriggerPolicy<VM: VMBinding>: Sync + Send {
     /// Failing to do so may result in unnecessay GCs, or result in an infinite loop if the new heap size
     /// can never accomodate the pending allocation.
     fn on_pending_allocation(&self, _pages: usize) {}
-    /// Inform the triggering policy that a GC starts.
-    fn on_gc_start(&self, _mmtk: &'static MMTK<VM>) {}
+    /// Inform the triggering policy that a pause starts.
+    fn on_pause_start(&self, _mmtk: &'static MMTK<VM>) {}
+    /// Inform the triggering policy that a pause ends.
+    fn on_pause_end(&self, _mmtk: &'static MMTK<VM>) {}
     /// Inform the triggering policy that a GC is about to start the release work. This is called
     /// in the global Release work packet. This means we assume a plan
     /// do not schedule any work that reclaims memory before the global `Release` work. The current plans
     /// satisfy this assumption: they schedule other release work in `plan.release()`.
     fn on_gc_release(&self, _mmtk: &'static MMTK<VM>) {}
-    /// Inform the triggering policy that a GC ends.
-    fn on_gc_end(&self, _mmtk: &'static MMTK<VM>) {}
     /// Is a GC required now? The GC trigger may implement its own heuristics to decide when
     /// a GC should be performed. However, we recommend the implementation to do its own checks
     /// first, and always call `plan.collection_required(space_full, space)` at the end as a fallback to see if the plan needs
@@ -483,7 +483,7 @@ impl MemBalancerStats {
     // * allocation = objects in mature space = promoted + pretentured = live pages in mature space before release - live pages at the end of last mature GC
     // * collection = live pages in mature space at the end of GC -  live pages in mature space before release
 
-    fn generational_mem_stats_on_gc_start<VM: VMBinding>(
+    fn generational_mem_stats_on_pause_start<VM: VMBinding>(
         &mut self,
         _plan: &dyn GenerationalPlan<VM = VM>,
     ) {
@@ -514,7 +514,7 @@ impl MemBalancerStats {
         }
     }
     /// Return true if we should compute a new heap limit. Only do so at the end of a mature GC
-    fn generational_mem_stats_on_gc_end<VM: VMBinding>(
+    fn generational_mem_stats_on_pause_end<VM: VMBinding>(
         &mut self,
         plan: &dyn GenerationalPlan<VM = VM>,
     ) -> bool {
@@ -538,7 +538,10 @@ impl MemBalancerStats {
     // * allocation = live pages at the start of GC - live pages at the end of last GC
     // * collection = live pages at the end of GC - live pages before release
 
-    fn non_generational_mem_stats_on_gc_start<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
+    fn non_generational_mem_stats_on_pause_start<VM: VMBinding>(
+        &mut self,
+        mmtk: &'static MMTK<VM>,
+    ) {
         self.allocation_pages = mmtk
             .get_plan()
             .get_reserved_pages()
@@ -554,7 +557,7 @@ impl MemBalancerStats {
         self.gc_release_live_pages = mmtk.get_plan().get_reserved_pages();
         trace!("live before release = {}", self.gc_release_live_pages);
     }
-    fn non_generational_mem_stats_on_gc_end<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
+    fn non_generational_mem_stats_on_pause_end<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
         self.gc_end_live_pages = mmtk.get_plan().get_reserved_pages();
         trace!("live pages = {}", self.gc_end_live_pages);
         // Use live pages as an estimate for pages traversed during GC
@@ -583,8 +586,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
         self.pending_pages.fetch_add(pages, Ordering::SeqCst);
     }
 
-    fn on_gc_start(&self, mmtk: &'static MMTK<VM>) {
-        trace!("=== on_gc_start ===");
+    fn on_pause_start(&self, mmtk: &'static MMTK<VM>) {
+        trace!("=== on_pause_start ===");
         self.access_stats(|stats| {
             stats.gc_start_time = Instant::now();
             stats.allocation_time += (stats.gc_start_time - stats.gc_end_time).as_secs_f64();
@@ -595,9 +598,9 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
             );
 
             if let Some(plan) = mmtk.get_plan().generational() {
-                stats.generational_mem_stats_on_gc_start(plan);
+                stats.generational_mem_stats_on_pause_start(plan);
             } else {
-                stats.non_generational_mem_stats_on_gc_start(mmtk);
+                stats.non_generational_mem_stats_on_pause_start(mmtk);
             }
         });
     }
@@ -613,8 +616,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
         });
     }
 
-    fn on_gc_end(&self, mmtk: &'static MMTK<VM>) {
-        trace!("=== on_gc_end ===");
+    fn on_pause_end(&self, mmtk: &'static MMTK<VM>) {
+        trace!("=== on_pause_end ===");
         self.access_stats(|stats| {
             stats.gc_end_time = Instant::now();
             stats.collection_time += (stats.gc_end_time - stats.gc_start_time).as_secs_f64();
@@ -625,7 +628,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
             );
 
             if let Some(plan) = mmtk.get_plan().generational() {
-                if stats.generational_mem_stats_on_gc_end(plan) {
+                if stats.generational_mem_stats_on_pause_end(plan) {
                     self.compute_new_heap_limit(
                         mmtk.get_plan().get_reserved_pages(),
                         // We reserve an extra of min nursery. This ensures that we will not trigger
@@ -636,7 +639,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
                     );
                 }
             } else {
-                stats.non_generational_mem_stats_on_gc_end(mmtk);
+                stats.non_generational_mem_stats_on_pause_end(mmtk);
                 self.compute_new_heap_limit(
                     mmtk.get_plan().get_reserved_pages(),
                     mmtk.get_plan().get_collection_reserved_pages(),


### PR DESCRIPTION
This PR renames `on_gc_start/end` to `on_pause_start/end`.

`on_pause_start` now is called in the `StopMutators` packet after all the threads are stopped. Previously `on_gc_start` is called in `ScheduleCollection` when mutator threads are still running. In some trigger heuristics like mem balancer, it will record the used memory in `on_gc_start/end` to estimate how much memory is freed during the GC. If we call `on_gc_start` when mutator is still running, the used memory is miscounted, as there will be more allocation after the `on_gc_start` is called.