### PR TITLE
Add `on_gc_start/end` to `GCTriggerPolicy`

### DIFF
--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -32,19 +32,24 @@ Notes for the mmtk-core developers:
 
 ## 0.33.0
 
-### `GCTriggerPolicy::on_gc_start`/`on_gc_end` renamed, and `on_pause_start` now fires after mutators stop
+### `GCTriggerPolicy::on_gc_start/on_gc_end` repurposed for GC cycles
 
 ```admonish tldr
-`GCTriggerPolicy::on_gc_start` and `on_gc_end` are renamed to `on_pause_start` and `on_pause_end`.
-In addition, `on_pause_start` is now called after all mutators have stopped, instead of at the very
-start of GC scheduling before mutators are asked to stop.
+The old `on_gc_start` and `on_gc_end` (called once per STW pause) are renamed to `on_pause_start`
+and `on_pause_end`. `on_pause_start` is now also called after all mutators have stopped, instead of
+at the very start of GC scheduling before mutators are asked to stop. The names `on_gc_start` and
+`on_gc_end` are reused for a new pair of hooks with different semantics: they are called once per
+*GC cycle* rather than once per pause. For stop-the-world GCs, no changes are needed for the delegated
+GC trigger; however, for concurrent GCs, the GC trigger needs to differentiate pauses and GC cycles,
+and use the correct hooks correspondingly.
 ```
 
 API changes:
 
 -   trait `util::heap::GCTriggerPolicy`
     +   `on_gc_start`: Renamed to `on_pause_start`.
-        *   Previously called when GC was scheduled, before mutators were told to stop.
+        *   Previously called once for every STW pause, when GC was scheduled and before mutators
+            were told to stop.
         *   Now called after all mutators have stopped (i.e. once the world is actually stopped for
             the pause). Implementations that only use this hook to record a timestamp or the
             reserved-page count for computing GC time/space overhead should still work correctly,
@@ -53,6 +58,14 @@ API changes:
             safepoint).
     +   `on_gc_end`: Renamed to `on_pause_end`.
         *   No change to timing, only the name.
+    +   `on_gc_start`/`on_gc_end`: New methods that reuse the old names, but with different meaning.
+        *   A GC cycle consists of one or more STW pauses plus any concurrent work in between them.
+            These new hooks are called once per GC cycle, rather than once per pause.
+        *   For a stop-the-world plan, a GC cycle is exactly one pause, so `on_gc_start`/`on_gc_end`
+            fire at the same time as `on_pause_start`/`on_pause_end`.
+        *   For a concurrent plan whose cycle spans multiple pauses (e.g. an initial mark pause and
+            a final mark pause with concurrent marking in between), `on_gc_start` is only called for
+            the first pause of the cycle, and `on_gc_end` only for the last.
 
 This only affects VM bindings that provide a custom `GCTriggerPolicy` (via
 `Collection::create_gc_trigger`).

--- a/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
+++ b/docs/userguide/src/tutorial/code/mygc_semispace/global.rs
@@ -128,12 +128,6 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
     }
     // ANCHOR_END: release
 
-    // ANCHOR: end_of_gc
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
-        self.common.end_of_gc(tls);
-    }
-    // ANCHOR_END: end_of_gc
-
     // Modify
     // ANCHOR: plan_get_collection_reserve
     fn get_collection_reserved_pages(&self) -> usize {
@@ -163,6 +157,10 @@ impl<VM: VMBinding> Plan for MyGC<VM> {
     // ANCHOR: plan_common
     fn common(&self) -> &CommonPlan<VM> {
         &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut CommonPlan<VM> {
+        &mut self.common
     }
     // ANCHOR_END: plan_common
 }

--- a/docs/userguide/src/tutorial/mygc/ss/alloc.md
+++ b/docs/userguide/src/tutorial/mygc/ss/alloc.md
@@ -124,8 +124,10 @@ collection for our GC plan.
 
 #### Other methods in the Plan trait
 
-The trait `Plan` requires a `common()` method that should return a 
-reference to the common plan. Implement this method now.
+The trait `Plan` has a `common()` method (and a `common_mut()` counterpart) that should
+return a (mutable) reference to the common plan. Implement these methods now. Several default
+method implementations in the `Plan` trait, such as `end_of_pause()`, rely on `common_mut()` to do
+the right thing, so once these are implemented, `MyGC` does not need to override those methods.
 
 ```rust
 {{#include ../../code/mygc_semispace/global.rs:plan_common}}

--- a/docs/userguide/src/tutorial/mygc/ss/collection.md
+++ b/docs/userguide/src/tutorial/mygc/ss/collection.md
@@ -160,14 +160,6 @@ with `&mygc_mutator_release`.  This function will be called at the release stage
 allocation semantics to the new tospace. When the mutator threads resume, any new allocations for
 `Default` will then go to the new tospace.
 
-### End of GC
-
-Find the method `end_of_gc()` in `mygc/global.rs`. Call `end_of_gc` from the common plan instead.
-
-```rust
-{{#include ../../code/mygc_semispace/global.rs:end_of_gc}}
-```
-
 ## Implementing the Trace trait for MyGC
 
 The [`Trace`] trait is key for tracing objects in a GC.

--- a/src/plan/compressor/global.rs
+++ b/src/plan/compressor/global.rs
@@ -55,6 +55,10 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
         &self.common
     }
 
+    fn common_mut(&mut self) -> &mut CommonPlan<VM> {
+        &mut self.common
+    }
+
     fn base(&self) -> &BasePlan<VM> {
         &self.common.base
     }
@@ -71,10 +75,6 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
     fn release(&mut self, tls: VMWorkerThread) {
         self.common.release(tls, true);
         self.compressor_space.release();
-    }
-
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
-        self.common.end_of_gc(tls);
     }
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {

--- a/src/plan/concurrent/immix/global.rs
+++ b/src/plan/concurrent/immix/global.rs
@@ -258,7 +258,7 @@ impl<VM: VMBinding> Plan for ConcurrentImmix<VM> {
         // Every pause ends a GC cycle, except `InitialMark`, which is followed by concurrent
         // marking and a `FinalMark` pause before the cycle ends.
         if pause != Pause::InitialMark {
-            mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+            mmtk.gc_trigger.policy.on_gc_end(mmtk);
         }
 
         info!("{:?} end", pause);
@@ -315,7 +315,7 @@ impl<VM: VMBinding> Plan for ConcurrentImmix<VM> {
         // Every pause starts a new GC cycle, except `FinalMark`, which continues the cycle
         // started by the preceding `InitialMark` pause.
         if pause != Pause::FinalMark {
-            mmtk.gc_trigger.policy.on_gc_cycle_start(mmtk);
+            mmtk.gc_trigger.policy.on_gc_start(mmtk);
         }
 
         info!("{:?} start", pause);

--- a/src/plan/concurrent/immix/global.rs
+++ b/src/plan/concurrent/immix/global.rs
@@ -27,6 +27,7 @@ use crate::util::metadata::log_bit::UnlogBitsOperation;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
+use crate::MMTK;
 use crate::{policy::immix::ImmixSpace, util::opaque_pointer::VMWorkerThread};
 use std::sync::atomic::AtomicBool;
 
@@ -235,7 +236,7 @@ impl<VM: VMBinding> Plan for ConcurrentImmix<VM> {
         }
     }
 
-    fn end_of_gc(&mut self, _tls: VMWorkerThread) {
+    fn end_of_pause(&mut self, mmtk: &'static MMTK<VM>, _tls: VMWorkerThread) {
         self.last_gc_was_defrag
             .store(self.immix_space.end_of_gc(), Ordering::Relaxed);
 
@@ -253,6 +254,13 @@ impl<VM: VMBinding> Plan for ConcurrentImmix<VM> {
             // We keep the value of `self.should_do_full_gc` so that if full GC is triggered,
             // the next GC will be full GC.
         }
+
+        // Every pause ends a GC cycle, except `InitialMark`, which is followed by concurrent
+        // marking and a `FinalMark` pause before the cycle ends.
+        if pause != Pause::InitialMark {
+            mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+        }
+
         info!("{:?} end", pause);
     }
 
@@ -280,7 +288,7 @@ impl<VM: VMBinding> Plan for ConcurrentImmix<VM> {
         &self.common
     }
 
-    fn notify_mutators_paused(&self, _scheduler: &GCWorkScheduler<VM>) {
+    fn notify_mutators_paused(&self, mmtk: &'static MMTK<VM>) {
         use crate::vm::ActivePlan;
         let pause = self.current_pause().unwrap();
         match pause {
@@ -303,6 +311,13 @@ impl<VM: VMBinding> Plan for ConcurrentImmix<VM> {
                 self.set_concurrent_marking_state(false);
             }
         }
+
+        // Every pause starts a new GC cycle, except `FinalMark`, which continues the cycle
+        // started by the preceding `InitialMark` pause.
+        if pause != Pause::FinalMark {
+            mmtk.gc_trigger.policy.on_gc_cycle_start(mmtk);
+        }
+
         info!("{:?} start", pause);
     }
 

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -24,6 +24,7 @@ use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
 use crate::vm::*;
 use crate::ObjectQueue;
+use crate::MMTK;
 use enum_map::EnumMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -117,9 +118,10 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
         }
     }
 
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
+    fn end_of_pause(&mut self, mmtk: &'static MMTK<VM>, tls: VMWorkerThread) {
         let next_gc_full_heap = CommonGenPlan::should_next_gc_be_full_heap(self);
-        self.gen.end_of_gc(tls, next_gc_full_heap);
+        self.gen.end_of_pause(tls, next_gc_full_heap);
+        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
     }
 
     fn get_collection_reserved_pages(&self) -> usize {

--- a/src/plan/generational/copying/global.rs
+++ b/src/plan/generational/copying/global.rs
@@ -121,7 +121,7 @@ impl<VM: VMBinding> Plan for GenCopy<VM> {
     fn end_of_pause(&mut self, mmtk: &'static MMTK<VM>, tls: VMWorkerThread) {
         let next_gc_full_heap = CommonGenPlan::should_next_gc_be_full_heap(self);
         self.gen.end_of_pause(tls, next_gc_full_heap);
-        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+        mmtk.gc_trigger.policy.on_gc_end(mmtk);
     }
 
     fn get_collection_reserved_pages(&self) -> usize {

--- a/src/plan/generational/global.rs
+++ b/src/plan/generational/global.rs
@@ -78,9 +78,9 @@ impl<VM: VMBinding> CommonGenPlan<VM> {
         self.nursery.release();
     }
 
-    pub fn end_of_gc(&mut self, tls: VMWorkerThread, next_gc_full_heap: bool) {
+    pub fn end_of_pause(&mut self, tls: VMWorkerThread, next_gc_full_heap: bool) {
         self.set_next_gc_full_heap(next_gc_full_heap);
-        self.common.end_of_gc(tls);
+        self.common.end_of_pause(tls);
     }
 
     /// Independent of how many pages remain in the page budget (a function of heap size), we must

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -27,6 +27,7 @@ use crate::util::ObjectReference;
 use crate::util::VMWorkerThread;
 use crate::vm::*;
 use crate::ObjectQueue;
+use crate::MMTK;
 
 use enum_map::EnumMap;
 use std::sync::atomic::AtomicBool;
@@ -156,12 +157,14 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
             .store(full_heap, Ordering::Relaxed);
     }
 
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
+    fn end_of_pause(&mut self, mmtk: &'static MMTK<VM>, tls: VMWorkerThread) {
         let next_gc_full_heap = CommonGenPlan::should_next_gc_be_full_heap(self);
-        self.gen.end_of_gc(tls, next_gc_full_heap);
+        self.gen.end_of_pause(tls, next_gc_full_heap);
 
         let did_defrag = self.immix_space.end_of_gc();
         self.last_gc_was_defrag.store(did_defrag, Ordering::Relaxed);
+
+        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
     }
 
     fn current_gc_may_move_object(&self) -> bool {

--- a/src/plan/generational/immix/global.rs
+++ b/src/plan/generational/immix/global.rs
@@ -164,7 +164,7 @@ impl<VM: VMBinding> Plan for GenImmix<VM> {
         let did_defrag = self.immix_space.end_of_gc();
         self.last_gc_was_defrag.store(did_defrag, Ordering::Relaxed);
 
-        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+        mmtk.gc_trigger.policy.on_gc_end(mmtk);
     }
 
     fn current_gc_may_move_object(&self) -> bool {

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -176,6 +176,11 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
         panic!("Common Plan not handled!")
     }
 
+    /// Get a mutable reference to the common plan. See [`Self::common`].
+    fn common_mut(&mut self) -> &mut CommonPlan<Self::VM> {
+        panic!("Common Plan not handled!")
+    }
+
     /// Return a reference to `GenerationalPlan` to allow
     /// access methods specific to generational plans if the plan is a generational plan.
     fn generational(
@@ -202,7 +207,23 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector>;
 
     /// Called when all mutators are paused. This is called before prepare.
-    fn notify_mutators_paused(&self, _scheduler: &GCWorkScheduler<Self::VM>) {}
+    ///
+    /// A GC cycle consists of one or more STW pauses (see
+    /// [`crate::util::heap::gc_trigger::GCTriggerPolicy::on_pause_start`]), plus any concurrent
+    /// work in between or after the pauses. The default implementation assumes this plan performs
+    /// an entire GC cycle within a single pause (i.e. it is not a `ConcurrentPlan`), and notifies
+    /// the GC trigger that a new GC cycle has started by calling
+    /// [`crate::util::heap::gc_trigger::GCTriggerPolicy::on_gc_cycle_start`]. A plan whose pauses
+    /// do not each start a whole new GC cycle -- e.g. a `ConcurrentPlan` with multiple pauses per
+    /// cycle -- must override this method (as well as [`Self::end_of_pause`]), and call
+    /// `on_gc_cycle_start` itself, only for the pauses that do start a new cycle (if any).
+    fn notify_mutators_paused(&self, mmtk: &'static MMTK<Self::VM>) {
+        assert!(
+            self.concurrent().is_none(),
+            "ConcurrentPlan must override notify_mutators_paused"
+        );
+        mmtk.gc_trigger.policy.on_gc_cycle_start(mmtk);
+    }
 
     /// Prepare the plan before a GC. This is invoked in an initial step in the GC.
     /// This is invoked once per GC by one worker thread. `tls` is the worker thread that executes this method.
@@ -217,10 +238,31 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
     /// This is invoked once per GC by one worker thread. `tls` is the worker thread that executes this method.
     fn release(&mut self, tls: VMWorkerThread);
 
-    /// Inform the plan about the end of a GC. It is guaranteed that there is no further work for this GC.
-    /// This is invoked once per GC by one worker thread. `tls` is the worker thread that executes this method.
-    // TODO: This is actually called at the end of a pause/STW, rather than the end of a GC. It should be renamed.
-    fn end_of_gc(&mut self, _tls: VMWorkerThread);
+    /// Inform the plan about the end of a pause. It is guaranteed that there is no further work
+    /// for this pause. This is invoked once per pause by one worker thread. `tls` is the worker
+    /// thread that executes this method.
+    ///
+    /// Because a GC cycle may consist of more than one pause (see [`Self::notify_mutators_paused`]
+    /// for what a GC cycle is), a plan's implementation of this method is also responsible for
+    /// telling the GC trigger whether the GC cycle has ended, by calling
+    /// [`crate::util::heap::gc_trigger::GCTriggerPolicy::on_gc_cycle_end`]. The default
+    /// implementation calls [`Self::common_mut`]'s `end_of_pause`, and assumes this plan performs
+    /// an entire GC cycle within a single pause (i.e. it is not a `ConcurrentPlan`), so it
+    /// notifies the GC trigger unconditionally. A plan whose pauses do not each end a whole GC
+    /// cycle -- e.g. a `ConcurrentPlan` with multiple pauses per cycle -- must override this
+    /// method, and call `on_gc_cycle_end` itself, only for the pauses that do end a cycle (if
+    /// any). A plan that does more at the end of a pause than just delegating to the common plan
+    /// (e.g. updating its own plan-specific state) must also override this method, but should
+    /// still call `on_gc_cycle_end` (unconditionally, unless it is a `ConcurrentPlan`) to preserve
+    /// this behaviour.
+    fn end_of_pause(&mut self, mmtk: &'static MMTK<Self::VM>, tls: VMWorkerThread) {
+        self.common_mut().end_of_pause(tls);
+        assert!(
+            self.concurrent().is_none(),
+            "ConcurrentPlan must override end_of_pause"
+        );
+        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+    }
 
     /// Notify the plan that an emergency collection will happen. The plan should try to free as much memory as possible.
     /// The default implementation will force a full heap collection for generational plans.
@@ -663,8 +705,8 @@ impl<VM: VMBinding> BasePlan<VM> {
         self.vm_space.set_side_log_bits();
     }
 
-    pub fn end_of_gc(&mut self, _tls: VMWorkerThread) {
-        // Do nothing here. None of the spaces needs end_of_gc.
+    pub fn end_of_pause(&mut self, _tls: VMWorkerThread) {
+        // Do nothing here. None of the spaces needs end_of_pause.
     }
 
     pub(crate) fn collection_required<P: Plan>(&self, plan: &P, space_full: bool) -> bool {
@@ -801,9 +843,9 @@ impl<VM: VMBinding> CommonPlan<VM> {
         self.base.set_side_log_bits();
     }
 
-    pub fn end_of_gc(&mut self, tls: VMWorkerThread) {
+    pub fn end_of_pause(&mut self, tls: VMWorkerThread) {
         self.end_of_gc_nonmoving_space();
-        self.base.end_of_gc(tls);
+        self.base.end_of_pause(tls);
     }
 
     pub fn get_immortal(&self) -> &ImmortalSpace<VM> {

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -208,21 +208,13 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
 
     /// Called when all mutators are paused. This is called before prepare.
     ///
-    /// A GC cycle consists of one or more STW pauses (see
-    /// [`crate::util::heap::gc_trigger::GCTriggerPolicy::on_pause_start`]), plus any concurrent
-    /// work in between or after the pauses. The default implementation assumes this plan performs
-    /// an entire GC cycle within a single pause (i.e. it is not a `ConcurrentPlan`), and notifies
-    /// the GC trigger that a new GC cycle has started by calling
-    /// [`crate::util::heap::gc_trigger::GCTriggerPolicy::on_gc_cycle_start`]. A plan whose pauses
-    /// do not each start a whole new GC cycle -- e.g. a `ConcurrentPlan` with multiple pauses per
-    /// cycle -- must override this method (as well as [`Self::end_of_pause`]), and call
-    /// `on_gc_cycle_start` itself, only for the pauses that do start a new cycle (if any).
+    /// A plan that overrides this function need to manage the invocation of `GCTriggerPolicy::on_gc_start` at the proper timing for the plan.
     fn notify_mutators_paused(&self, mmtk: &'static MMTK<Self::VM>) {
         assert!(
             self.concurrent().is_none(),
             "ConcurrentPlan must override notify_mutators_paused"
         );
-        mmtk.gc_trigger.policy.on_gc_cycle_start(mmtk);
+        mmtk.gc_trigger.policy.on_gc_start(mmtk);
     }
 
     /// Prepare the plan before a GC. This is invoked in an initial step in the GC.
@@ -242,26 +234,15 @@ pub trait Plan: 'static + HasSpaces + Sync + Downcast {
     /// for this pause. This is invoked once per pause by one worker thread. `tls` is the worker
     /// thread that executes this method.
     ///
-    /// Because a GC cycle may consist of more than one pause (see [`Self::notify_mutators_paused`]
-    /// for what a GC cycle is), a plan's implementation of this method is also responsible for
-    /// telling the GC trigger whether the GC cycle has ended, by calling
-    /// [`crate::util::heap::gc_trigger::GCTriggerPolicy::on_gc_cycle_end`]. The default
-    /// implementation calls [`Self::common_mut`]'s `end_of_pause`, and assumes this plan performs
-    /// an entire GC cycle within a single pause (i.e. it is not a `ConcurrentPlan`), so it
-    /// notifies the GC trigger unconditionally. A plan whose pauses do not each end a whole GC
-    /// cycle -- e.g. a `ConcurrentPlan` with multiple pauses per cycle -- must override this
-    /// method, and call `on_gc_cycle_end` itself, only for the pauses that do end a cycle (if
-    /// any). A plan that does more at the end of a pause than just delegating to the common plan
-    /// (e.g. updating its own plan-specific state) must also override this method, but should
-    /// still call `on_gc_cycle_end` (unconditionally, unless it is a `ConcurrentPlan`) to preserve
-    /// this behaviour.
+    /// A plan that overrides this function need to do whatever the default implementation does at the proper timing
+    /// for the plan, such as calling `CommonPlan::end_of_pause` and `GCTriggerPolicy::on_gc_end`.
     fn end_of_pause(&mut self, mmtk: &'static MMTK<Self::VM>, tls: VMWorkerThread) {
         self.common_mut().end_of_pause(tls);
         assert!(
             self.concurrent().is_none(),
             "ConcurrentPlan must override end_of_pause"
         );
-        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+        mmtk.gc_trigger.policy.on_gc_end(mmtk);
     }
 
     /// Notify the plan that an emergency collection will happen. The plan should try to free as much memory as possible.

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -97,7 +97,7 @@ impl<VM: VMBinding> Plan for Immix<VM> {
         self.last_gc_was_defrag
             .store(self.immix_space.end_of_gc(), Ordering::Relaxed);
         self.common.end_of_pause(tls);
-        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+        mmtk.gc_trigger.policy.on_gc_end(mmtk);
     }
 
     fn current_gc_may_move_object(&self) -> bool {

--- a/src/plan/immix/global.rs
+++ b/src/plan/immix/global.rs
@@ -18,6 +18,7 @@ use crate::util::heap::VMRequest;
 use crate::util::metadata::log_bit::UnlogBitsOperation;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::vm::VMBinding;
+use crate::MMTK;
 use crate::{policy::immix::ImmixSpace, util::opaque_pointer::VMWorkerThread};
 use std::sync::atomic::AtomicBool;
 
@@ -92,10 +93,11 @@ impl<VM: VMBinding> Plan for Immix<VM> {
         self.release_inner(tls, UnlogBitsOperation::NoOp);
     }
 
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
+    fn end_of_pause(&mut self, mmtk: &'static MMTK<VM>, tls: VMWorkerThread) {
         self.last_gc_was_defrag
             .store(self.immix_space.end_of_gc(), Ordering::Relaxed);
-        self.common.end_of_gc(tls);
+        self.common.end_of_pause(tls);
+        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
     }
 
     fn current_gc_may_move_object(&self) -> bool {

--- a/src/plan/markcompact/global.rs
+++ b/src/plan/markcompact/global.rs
@@ -64,6 +64,10 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
         &self.common
     }
 
+    fn common_mut(&mut self) -> &mut CommonPlan<VM> {
+        &mut self.common
+    }
+
     fn prepare(&mut self, _tls: VMWorkerThread) {
         self.common.prepare(_tls, true);
         self.mc_space.prepare();
@@ -72,10 +76,6 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
     fn release(&mut self, _tls: VMWorkerThread) {
         self.common.release(_tls, true);
         self.mc_space.release();
-    }
-
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
-        self.common.end_of_gc(tls);
     }
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -15,6 +15,7 @@ use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::VMWorkerThread;
 use crate::vm::VMBinding;
+use crate::MMTK;
 use enum_map::EnumMap;
 use mmtk_macros::{HasSpaces, PlanTraceObject};
 
@@ -66,9 +67,10 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
         self.common.release(tls, true);
     }
 
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
+    fn end_of_pause(&mut self, mmtk: &'static MMTK<VM>, tls: VMWorkerThread) {
         self.ms.end_of_gc();
-        self.common.end_of_gc(tls);
+        self.common.end_of_pause(tls);
+        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {

--- a/src/plan/marksweep/global.rs
+++ b/src/plan/marksweep/global.rs
@@ -70,7 +70,7 @@ impl<VM: VMBinding> Plan for MarkSweep<VM> {
     fn end_of_pause(&mut self, mmtk: &'static MMTK<VM>, tls: VMWorkerThread) {
         self.ms.end_of_gc();
         self.common.end_of_pause(tls);
-        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+        mmtk.gc_trigger.policy.on_gc_end(mmtk);
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {

--- a/src/plan/nogc/global.rs
+++ b/src/plan/nogc/global.rs
@@ -15,6 +15,7 @@ use crate::util::heap::VMRequest;
 use crate::util::metadata::side_metadata::SideMetadataContext;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
+use crate::MMTK;
 use enum_map::EnumMap;
 use mmtk_macros::HasSpaces;
 
@@ -66,7 +67,7 @@ impl<VM: VMBinding> Plan for NoGC<VM> {
         unreachable!()
     }
 
-    fn end_of_gc(&mut self, _tls: VMWorkerThread) {
+    fn end_of_pause(&mut self, _mmtk: &'static MMTK<VM>, _tls: VMWorkerThread) {
         unreachable!()
     }
 

--- a/src/plan/pageprotect/global.rs
+++ b/src/plan/pageprotect/global.rs
@@ -57,10 +57,6 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
         self.space.release(true);
     }
 
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
-        self.common.end_of_gc(tls);
-    }
-
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
         self.base().collection_required(self, space_full)
     }
@@ -83,6 +79,10 @@ impl<VM: VMBinding> Plan for PageProtect<VM> {
 
     fn common(&self) -> &CommonPlan<VM> {
         &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut CommonPlan<VM> {
+        &mut self.common
     }
 }
 

--- a/src/plan/semispace/global.rs
+++ b/src/plan/semispace/global.rs
@@ -95,10 +95,6 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
         self.fromspace().release();
     }
 
-    fn end_of_gc(&mut self, tls: VMWorkerThread) {
-        self.common.end_of_gc(tls)
-    }
-
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
         self.base().collection_required(self, space_full)
     }
@@ -132,6 +128,10 @@ impl<VM: VMBinding> Plan for SemiSpace<VM> {
 
     fn common(&self) -> &CommonPlan<VM> {
         &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut CommonPlan<VM> {
+        &mut self.common
     }
 }
 

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -171,7 +171,7 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
 
         self.immix.common.end_of_pause(tls);
 
-        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
+        mmtk.gc_trigger.policy.on_gc_end(mmtk);
     }
 
     fn collection_required(&self, space_full: bool, space: Option<SpaceStats<Self::VM>>) -> bool {

--- a/src/plan/sticky/immix/global.rs
+++ b/src/plan/sticky/immix/global.rs
@@ -21,6 +21,7 @@ use crate::util::statistics::counter::EventCounter;
 use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use crate::Plan;
+use crate::MMTK;
 
 use atomic::Ordering;
 use std::sync::atomic::AtomicBool;
@@ -154,7 +155,11 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
         }
     }
 
-    fn end_of_gc(&mut self, tls: crate::util::opaque_pointer::VMWorkerThread) {
+    fn end_of_pause(
+        &mut self,
+        mmtk: &'static MMTK<VM>,
+        tls: crate::util::opaque_pointer::VMWorkerThread,
+    ) {
         let next_gc_full_heap =
             crate::plan::generational::global::CommonGenPlan::should_next_gc_be_full_heap(self);
         self.next_gc_full_heap
@@ -164,7 +169,9 @@ impl<VM: VMBinding> Plan for StickyImmix<VM> {
         self.immix
             .set_last_gc_was_defrag(was_defrag, Ordering::Relaxed);
 
-        self.immix.common.end_of_gc(tls);
+        self.immix.common.end_of_pause(tls);
+
+        mmtk.gc_trigger.policy.on_gc_cycle_end(mmtk);
     }
 
     fn collection_required(&self, space_full: bool, space: Option<SpaceStats<Self::VM>>) -> bool {

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -231,7 +231,9 @@ impl<C: GCWorkContext> GCWork<C::VM> for StopMutators<C> {
             }
         });
         trace!("stop_all_mutators end");
-        mmtk.get_plan().notify_mutators_paused(&mmtk.scheduler);
+        // This also tells the GC trigger whether a new GC cycle has started (see
+        // `Plan::notify_mutators_paused`).
+        mmtk.get_plan().notify_mutators_paused(mmtk);
         mmtk.scheduler.notify_mutators_paused(mmtk);
         // Tell GC trigger that the pause started.
         mmtk.gc_trigger.policy.on_pause_start(mmtk);

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -586,7 +586,9 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         // All other workers are parked, so it is safe to access the Plan instance mutably.
         probe!(mmtk, plan_end_of_gc_begin);
         let plan_mut: &mut dyn Plan<VM = VM> = unsafe { mmtk.get_plan_mut() };
-        plan_mut.end_of_gc(worker.tls);
+        // This also tells the GC trigger whether the GC cycle has ended (see
+        // `Plan::end_of_pause`).
+        plan_mut.end_of_pause(mmtk, worker.tls);
         probe!(mmtk, plan_end_of_gc_end);
 
         // Compute the elapsed time of the GC.

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -333,9 +333,23 @@ pub trait GCTriggerPolicy<VM: VMBinding>: Sync + Send {
     /// Failing to do so may result in unnecessay GCs, or result in an infinite loop if the new heap size
     /// can never accomodate the pending allocation.
     fn on_pending_allocation(&self, _pages: usize) {}
-    /// Inform the triggering policy that a pause starts.
+    /// Inform the triggering policy that a GC cycle starts. A GC cycle consists of one or more
+    /// GC pauses (see [`Self::on_pause_start`]) plus any concurrent work in between the pauses.
+    /// For a stop-the-world GC, a GC cycle is just a single pause, and this is called at the same
+    /// time as [`Self::on_pause_start`]. For a concurrent GC that splits a cycle into multiple
+    /// pauses (e.g. an initial mark pause and a final mark pause with concurrent marking in
+    /// between), this is only called once per cycle, for the first pause in the cycle.
+    fn on_gc_cycle_start(&self, _mmtk: &'static MMTK<VM>) {}
+    /// Inform the triggering policy that a GC cycle ends. See [`Self::on_gc_cycle_start`] for what
+    /// a GC cycle is. This is only called once per GC cycle, for the last pause in the cycle.
+    fn on_gc_cycle_end(&self, _mmtk: &'static MMTK<VM>) {}
+    /// Inform the triggering policy that a pause starts. For a concurrent GC, this is called once
+    /// for every STW pause in a GC cycle, not just once per cycle. See
+    /// [`Self::on_gc_cycle_start`] for the hook that is only called once per GC cycle.
     fn on_pause_start(&self, _mmtk: &'static MMTK<VM>) {}
-    /// Inform the triggering policy that a pause ends.
+    /// Inform the triggering policy that a pause ends. For a concurrent GC, this is called once
+    /// for every STW pause in a GC cycle, not just once per cycle. See [`Self::on_gc_cycle_end`]
+    /// for the hook that is only called once per GC cycle.
     fn on_pause_end(&self, _mmtk: &'static MMTK<VM>) {}
     /// Inform the triggering policy that a GC is about to start the release work. This is called
     /// in the global Release work packet. This means we assume a plan
@@ -483,7 +497,7 @@ impl MemBalancerStats {
     // * allocation = objects in mature space = promoted + pretentured = live pages in mature space before release - live pages at the end of last mature GC
     // * collection = live pages in mature space at the end of GC -  live pages in mature space before release
 
-    fn generational_mem_stats_on_pause_start<VM: VMBinding>(
+    fn generational_mem_stats_on_cycle_start<VM: VMBinding>(
         &mut self,
         _plan: &dyn GenerationalPlan<VM = VM>,
     ) {
@@ -514,7 +528,7 @@ impl MemBalancerStats {
         }
     }
     /// Return true if we should compute a new heap limit. Only do so at the end of a mature GC
-    fn generational_mem_stats_on_pause_end<VM: VMBinding>(
+    fn generational_mem_stats_on_cycle_end<VM: VMBinding>(
         &mut self,
         plan: &dyn GenerationalPlan<VM = VM>,
     ) -> bool {
@@ -538,7 +552,7 @@ impl MemBalancerStats {
     // * allocation = live pages at the start of GC - live pages at the end of last GC
     // * collection = live pages at the end of GC - live pages before release
 
-    fn non_generational_mem_stats_on_pause_start<VM: VMBinding>(
+    fn non_generational_mem_stats_on_cycle_start<VM: VMBinding>(
         &mut self,
         mmtk: &'static MMTK<VM>,
     ) {
@@ -557,7 +571,7 @@ impl MemBalancerStats {
         self.gc_release_live_pages = mmtk.get_plan().get_reserved_pages();
         trace!("live before release = {}", self.gc_release_live_pages);
     }
-    fn non_generational_mem_stats_on_pause_end<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
+    fn non_generational_mem_stats_on_cycle_end<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
         self.gc_end_live_pages = mmtk.get_plan().get_reserved_pages();
         trace!("live pages = {}", self.gc_end_live_pages);
         // Use live pages as an estimate for pages traversed during GC
@@ -586,8 +600,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
         self.pending_pages.fetch_add(pages, Ordering::SeqCst);
     }
 
-    fn on_pause_start(&self, mmtk: &'static MMTK<VM>) {
-        trace!("=== on_pause_start ===");
+    fn on_gc_cycle_start(&self, mmtk: &'static MMTK<VM>) {
+        trace!("=== on_gc_cycle_start ===");
         self.access_stats(|stats| {
             stats.gc_start_time = Instant::now();
             stats.allocation_time += (stats.gc_start_time - stats.gc_end_time).as_secs_f64();
@@ -598,9 +612,9 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
             );
 
             if let Some(plan) = mmtk.get_plan().generational() {
-                stats.generational_mem_stats_on_pause_start(plan);
+                stats.generational_mem_stats_on_cycle_start(plan);
             } else {
-                stats.non_generational_mem_stats_on_pause_start(mmtk);
+                stats.non_generational_mem_stats_on_cycle_start(mmtk);
             }
         });
     }
@@ -616,8 +630,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
         });
     }
 
-    fn on_pause_end(&self, mmtk: &'static MMTK<VM>) {
-        trace!("=== on_pause_end ===");
+    fn on_gc_cycle_end(&self, mmtk: &'static MMTK<VM>) {
+        trace!("=== on_gc_cycle_end ===");
         self.access_stats(|stats| {
             stats.gc_end_time = Instant::now();
             stats.collection_time += (stats.gc_end_time - stats.gc_start_time).as_secs_f64();
@@ -628,7 +642,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
             );
 
             if let Some(plan) = mmtk.get_plan().generational() {
-                if stats.generational_mem_stats_on_pause_end(plan) {
+                if stats.generational_mem_stats_on_cycle_end(plan) {
                     self.compute_new_heap_limit(
                         mmtk.get_plan().get_reserved_pages(),
                         // We reserve an extra of min nursery. This ensures that we will not trigger
@@ -639,7 +653,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
                     );
                 }
             } else {
-                stats.non_generational_mem_stats_on_pause_end(mmtk);
+                stats.non_generational_mem_stats_on_cycle_end(mmtk);
                 self.compute_new_heap_limit(
                     mmtk.get_plan().get_reserved_pages(),
                     mmtk.get_plan().get_collection_reserved_pages(),

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -552,10 +552,7 @@ impl MemBalancerStats {
     // * allocation = live pages at the start of GC - live pages at the end of last GC
     // * collection = live pages at the end of GC - live pages before release
 
-    fn non_generational_mem_stats_on_gc_start<VM: VMBinding>(
-        &mut self,
-        mmtk: &'static MMTK<VM>,
-    ) {
+    fn non_generational_mem_stats_on_gc_start<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
         self.allocation_pages = mmtk
             .get_plan()
             .get_reserved_pages()

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -339,16 +339,16 @@ pub trait GCTriggerPolicy<VM: VMBinding>: Sync + Send {
     /// time as [`Self::on_pause_start`]. For a concurrent GC that splits a cycle into multiple
     /// pauses (e.g. an initial mark pause and a final mark pause with concurrent marking in
     /// between), this is only called once per cycle, for the first pause in the cycle.
-    fn on_gc_cycle_start(&self, _mmtk: &'static MMTK<VM>) {}
-    /// Inform the triggering policy that a GC cycle ends. See [`Self::on_gc_cycle_start`] for what
+    fn on_gc_start(&self, _mmtk: &'static MMTK<VM>) {}
+    /// Inform the triggering policy that a GC cycle ends. See [`Self::on_gc_start`] for what
     /// a GC cycle is. This is only called once per GC cycle, for the last pause in the cycle.
-    fn on_gc_cycle_end(&self, _mmtk: &'static MMTK<VM>) {}
+    fn on_gc_end(&self, _mmtk: &'static MMTK<VM>) {}
     /// Inform the triggering policy that a pause starts. For a concurrent GC, this is called once
     /// for every STW pause in a GC cycle, not just once per cycle. See
-    /// [`Self::on_gc_cycle_start`] for the hook that is only called once per GC cycle.
+    /// [`Self::on_gc_start`] for the hook that is only called once per GC cycle.
     fn on_pause_start(&self, _mmtk: &'static MMTK<VM>) {}
     /// Inform the triggering policy that a pause ends. For a concurrent GC, this is called once
-    /// for every STW pause in a GC cycle, not just once per cycle. See [`Self::on_gc_cycle_end`]
+    /// for every STW pause in a GC cycle, not just once per cycle. See [`Self::on_gc_end`]
     /// for the hook that is only called once per GC cycle.
     fn on_pause_end(&self, _mmtk: &'static MMTK<VM>) {}
     /// Inform the triggering policy that a GC is about to start the release work. This is called
@@ -497,7 +497,7 @@ impl MemBalancerStats {
     // * allocation = objects in mature space = promoted + pretentured = live pages in mature space before release - live pages at the end of last mature GC
     // * collection = live pages in mature space at the end of GC -  live pages in mature space before release
 
-    fn generational_mem_stats_on_cycle_start<VM: VMBinding>(
+    fn generational_mem_stats_on_gc_start<VM: VMBinding>(
         &mut self,
         _plan: &dyn GenerationalPlan<VM = VM>,
     ) {
@@ -528,7 +528,7 @@ impl MemBalancerStats {
         }
     }
     /// Return true if we should compute a new heap limit. Only do so at the end of a mature GC
-    fn generational_mem_stats_on_cycle_end<VM: VMBinding>(
+    fn generational_mem_stats_on_gc_end<VM: VMBinding>(
         &mut self,
         plan: &dyn GenerationalPlan<VM = VM>,
     ) -> bool {
@@ -552,7 +552,7 @@ impl MemBalancerStats {
     // * allocation = live pages at the start of GC - live pages at the end of last GC
     // * collection = live pages at the end of GC - live pages before release
 
-    fn non_generational_mem_stats_on_cycle_start<VM: VMBinding>(
+    fn non_generational_mem_stats_on_gc_start<VM: VMBinding>(
         &mut self,
         mmtk: &'static MMTK<VM>,
     ) {
@@ -571,7 +571,7 @@ impl MemBalancerStats {
         self.gc_release_live_pages = mmtk.get_plan().get_reserved_pages();
         trace!("live before release = {}", self.gc_release_live_pages);
     }
-    fn non_generational_mem_stats_on_cycle_end<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
+    fn non_generational_mem_stats_on_gc_end<VM: VMBinding>(&mut self, mmtk: &'static MMTK<VM>) {
         self.gc_end_live_pages = mmtk.get_plan().get_reserved_pages();
         trace!("live pages = {}", self.gc_end_live_pages);
         // Use live pages as an estimate for pages traversed during GC
@@ -600,8 +600,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
         self.pending_pages.fetch_add(pages, Ordering::SeqCst);
     }
 
-    fn on_gc_cycle_start(&self, mmtk: &'static MMTK<VM>) {
-        trace!("=== on_gc_cycle_start ===");
+    fn on_gc_start(&self, mmtk: &'static MMTK<VM>) {
+        trace!("=== on_gc_start ===");
         self.access_stats(|stats| {
             stats.gc_start_time = Instant::now();
             stats.allocation_time += (stats.gc_start_time - stats.gc_end_time).as_secs_f64();
@@ -612,9 +612,9 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
             );
 
             if let Some(plan) = mmtk.get_plan().generational() {
-                stats.generational_mem_stats_on_cycle_start(plan);
+                stats.generational_mem_stats_on_gc_start(plan);
             } else {
-                stats.non_generational_mem_stats_on_cycle_start(mmtk);
+                stats.non_generational_mem_stats_on_gc_start(mmtk);
             }
         });
     }
@@ -630,8 +630,8 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
         });
     }
 
-    fn on_gc_cycle_end(&self, mmtk: &'static MMTK<VM>) {
-        trace!("=== on_gc_cycle_end ===");
+    fn on_gc_end(&self, mmtk: &'static MMTK<VM>) {
+        trace!("=== on_gc_end ===");
         self.access_stats(|stats| {
             stats.gc_end_time = Instant::now();
             stats.collection_time += (stats.gc_end_time - stats.gc_start_time).as_secs_f64();
@@ -642,7 +642,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
             );
 
             if let Some(plan) = mmtk.get_plan().generational() {
-                if stats.generational_mem_stats_on_cycle_end(plan) {
+                if stats.generational_mem_stats_on_gc_end(plan) {
                     self.compute_new_heap_limit(
                         mmtk.get_plan().get_reserved_pages(),
                         // We reserve an extra of min nursery. This ensures that we will not trigger
@@ -653,7 +653,7 @@ impl<VM: VMBinding> GCTriggerPolicy<VM> for MemBalancerTrigger {
                     );
                 }
             } else {
-                stats.non_generational_mem_stats_on_cycle_end(mmtk);
+                stats.non_generational_mem_stats_on_gc_end(mmtk);
                 self.compute_new_heap_limit(
                     mmtk.get_plan().get_reserved_pages(),
                     mmtk.get_plan().get_collection_reserved_pages(),


### PR DESCRIPTION
In addition to `on_pause_start/end`, this PR adds `on_gc_start/end` to `GCTriggerPolicy`. The implementation of `on_pause_start/end` of current trigger policy is now moved to `on_gc_start/end`.

`Plan::end_of_gc` is renamed to `Plan::end_of_pause`.

`on_gc_start/end` is called within the default implementation `Plan::notify_mutators_paused` and `Plan::end_of_pause` with an assertion that the plan is not concurrent. For any plan that overrides those above two `Plan` methods, they need to make sure they call `on_gc_start/end` properly.