### PR TITLE
Rename Compressor to OVC, MarkCompact to Lisp2

### DIFF
--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -13,9 +13,9 @@ fi
 
 ALL_PLANS=$(sed -n '/enum PlanSelector/,/}/p' src/util/options.rs | sed -e 's;//.*;;g' -e '/^$/d' -e 's/,//g' | xargs | grep -o '{.*}' | grep -o '\w\+')
 
-# At the moment, the Compressor does not work with the mock VM tests.
-# So we skip testing the Compressor entirely.
-ALL_PLANS=$(echo -n "$ALL_PLANS" | sed '/Compressor/d')
+# At the moment, OVC does not work with the mock VM tests.
+# So we skip testing OVC entirely.
+ALL_PLANS=$(echo -n "$ALL_PLANS" | sed '/OVC/d')
 
 # Test with mock VM:
 # - Find all the files that start with mock_test_

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,11 +192,11 @@ extreme_assertions = []
 # Enable multiple spaces for NoGC, each allocator maps to an individual ImmortalSpace.
 nogc_multi_space = []
 
-# Disable multiple spaces for Compressor.
-# Enabling this feature will cause the Compressor to move all objects, which will be
+# Disable multiple spaces for OVC.
+# Enabling this feature will cause OVC to move all objects, which will be
 # slower for large objects and will be outright incorrect for bindings which allocate
 # non-moving objects; but compacting all objects will be more space-efficient.
-compressor_single_space = []
+ovc_single_space = []
 
 # To collect statistics for each GC work packet. Enabling this may introduce a small overhead (several percentage slowdown on benchmark time).
 work_packet_stats = []

--- a/docs/userguide/src/migration/prefix.md
+++ b/docs/userguide/src/migration/prefix.md
@@ -30,6 +30,34 @@ Notes for the mmtk-core developers:
 
 <!-- Insert new versions here -->
 
+## 0.34.0
+
+### Rename "Compressor" to "OVC", and "MarkCompact" to "Lisp2"
+
+```admonish tldr
+The `Compressor` plan is renamed to `OVC`, and the `MarkCompact` plan is renamed to `Lisp2`.
+Both plans now live under the shared `plan::markcompact` module, as
+`plan::markcompact::ovc::OVC` and `plan::markcompact::lisp2::Lisp2` respectively. VM bindings that
+select a plan by name (e.g. via `MMTK_PLAN`), or refer to the renamed types/modules directly, need to
+be updated.
+```
+
+API changes:
+
+*   enum `util::options::PlanSelector`
+    -   `Compressor` -> `OVC`
+    -   `MarkCompact` -> `Lisp2`
+        +   This also changes the string accepted for the `plan` option (e.g. via the `MMTK_PLAN`
+            environment variable used by some bindings): use `"OVC"`/`"Lisp2"` instead of
+            `"Compressor"`/`"MarkCompact"`.
+*   Cargo feature `compressor_single_space` -> `ovc_single_space`
+
+Not API change, but worth noting:
+
+*   Any string that names these plans (e.g. the `MMTK_PLAN` environment variable used by some
+    bindings, or benchmark/CI configuration keyed by plan name) must be updated from
+    `"MarkCompact"`/`"Compressor"` to `"Lisp2"`/`"OVC"`.
+
 ## 0.33.0
 
 ### `GCTriggerPolicy::on_gc_start/on_gc_end` repurposed for GC cycles

--- a/docs/userguide/src/portingguide/concerns/address-based-hashing.md
+++ b/docs/userguide/src/portingguide/concerns/address-based-hashing.md
@@ -157,9 +157,9 @@ Hash at the end                    │   Header   │ ordinary fields...       �
 
 MMTk calls the following trait methods implemented by the VM binding during copying GC.
 
--   For non-delayed-copy collectors (all moving plans except MarkCompact)
+-   For non-delayed-copy collectors (all moving plans except Lisp2 and OVC)
     -   `ObjectModel::copy`
--   For delayed-copy collectors (MarkCompact)
+-   For delayed-copy collectors (Lisp2 and OVC)
     -   `ObjectModel::copy_to`
     -   `ObjectModel::get_reference_when_copied_to`
     -   `ObjectModel::get_size_when_copied`

--- a/docs/userguide/src/portingguide/concerns/weakref.md
+++ b/docs/userguide/src/portingguide/concerns/weakref.md
@@ -432,7 +432,7 @@ entries and another for young entries.
 ### Copying versus non-copying GC
 
 MMTk provides both copying and non-copying GC plans.  `MarkSweep` never moves any objects.
-`MarkCompact`, `SemiSpace` always moves all objects (except objects in the large object space,
+`Lisp2`, `OVC`, `SemiSpace` always moves all objects (except objects in the large object space,
 immortal space, VM space, etc.).  Immix-based plans sometimes do non-copying GC, and sometimes do
 copying GC.  Regardless of the plan, the VM binding can query if the current GC is a copying GC by
 calling

--- a/src/plan/compressor/mod.rs
+++ b/src/plan/compressor/mod.rs
@@ -1,5 +1,0 @@
-pub(super) mod gc_work;
-pub(super) mod global;
-pub(super) mod mutator;
-
-pub use self::global::Compressor;

--- a/src/plan/global.rs
+++ b/src/plan/global.rs
@@ -54,8 +54,8 @@ pub fn create_mutator<VM: VMBinding>(
         PlanSelector::PageProtect => {
             crate::plan::pageprotect::mutator::create_pp_mutator(tls, mmtk)
         }
-        PlanSelector::MarkCompact => {
-            crate::plan::markcompact::mutator::create_markcompact_mutator(tls, mmtk)
+        PlanSelector::Lisp2 => {
+            crate::plan::markcompact::lisp2::mutator::create_lisp2_mutator(tls, mmtk)
         }
         PlanSelector::StickyImmix => {
             crate::plan::sticky::immix::mutator::create_stickyimmix_mutator(tls, mmtk)
@@ -63,9 +63,7 @@ pub fn create_mutator<VM: VMBinding>(
         PlanSelector::ConcurrentImmix => {
             crate::plan::concurrent::immix::mutator::create_concurrent_immix_mutator(tls, mmtk)
         }
-        PlanSelector::Compressor => {
-            crate::plan::compressor::mutator::create_compressor_mutator(tls, mmtk)
-        }
+        PlanSelector::OVC => crate::plan::markcompact::ovc::mutator::create_ovc_mutator(tls, mmtk),
     })
 }
 
@@ -100,8 +98,8 @@ pub fn create_plan<VM: VMBinding>(
         PlanSelector::PageProtect => {
             Box::new(crate::plan::pageprotect::PageProtect::new(args)) as Box<dyn Plan<VM = VM>>
         }
-        PlanSelector::MarkCompact => {
-            Box::new(crate::plan::markcompact::MarkCompact::new(args)) as Box<dyn Plan<VM = VM>>
+        PlanSelector::Lisp2 => {
+            Box::new(crate::plan::markcompact::lisp2::Lisp2::new(args)) as Box<dyn Plan<VM = VM>>
         }
         PlanSelector::StickyImmix => {
             Box::new(crate::plan::sticky::immix::StickyImmix::new(args)) as Box<dyn Plan<VM = VM>>
@@ -110,8 +108,8 @@ pub fn create_plan<VM: VMBinding>(
             Box::new(crate::plan::concurrent::immix::ConcurrentImmix::new(args))
                 as Box<dyn Plan<VM = VM>>
         }
-        PlanSelector::Compressor => {
-            Box::new(crate::plan::compressor::Compressor::new(args)) as Box<dyn Plan<VM = VM>>
+        PlanSelector::OVC => {
+            Box::new(crate::plan::markcompact::ovc::OVC::new(args)) as Box<dyn Plan<VM = VM>>
         }
     }
 }

--- a/src/plan/markcompact/lisp2/gc_work.rs
+++ b/src/plan/markcompact/lisp2/gc_work.rs
@@ -14,18 +14,18 @@ use std::marker::PhantomData;
 
 /// iterate through the heap and calculate the new location of live objects
 pub struct CalculateForwardingAddress<VM: VMBinding> {
-    mc_space: &'static Lisp2Space<VM>,
+    space: &'static Lisp2Space<VM>,
 }
 
 impl<VM: VMBinding> GCWork<VM> for CalculateForwardingAddress<VM> {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        self.mc_space.calculate_forwarding_pointer();
+        self.space.calculate_forwarding_pointer();
     }
 }
 
 impl<VM: VMBinding> CalculateForwardingAddress<VM> {
-    pub fn new(mc_space: &'static Lisp2Space<VM>) -> Self {
-        Self { mc_space }
+    pub fn new(space: &'static Lisp2Space<VM>) -> Self {
+        Self { space }
     }
 }
 
@@ -77,18 +77,18 @@ impl<VM: VMBinding> UpdateReferences<VM> {
 
 /// compact live objects based on forwarding pointers calculated before
 pub struct Compact<VM: VMBinding> {
-    mc_space: &'static Lisp2Space<VM>,
+    space: &'static Lisp2Space<VM>,
 }
 
 impl<VM: VMBinding> GCWork<VM> for Compact<VM> {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        self.mc_space.compact();
+        self.space.compact();
     }
 }
 
 impl<VM: VMBinding> Compact<VM> {
-    pub fn new(mc_space: &'static Lisp2Space<VM>) -> Self {
-        Self { mc_space }
+    pub fn new(space: &'static Lisp2Space<VM>) -> Self {
+        Self { space }
     }
 }
 

--- a/src/plan/markcompact/lisp2/gc_work.rs
+++ b/src/plan/markcompact/lisp2/gc_work.rs
@@ -1,7 +1,7 @@
-use super::global::MarkCompact;
+use super::global::Lisp2;
 use crate::plan::tracing::{PlanTrace, UnsupportedTrace};
-use crate::policy::markcompactspace::MarkCompactSpace;
-use crate::policy::markcompactspace::{TRACE_KIND_FORWARD, TRACE_KIND_MARK};
+use crate::policy::lisp2space::Lisp2Space;
+use crate::policy::lisp2space::{TRACE_KIND_FORWARD, TRACE_KIND_MARK};
 use crate::scheduler::gc_work::*;
 use crate::scheduler::GCWork;
 use crate::scheduler::GCWorker;
@@ -14,7 +14,7 @@ use std::marker::PhantomData;
 
 /// iterate through the heap and calculate the new location of live objects
 pub struct CalculateForwardingAddress<VM: VMBinding> {
-    mc_space: &'static MarkCompactSpace<VM>,
+    mc_space: &'static Lisp2Space<VM>,
 }
 
 impl<VM: VMBinding> GCWork<VM> for CalculateForwardingAddress<VM> {
@@ -24,7 +24,7 @@ impl<VM: VMBinding> GCWork<VM> for CalculateForwardingAddress<VM> {
 }
 
 impl<VM: VMBinding> CalculateForwardingAddress<VM> {
-    pub fn new(mc_space: &'static MarkCompactSpace<VM>) -> Self {
+    pub fn new(mc_space: &'static Lisp2Space<VM>) -> Self {
         Self { mc_space }
     }
 }
@@ -32,7 +32,7 @@ impl<VM: VMBinding> CalculateForwardingAddress<VM> {
 /// create another round of root scanning work packets
 /// to update object references
 pub struct UpdateReferences<VM: VMBinding> {
-    plan: *const MarkCompact<VM>,
+    plan: *const Lisp2<VM>,
     p: PhantomData<VM>,
 }
 
@@ -44,7 +44,7 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         VM::VMScanning::prepare_for_roots_re_scanning();
         mmtk.state.prepare_for_stack_scanning();
         // Prepare common and base spaces for the 2nd round of transitive closure
-        let plan_mut = unsafe { &mut *(self.plan as *mut MarkCompact<VM>) };
+        let plan_mut = unsafe { &mut *(self.plan as *mut Lisp2<VM>) };
         plan_mut.common.release(worker.tls, true);
         plan_mut.common.prepare(worker.tls, true);
         #[cfg(feature = "extreme_assertions")]
@@ -57,17 +57,17 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
 
         for mutator in VM::VMActivePlan::mutators() {
             mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots].add(ScanMutatorRoots::<
-                MarkCompactForwardingGCWorkContext<VM>,
+                Lisp2ForwardingGCWorkContext<VM>,
             >(mutator));
         }
 
         mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
-            .add(ScanVMSpecificRoots::<MarkCompactForwardingGCWorkContext<VM>>::new());
+            .add(ScanVMSpecificRoots::<Lisp2ForwardingGCWorkContext<VM>>::new());
     }
 }
 
 impl<VM: VMBinding> UpdateReferences<VM> {
-    pub fn new(plan: &MarkCompact<VM>) -> Self {
+    pub fn new(plan: &Lisp2<VM>) -> Self {
         Self {
             plan,
             p: PhantomData,
@@ -77,7 +77,7 @@ impl<VM: VMBinding> UpdateReferences<VM> {
 
 /// compact live objects based on forwarding pointers calculated before
 pub struct Compact<VM: VMBinding> {
-    mc_space: &'static MarkCompactSpace<VM>,
+    mc_space: &'static Lisp2Space<VM>,
 }
 
 impl<VM: VMBinding> GCWork<VM> for Compact<VM> {
@@ -87,28 +87,28 @@ impl<VM: VMBinding> GCWork<VM> for Compact<VM> {
 }
 
 impl<VM: VMBinding> Compact<VM> {
-    pub fn new(mc_space: &'static MarkCompactSpace<VM>) -> Self {
+    pub fn new(mc_space: &'static Lisp2Space<VM>) -> Self {
         Self { mc_space }
     }
 }
 
 /// Marking trace
-pub type MarkingTrace<VM> = PlanTrace<MarkCompact<VM>, TRACE_KIND_MARK>;
+pub type MarkingTrace<VM> = PlanTrace<Lisp2<VM>, TRACE_KIND_MARK>;
 /// Forwarding trace
-pub type ForwardingTrace<VM> = PlanTrace<MarkCompact<VM>, TRACE_KIND_FORWARD>;
+pub type ForwardingTrace<VM> = PlanTrace<Lisp2<VM>, TRACE_KIND_FORWARD>;
 
-pub struct MarkCompactGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
-impl<VM: VMBinding> crate::scheduler::GCWorkContext for MarkCompactGCWorkContext<VM> {
+pub struct Lisp2GCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::scheduler::GCWorkContext for Lisp2GCWorkContext<VM> {
     type VM = VM;
-    type PlanType = MarkCompact<VM>;
+    type PlanType = Lisp2<VM>;
     type DefaultTrace = MarkingTrace<VM>;
     type PinningTrace = UnsupportedTrace<VM>;
 }
 
-pub struct MarkCompactForwardingGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
-impl<VM: VMBinding> crate::scheduler::GCWorkContext for MarkCompactForwardingGCWorkContext<VM> {
+pub struct Lisp2ForwardingGCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::scheduler::GCWorkContext for Lisp2ForwardingGCWorkContext<VM> {
     type VM = VM;
-    type PlanType = MarkCompact<VM>;
+    type PlanType = Lisp2<VM>;
     type DefaultTrace = ForwardingTrace<VM>;
     type PinningTrace = UnsupportedTrace<VM>;
 }

--- a/src/plan/markcompact/lisp2/global.rs
+++ b/src/plan/markcompact/lisp2/global.rs
@@ -1,17 +1,17 @@
-use super::gc_work::MarkCompactGCWorkContext;
+use super::gc_work::Lisp2GCWorkContext;
 use super::gc_work::{
     CalculateForwardingAddress, Compact, ForwardingTrace, MarkingTrace, UpdateReferences,
 };
 use crate::plan::global::CommonPlan;
 use crate::plan::global::{BasePlan, CreateGeneralPlanArgs, CreateSpecificPlanArgs};
-use crate::plan::markcompact::mutator::ALLOCATOR_MAPPING;
+use crate::plan::markcompact::lisp2::mutator::ALLOCATOR_MAPPING;
 use crate::plan::tracing::gc_work::weakref::{
     VMForwardWeakRefs, VMPostForwarding, VMProcessWeakRefs,
 };
 use crate::plan::AllocationSemantics;
 use crate::plan::Plan;
 use crate::plan::PlanConstraints;
-use crate::policy::markcompactspace::MarkCompactSpace;
+use crate::policy::lisp2space::Lisp2Space;
 use crate::policy::space::Space;
 use crate::scheduler::gc_work::*;
 use crate::scheduler::*;
@@ -30,16 +30,16 @@ use enum_map::EnumMap;
 use mmtk_macros::{HasSpaces, PlanTraceObject};
 
 #[derive(HasSpaces, PlanTraceObject)]
-pub struct MarkCompact<VM: VMBinding> {
+pub struct Lisp2<VM: VMBinding> {
     #[space]
     #[copy_semantics(CopySemantics::DefaultCopy)]
-    pub mc_space: MarkCompactSpace<VM>,
+    pub mc_space: Lisp2Space<VM>,
     #[parent]
     pub common: CommonPlan<VM>,
 }
 
-/// The plan constraints for the mark compact plan.
-pub const MARKCOMPACT_CONSTRAINTS: PlanConstraints = PlanConstraints {
+/// The plan constraints for the Lisp2 plan.
+pub const LISP2_CONSTRAINTS: PlanConstraints = PlanConstraints {
     moves_objects: true,
     needs_forward_after_liveness: true,
     max_non_los_default_alloc_bytes:
@@ -47,9 +47,9 @@ pub const MARKCOMPACT_CONSTRAINTS: PlanConstraints = PlanConstraints {
     ..PlanConstraints::default()
 };
 
-impl<VM: VMBinding> Plan for MarkCompact<VM> {
+impl<VM: VMBinding> Plan for Lisp2<VM> {
     fn constraints(&self) -> &'static PlanConstraints {
-        &MARKCOMPACT_CONSTRAINTS
+        &LISP2_CONSTRAINTS
     }
 
     fn base(&self) -> &BasePlan<VM> {
@@ -88,11 +88,11 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
 
         // Stop & scan mutators (mutator scanning can happen before STW)
         scheduler.work_buckets[WorkBucketStage::Unconstrained]
-            .add(StopMutators::<MarkCompactGCWorkContext<VM>>::new());
+            .add(StopMutators::<Lisp2GCWorkContext<VM>>::new());
 
         // Prepare global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Prepare]
-            .add(Prepare::<MarkCompactGCWorkContext<VM>>::new(self));
+            .add(Prepare::<Lisp2GCWorkContext<VM>>::new(self));
 
         scheduler.work_buckets[WorkBucketStage::CalculateForwarding]
             .add(CalculateForwardingAddress::<VM>::new(&self.mc_space));
@@ -102,7 +102,7 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
 
         // Release global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Release]
-            .add(Release::<MarkCompactGCWorkContext<VM>>::new(self));
+            .add(Release::<Lisp2GCWorkContext<VM>>::new(self));
 
         // Reference processing
         if !*self.base().options.no_reference_types {
@@ -177,7 +177,7 @@ impl<VM: VMBinding> Plan for MarkCompact<VM> {
     }
 }
 
-impl<VM: VMBinding> MarkCompact<VM> {
+impl<VM: VMBinding> Lisp2<VM> {
     pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
         // if vo_bit is enabled, VO_BIT_SIDE_METADATA_SPEC will be added to
         // SideMetadataContext by default, so we don't need to add it here.
@@ -191,26 +191,26 @@ impl<VM: VMBinding> MarkCompact<VM> {
 
         let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
-            constraints: &MARKCOMPACT_CONSTRAINTS,
+            constraints: &LISP2_CONSTRAINTS,
             global_side_metadata_specs,
         };
 
-        let mc_space = MarkCompactSpace::new(plan_args.get_normal_space_args(
+        let mc_space = Lisp2Space::new(plan_args.get_normal_space_args(
             "mc",
             true,
             false,
             VMRequest::discontiguous(),
         ));
 
-        MarkCompact {
+        Lisp2 {
             mc_space,
             common: CommonPlan::new(plan_args),
         }
     }
 }
 
-impl<VM: VMBinding> MarkCompact<VM> {
-    pub fn mc_space(&self) -> &MarkCompactSpace<VM> {
+impl<VM: VMBinding> Lisp2<VM> {
+    pub fn mc_space(&self) -> &Lisp2Space<VM> {
         &self.mc_space
     }
 }

--- a/src/plan/markcompact/lisp2/global.rs
+++ b/src/plan/markcompact/lisp2/global.rs
@@ -33,7 +33,7 @@ use mmtk_macros::{HasSpaces, PlanTraceObject};
 pub struct Lisp2<VM: VMBinding> {
     #[space]
     #[copy_semantics(CopySemantics::DefaultCopy)]
-    pub mc_space: Lisp2Space<VM>,
+    pub lisp2_space: Lisp2Space<VM>,
     #[parent]
     pub common: CommonPlan<VM>,
 }
@@ -70,12 +70,12 @@ impl<VM: VMBinding> Plan for Lisp2<VM> {
 
     fn prepare(&mut self, _tls: VMWorkerThread) {
         self.common.prepare(_tls, true);
-        self.mc_space.prepare();
+        self.lisp2_space.prepare();
     }
 
     fn release(&mut self, _tls: VMWorkerThread) {
         self.common.release(_tls, true);
-        self.mc_space.release();
+        self.lisp2_space.release();
     }
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
@@ -95,10 +95,10 @@ impl<VM: VMBinding> Plan for Lisp2<VM> {
             .add(Prepare::<Lisp2GCWorkContext<VM>>::new(self));
 
         scheduler.work_buckets[WorkBucketStage::CalculateForwarding]
-            .add(CalculateForwardingAddress::<VM>::new(&self.mc_space));
+            .add(CalculateForwardingAddress::<VM>::new(&self.lisp2_space));
         // do another trace to update references
         scheduler.work_buckets[WorkBucketStage::SecondRoots].add(UpdateReferences::<VM>::new(self));
-        scheduler.work_buckets[WorkBucketStage::Compact].add(Compact::<VM>::new(&self.mc_space));
+        scheduler.work_buckets[WorkBucketStage::Compact].add(Compact::<VM>::new(&self.lisp2_space));
 
         // Release global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Release]
@@ -165,7 +165,7 @@ impl<VM: VMBinding> Plan for Lisp2<VM> {
     }
 
     fn get_used_pages(&self) -> usize {
-        self.mc_space.reserved_pages() + self.common.get_used_pages()
+        self.lisp2_space.reserved_pages() + self.common.get_used_pages()
     }
 
     fn get_collection_reserved_pages(&self) -> usize {
@@ -195,22 +195,22 @@ impl<VM: VMBinding> Lisp2<VM> {
             global_side_metadata_specs,
         };
 
-        let mc_space = Lisp2Space::new(plan_args.get_normal_space_args(
-            "mc",
+        let lisp2_space = Lisp2Space::new(plan_args.get_normal_space_args(
+            "lisp2",
             true,
             false,
             VMRequest::discontiguous(),
         ));
 
         Lisp2 {
-            mc_space,
+            lisp2_space,
             common: CommonPlan::new(plan_args),
         }
     }
 }
 
 impl<VM: VMBinding> Lisp2<VM> {
-    pub fn mc_space(&self) -> &Lisp2Space<VM> {
-        &self.mc_space
+    pub fn lisp2_space(&self) -> &Lisp2Space<VM> {
+        &self.lisp2_space
     }
 }

--- a/src/plan/markcompact/lisp2/mod.rs
+++ b/src/plan/markcompact/lisp2/mod.rs
@@ -1,0 +1,9 @@
+//! Plan: Lisp2 (mark-compact using the Lisp-2 compaction algorithm)
+
+pub(in crate::plan) mod gc_work;
+pub(in crate::plan) mod global;
+pub(in crate::plan) mod mutator;
+
+pub use self::global::Lisp2;
+
+pub use self::global::LISP2_CONSTRAINTS;

--- a/src/plan/markcompact/lisp2/mutator.rs
+++ b/src/plan/markcompact/lisp2/mutator.rs
@@ -1,4 +1,4 @@
-use super::MarkCompact;
+use super::Lisp2;
 use crate::plan::mutator_context::common_prepare_func;
 use crate::plan::mutator_context::common_release_func;
 use crate::plan::mutator_context::create_allocator_mapping;
@@ -9,54 +9,54 @@ use crate::plan::mutator_context::MutatorConfig;
 use crate::plan::mutator_context::ReservedAllocators;
 use crate::plan::AllocationSemantics;
 use crate::util::alloc::allocators::AllocatorSelector;
-use crate::util::alloc::MarkCompactAllocator;
+use crate::util::alloc::Lisp2Allocator;
 use crate::util::opaque_pointer::*;
 use crate::vm::VMBinding;
 use crate::MMTK;
 use enum_map::EnumMap;
 
 const RESERVED_ALLOCATORS: ReservedAllocators = ReservedAllocators {
-    n_mark_compact: 1,
+    n_lisp2: 1,
     ..ReservedAllocators::DEFAULT
 };
 
 lazy_static! {
     pub static ref ALLOCATOR_MAPPING: EnumMap<AllocationSemantics, AllocatorSelector> = {
         let mut map = create_allocator_mapping(RESERVED_ALLOCATORS, true);
-        map[AllocationSemantics::Default] = AllocatorSelector::MarkCompact(0);
+        map[AllocationSemantics::Default] = AllocatorSelector::Lisp2(0);
         map
     };
 }
 
-pub fn create_markcompact_mutator<VM: VMBinding>(
+pub fn create_lisp2_mutator<VM: VMBinding>(
     mutator_tls: VMMutatorThread,
     mmtk: &'static MMTK<VM>,
 ) -> Mutator<VM> {
-    let markcompact = mmtk.get_plan().downcast_ref::<MarkCompact<VM>>().unwrap();
+    let lisp2 = mmtk.get_plan().downcast_ref::<Lisp2<VM>>().unwrap();
     let config = MutatorConfig {
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
-            let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, markcompact);
-            vec.push((AllocatorSelector::MarkCompact(0), markcompact.mc_space()));
+            let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, lisp2);
+            vec.push((AllocatorSelector::Lisp2(0), lisp2.mc_space()));
             vec
         }),
         prepare_func: &common_prepare_func,
-        release_func: &markcompact_mutator_release,
+        release_func: &lisp2_mutator_release,
     };
     let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }
 
-pub fn markcompact_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
+pub fn lisp2_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
     // reset the thread-local allocation bump pointer
-    let markcompact_allocator = unsafe {
+    let lisp2_allocator = unsafe {
         mutator
             .allocators
             .get_allocator_mut(mutator.config.allocator_mapping[AllocationSemantics::Default])
     }
-    .downcast_mut::<MarkCompactAllocator<VM>>()
+    .downcast_mut::<Lisp2Allocator<VM>>()
     .unwrap();
-    markcompact_allocator.reset();
+    lisp2_allocator.reset();
 
     common_release_func(mutator, tls);
 }

--- a/src/plan/markcompact/lisp2/mutator.rs
+++ b/src/plan/markcompact/lisp2/mutator.rs
@@ -37,7 +37,7 @@ pub fn create_lisp2_mutator<VM: VMBinding>(
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(RESERVED_ALLOCATORS, true, lisp2);
-            vec.push((AllocatorSelector::Lisp2(0), lisp2.mc_space()));
+            vec.push((AllocatorSelector::Lisp2(0), lisp2.lisp2_space()));
             vec
         }),
         prepare_func: &common_prepare_func,

--- a/src/plan/markcompact/mod.rs
+++ b/src/plan/markcompact/mod.rs
@@ -1,6 +1,8 @@
-pub(super) mod gc_work;
-pub(super) mod global;
-pub(super) mod mutator;
+//! Mark-compact plans.
 
-pub use self::global::MarkCompact;
-pub use self::global::MARKCOMPACT_CONSTRAINTS;
+/// Mark-compact using the Lisp-2 compaction algorithm
+pub mod lisp2;
+/// Mark-compact using offset-vector bitmaps (OVC)
+pub mod ovc;
+
+pub use lisp2::LISP2_CONSTRAINTS;

--- a/src/plan/markcompact/ovc/gc_work.rs
+++ b/src/plan/markcompact/ovc/gc_work.rs
@@ -1,33 +1,30 @@
-use super::global::Compressor;
+use super::global::OVC;
 use crate::plan::tracing::{PlanTrace, UnsupportedTrace};
-use crate::policy::compressor::{CompressorSpace, TRACE_KIND_FORWARD_ROOT, TRACE_KIND_MARK};
 use crate::policy::largeobjectspace::LargeObjectSpace;
+use crate::policy::ovc::{OVCSpace, TRACE_KIND_FORWARD_ROOT, TRACE_KIND_MARK};
 use crate::scheduler::gc_work::*;
 use crate::scheduler::{GCWork, GCWorker, WorkBucketStage};
 use crate::vm::{ActivePlan, Scanning, VMBinding};
 use crate::MMTK;
 use std::marker::{PhantomData, Send};
 
-/// Generate more packets by calling a method on [`CompressorSpace`].
-pub struct GenerateWork<VM: VMBinding, F: Fn(&'static CompressorSpace<VM>) + Send + 'static> {
-    compressor_space: &'static CompressorSpace<VM>,
+/// Generate more packets by calling a method on [`OVCSpace`].
+pub struct GenerateWork<VM: VMBinding, F: Fn(&'static OVCSpace<VM>) + Send + 'static> {
+    ovc_space: &'static OVCSpace<VM>,
     f: F,
 }
 
-impl<VM: VMBinding, F: Fn(&'static CompressorSpace<VM>) + Send + 'static> GCWork<VM>
+impl<VM: VMBinding, F: Fn(&'static OVCSpace<VM>) + Send + 'static> GCWork<VM>
     for GenerateWork<VM, F>
 {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        (self.f)(self.compressor_space);
+        (self.f)(self.ovc_space);
     }
 }
 
-impl<VM: VMBinding, F: Fn(&'static CompressorSpace<VM>) + Send + 'static> GenerateWork<VM, F> {
-    pub fn new(compressor_space: &'static CompressorSpace<VM>, f: F) -> Self {
-        Self {
-            compressor_space,
-            f,
-        }
+impl<VM: VMBinding, F: Fn(&'static OVCSpace<VM>) + Send + 'static> GenerateWork<VM, F> {
+    pub fn new(ovc_space: &'static OVCSpace<VM>, f: F) -> Self {
+        Self { ovc_space, f }
     }
 }
 
@@ -48,13 +45,12 @@ impl<VM: VMBinding> GCWork<VM> for UpdateReferences<VM> {
         mmtk.slot_logger.reset();
 
         for mutator in VM::VMActivePlan::mutators() {
-            mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots].add(ScanMutatorRoots::<
-                CompressorForwardingWorkContext<VM>,
-            >(mutator));
+            mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
+                .add(ScanMutatorRoots::<OVCForwardingWorkContext<VM>>(mutator));
         }
 
         mmtk.scheduler.work_buckets[WorkBucketStage::SecondRoots]
-            .add(ScanVMSpecificRoots::<CompressorForwardingWorkContext<VM>>::new());
+            .add(ScanVMSpecificRoots::<OVCForwardingWorkContext<VM>>::new());
     }
 }
 
@@ -66,45 +62,39 @@ impl<VM: VMBinding> UpdateReferences<VM> {
 
 /// Reset the allocator and update references in large object space.
 pub struct AfterCompact<VM: VMBinding> {
-    compressor_space: &'static CompressorSpace<VM>,
+    ovc_space: &'static OVCSpace<VM>,
     los: &'static LargeObjectSpace<VM>,
 }
 
 impl<VM: VMBinding> GCWork<VM> for AfterCompact<VM> {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        self.compressor_space.after_compact(worker, self.los);
+        self.ovc_space.after_compact(worker, self.los);
     }
 }
 
 impl<VM: VMBinding> AfterCompact<VM> {
-    pub fn new(
-        compressor_space: &'static CompressorSpace<VM>,
-        los: &'static LargeObjectSpace<VM>,
-    ) -> Self {
-        Self {
-            compressor_space,
-            los,
-        }
+    pub fn new(ovc_space: &'static OVCSpace<VM>, los: &'static LargeObjectSpace<VM>) -> Self {
+        Self { ovc_space, los }
     }
 }
 
 /// Marking trace
-pub type MarkingTrace<VM> = PlanTrace<Compressor<VM>, TRACE_KIND_MARK>;
+pub type MarkingTrace<VM> = PlanTrace<OVC<VM>, TRACE_KIND_MARK>;
 /// Forwarding trace
-pub type ForwardingTrace<VM> = PlanTrace<Compressor<VM>, TRACE_KIND_FORWARD_ROOT>;
+pub type ForwardingTrace<VM> = PlanTrace<OVC<VM>, TRACE_KIND_FORWARD_ROOT>;
 
-pub struct CompressorWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
-impl<VM: VMBinding> crate::scheduler::GCWorkContext for CompressorWorkContext<VM> {
+pub struct OVCWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::scheduler::GCWorkContext for OVCWorkContext<VM> {
     type VM = VM;
-    type PlanType = Compressor<VM>;
+    type PlanType = OVC<VM>;
     type DefaultTrace = MarkingTrace<VM>;
     type PinningTrace = UnsupportedTrace<VM>;
 }
 
-pub struct CompressorForwardingWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
-impl<VM: VMBinding> crate::scheduler::GCWorkContext for CompressorForwardingWorkContext<VM> {
+pub struct OVCForwardingWorkContext<VM: VMBinding>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::scheduler::GCWorkContext for OVCForwardingWorkContext<VM> {
     type VM = VM;
-    type PlanType = Compressor<VM>;
+    type PlanType = OVC<VM>;
     type DefaultTrace = ForwardingTrace<VM>;
     type PinningTrace = UnsupportedTrace<VM>;
 }

--- a/src/plan/markcompact/ovc/global.rs
+++ b/src/plan/markcompact/ovc/global.rs
@@ -1,15 +1,15 @@
-use super::gc_work::CompressorWorkContext;
+use super::gc_work::OVCWorkContext;
 use super::gc_work::{AfterCompact, ForwardingTrace, GenerateWork, MarkingTrace, UpdateReferences};
-use crate::plan::compressor::mutator::ALLOCATOR_MAPPING;
 use crate::plan::global::CreateGeneralPlanArgs;
 use crate::plan::global::CreateSpecificPlanArgs;
 use crate::plan::global::{BasePlan, CommonPlan};
+use crate::plan::markcompact::ovc::mutator::ALLOCATOR_MAPPING;
 use crate::plan::plan_constraints::MAX_NON_LOS_ALLOC_BYTES_COPYING_PLAN;
 use crate::plan::tracing::gc_work::weakref::{
     VMForwardWeakRefs, VMPostForwarding, VMProcessWeakRefs,
 };
 use crate::plan::{AllocationSemantics, Plan, PlanConstraints};
-use crate::policy::compressor::CompressorSpace;
+use crate::policy::ovc::OVCSpace;
 use crate::policy::space::Space;
 use crate::scheduler::gc_work::*;
 use crate::scheduler::{GCWorkScheduler, WorkBucketStage};
@@ -23,28 +23,28 @@ use crate::vm::VMBinding;
 use enum_map::EnumMap;
 use mmtk_macros::{HasSpaces, PlanTraceObject};
 
-/// [`Compressor`] implements a stop-the-world and parallel implementation of
+/// [`OVC`] implements a stop-the-world and parallel implementation of
 /// the Compressor, as described in Kermany and Petrank,
 /// [The Compressor: concurrent, incremental, and parallel compaction](https://dl.acm.org/doi/10.1145/1133255.1134023).
 #[derive(HasSpaces, PlanTraceObject)]
-pub struct Compressor<VM: VMBinding> {
+pub struct OVC<VM: VMBinding> {
     #[parent]
     pub common: CommonPlan<VM>,
     #[space]
-    pub compressor_space: CompressorSpace<VM>,
+    pub ovc_space: OVCSpace<VM>,
 }
 
-/// The plan constraints for the Compressor plan.
-pub const COMPRESSOR_CONSTRAINTS: PlanConstraints = PlanConstraints {
+/// The plan constraints for the OVC plan.
+pub const OVC_CONSTRAINTS: PlanConstraints = PlanConstraints {
     max_non_los_default_alloc_bytes: MAX_NON_LOS_ALLOC_BYTES_COPYING_PLAN,
     moves_objects: true,
     needs_forward_after_liveness: true,
     ..PlanConstraints::default()
 };
 
-impl<VM: VMBinding> Plan for Compressor<VM> {
+impl<VM: VMBinding> Plan for OVC<VM> {
     fn constraints(&self) -> &'static PlanConstraints {
-        &COMPRESSOR_CONSTRAINTS
+        &OVC_CONSTRAINTS
     }
 
     fn collection_required(&self, space_full: bool, _space: Option<SpaceStats<Self::VM>>) -> bool {
@@ -69,12 +69,12 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
 
     fn prepare(&mut self, tls: VMWorkerThread) {
         self.common.prepare(tls, true);
-        self.compressor_space.prepare();
+        self.ovc_space.prepare();
     }
 
     fn release(&mut self, tls: VMWorkerThread) {
         self.common.release(tls, true);
-        self.compressor_space.release();
+        self.ovc_space.release();
     }
 
     fn get_allocator_mapping(&self) -> &'static EnumMap<AllocationSemantics, AllocatorSelector> {
@@ -87,32 +87,32 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
 
         // Stop & scan mutators (mutator scanning can happen before STW)
         scheduler.work_buckets[WorkBucketStage::Unconstrained]
-            .add(StopMutators::<CompressorWorkContext<VM>>::new());
+            .add(StopMutators::<OVCWorkContext<VM>>::new());
 
         // Prepare global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Prepare]
-            .add(Prepare::<CompressorWorkContext<VM>>::new(self));
+            .add(Prepare::<OVCWorkContext<VM>>::new(self));
 
         scheduler.work_buckets[WorkBucketStage::CalculateForwarding].add(GenerateWork::new(
-            &self.compressor_space,
-            CompressorSpace::<VM>::add_offset_vector_tasks,
+            &self.ovc_space,
+            OVCSpace::<VM>::add_offset_vector_tasks,
         ));
 
         // scan roots to update their references
         scheduler.work_buckets[WorkBucketStage::SecondRoots].add(UpdateReferences::<VM>::new());
 
         scheduler.work_buckets[WorkBucketStage::Compact].add(GenerateWork::new(
-            &self.compressor_space,
-            CompressorSpace::<VM>::add_compact_tasks,
+            &self.ovc_space,
+            OVCSpace::<VM>::add_compact_tasks,
         ));
 
         scheduler.work_buckets[WorkBucketStage::Compact].set_sentinel(Box::new(
-            AfterCompact::<VM>::new(&self.compressor_space, &self.common.los),
+            AfterCompact::<VM>::new(&self.ovc_space, &self.common.los),
         ));
 
         // Release global/collectors/mutators
         scheduler.work_buckets[WorkBucketStage::Release]
-            .add(Release::<CompressorWorkContext<VM>>::new(self));
+            .add(Release::<OVCWorkContext<VM>>::new(self));
 
         // Reference processing
         if !*self.base().options.no_reference_types {
@@ -175,21 +175,21 @@ impl<VM: VMBinding> Plan for Compressor<VM> {
     }
 
     fn get_used_pages(&self) -> usize {
-        self.compressor_space.reserved_pages() + self.common.get_used_pages()
+        self.ovc_space.reserved_pages() + self.common.get_used_pages()
     }
 }
 
-impl<VM: VMBinding> Compressor<VM> {
+impl<VM: VMBinding> OVC<VM> {
     pub fn new(args: CreateGeneralPlanArgs<VM>) -> Self {
         let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,
-            constraints: &COMPRESSOR_CONSTRAINTS,
+            constraints: &OVC_CONSTRAINTS,
             global_side_metadata_specs: SideMetadataContext::new_global_specs(&[]),
         };
 
-        Compressor {
-            compressor_space: CompressorSpace::new(plan_args.get_normal_space_args(
-                "compressor_space",
+        OVC {
+            ovc_space: OVCSpace::new(plan_args.get_normal_space_args(
+                "ovc_space",
                 true,
                 false,
                 VMRequest::discontiguous(),

--- a/src/plan/markcompact/ovc/mod.rs
+++ b/src/plan/markcompact/ovc/mod.rs
@@ -1,0 +1,7 @@
+//! Plan: OVC (mark-compact using offset-vector bitmaps)
+
+pub(in crate::plan) mod gc_work;
+pub(in crate::plan) mod global;
+pub(in crate::plan) mod mutator;
+
+pub use self::global::OVC;

--- a/src/plan/markcompact/ovc/mutator.rs
+++ b/src/plan/markcompact/ovc/mutator.rs
@@ -1,4 +1,4 @@
-use crate::plan::compressor::Compressor;
+use crate::plan::markcompact::ovc::OVC;
 use crate::plan::mutator_context::common_prepare_func;
 use crate::plan::mutator_context::Mutator;
 use crate::plan::mutator_context::MutatorBuilder;
@@ -20,12 +20,12 @@ const RESERVED_ALLOCATORS: ReservedAllocators = ReservedAllocators {
 };
 
 lazy_static! {
-    /// When compressor_single_space is enabled, force all allocations to go to the default allocator and space.
+    /// When ovc_single_space is enabled, force all allocations to go to the default allocator and space.
     static ref ALLOCATOR_MAPPING_SINGLE_SPACE: EnumMap<AllocationSemantics, AllocatorSelector> = enum_map! {
         _ => AllocatorSelector::BumpPointer(0),
     };
     pub static ref ALLOCATOR_MAPPING: EnumMap<AllocationSemantics, AllocatorSelector> = {
-        if cfg!(feature = "compressor_single_space") {
+        if cfg!(feature = "ovc_single_space") {
             *ALLOCATOR_MAPPING_SINGLE_SPACE
         } else {
             let mut map = create_allocator_mapping(RESERVED_ALLOCATORS, true);
@@ -35,31 +35,31 @@ lazy_static! {
     };
 }
 
-pub fn create_compressor_mutator<VM: VMBinding>(
+pub fn create_ovc_mutator<VM: VMBinding>(
     mutator_tls: VMMutatorThread,
     mmtk: &'static MMTK<VM>,
 ) -> Mutator<VM> {
-    let plan = mmtk.get_plan().downcast_ref::<Compressor<VM>>().unwrap();
+    let plan = mmtk.get_plan().downcast_ref::<OVC<VM>>().unwrap();
     let config = MutatorConfig {
         allocator_mapping: &ALLOCATOR_MAPPING,
         space_mapping: Box::new({
             let mut vec = create_space_mapping(
                 RESERVED_ALLOCATORS,
-                !cfg!(feature = "compressor_single_space"),
+                !cfg!(feature = "ovc_single_space"),
                 plan,
             );
-            vec.push((AllocatorSelector::BumpPointer(0), &plan.compressor_space));
+            vec.push((AllocatorSelector::BumpPointer(0), &plan.ovc_space));
             vec
         }),
         prepare_func: &common_prepare_func,
-        release_func: &compressor_mutator_release,
+        release_func: &ovc_mutator_release,
     };
 
     let builder = MutatorBuilder::new(mutator_tls, mmtk, config);
     builder.build()
 }
 
-pub fn compressor_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
+pub fn ovc_mutator_release<VM: VMBinding>(mutator: &mut Mutator<VM>, tls: VMWorkerThread) {
     // reset the thread-local allocation bump pointer
     let bump_allocator = unsafe {
         mutator

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -44,7 +44,6 @@ mod generational;
 /// Sticky plans (using sticky marks for generational behaviors without a copying nursery)
 mod sticky;
 
-mod compressor;
 mod concurrent;
 mod immix;
 mod markcompact;
@@ -62,7 +61,7 @@ pub(crate) use generational::global::GenerationalPlan;
 pub use generational::copying::GENCOPY_CONSTRAINTS;
 pub use generational::immix::GENIMMIX_CONSTRAINTS;
 pub use immix::IMMIX_CONSTRAINTS;
-pub use markcompact::MARKCOMPACT_CONSTRAINTS;
+pub use markcompact::LISP2_CONSTRAINTS;
 pub use marksweep::MS_CONSTRAINTS;
 pub use nogc::NOGC_CONSTRAINTS;
 pub use pageprotect::PP_CONSTRAINTS;

--- a/src/plan/mutator_context.rs
+++ b/src/plan/mutator_context.rs
@@ -379,9 +379,9 @@ impl<VM: VMBinding> Mutator<VM> {
                     offset_of!(Allocators<VM>, malloc)
                         + size_of::<MallocAllocator<VM>>() * index as usize
                 }
-                AllocatorSelector::MarkCompact(index) => {
-                    offset_of!(Allocators<VM>, markcompact)
-                        + size_of::<MarkCompactAllocator<VM>>() * index as usize
+                AllocatorSelector::Lisp2(index) => {
+                    offset_of!(Allocators<VM>, lisp2)
+                        + size_of::<Lisp2Allocator<VM>>() * index as usize
                 }
                 AllocatorSelector::None => panic!("Expect a valid AllocatorSelector, found None"),
             }
@@ -488,7 +488,7 @@ pub(crate) struct ReservedAllocators {
     pub n_large_object: u8,
     pub n_malloc: u8,
     pub n_immix: u8,
-    pub n_mark_compact: u8,
+    pub n_lisp2: u8,
     pub n_free_list: u8,
 }
 
@@ -498,7 +498,7 @@ impl ReservedAllocators {
         n_large_object: 0,
         n_malloc: 0,
         n_immix: 0,
-        n_mark_compact: 0,
+        n_lisp2: 0,
         n_free_list: 0,
     };
     /// check if the number of each allocator is okay. Panics if any allocator exceeds the max number.
@@ -521,7 +521,7 @@ impl ReservedAllocators {
             "Allocator mapping declared more immix allocators than the max allowed."
         );
         assert!(
-            self.n_mark_compact as usize <= MAX_MARK_COMPACT_ALLOCATORS,
+            self.n_lisp2 as usize <= MAX_LISP2_ALLOCATORS,
             "Allocator mapping declared more mark compact allocators than the max allowed."
         );
         assert!(
@@ -555,9 +555,9 @@ impl ReservedAllocators {
         selector
     }
     #[allow(dead_code)]
-    fn add_mark_compact_allocator(&mut self) -> AllocatorSelector {
-        let selector = AllocatorSelector::MarkCompact(self.n_mark_compact);
-        self.n_mark_compact += 1;
+    fn add_lisp2_allocator(&mut self) -> AllocatorSelector {
+        let selector = AllocatorSelector::Lisp2(self.n_lisp2);
+        self.n_lisp2 += 1;
         selector
     }
     #[allow(dead_code)]

--- a/src/plan/tracing/mod.rs
+++ b/src/plan/tracing/mod.rs
@@ -65,7 +65,7 @@ pub trait Trace: 'static + Send + Clone {
     /// ## The enqueued value and the return value
     ///
     /// The return value may be different from the enqueued value.  For example, during the
-    /// forwarding stage of MarkCompact, it returns the new object reference, but enqueues the old
+    /// forwarding stage of Lisp2, it returns the new object reference, but enqueues the old
     /// `object` because the object has not been moved, yet.
     ///
     /// ## The `queue` can be a callback instead of a collection

--- a/src/policy/compressor/mod.rs
+++ b/src/policy/compressor/mod.rs
@@ -1,4 +1,0 @@
-pub mod compressorspace;
-pub mod forwarding;
-
-pub use compressorspace::*;

--- a/src/policy/largeobjectspace.rs
+++ b/src/policy/largeobjectspace.rs
@@ -393,7 +393,7 @@ impl<VM: VMBinding> LargeObjectSpace<VM> {
         }
     }
 
-    /// Enumerate objects in the to-space.  It is a workaround for Compressor which currently needs
+    /// Enumerate objects in the to-space.  It is a workaround for OVC which currently needs
     /// to enumerate reachable objects for during reference forwarding.
     pub(crate) fn enumerate_to_space_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
         // This function is intended to enumerate objects in the to-space.

--- a/src/policy/lisp2space.rs
+++ b/src/policy/lisp2space.rs
@@ -19,20 +19,20 @@ use atomic::Ordering;
 pub(crate) const TRACE_KIND_MARK: TraceKind = 0;
 pub(crate) const TRACE_KIND_FORWARD: TraceKind = 1;
 
-pub struct MarkCompactSpace<VM: VMBinding> {
+pub struct Lisp2Space<VM: VMBinding> {
     common: CommonSpace<VM>,
     pr: MonotonePageResource<VM>,
 }
 
 const GC_MARK_BIT_MASK: u8 = 1;
 
-/// For each MarkCompact object, we need one extra word for storing forwarding pointer (Lisp-2 implementation).
+/// For each Lisp2 object, we need one extra word for storing forwarding pointer (Lisp-2 implementation).
 /// Note that considering the object alignment, we may end up allocating/reserving more than one word per object.
-/// See [`MarkCompactSpace::HEADER_RESERVED_IN_BYTES`].
+/// See [`Lisp2Space::HEADER_RESERVED_IN_BYTES`].
 pub const GC_EXTRA_HEADER_WORD: usize = 1;
 const GC_EXTRA_HEADER_BYTES: usize = GC_EXTRA_HEADER_WORD << LOG_BYTES_IN_WORD;
 
-impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
+impl<VM: VMBinding> SFT for Lisp2Space<VM> {
     fn name(&self) -> &'static str {
         self.get_name()
     }
@@ -47,12 +47,12 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
 
     #[cfg(feature = "object_pinning")]
     fn pin_object(&self, _object: ObjectReference) -> bool {
-        panic!("Cannot pin/unpin objects of MarkCompactSpace.")
+        panic!("Cannot pin/unpin objects of Lisp2Space.")
     }
 
     #[cfg(feature = "object_pinning")]
     fn unpin_object(&self, _object: ObjectReference) -> bool {
-        panic!("Cannot pin/unpin objects of MarkCompactSpace.")
+        panic!("Cannot pin/unpin objects of Lisp2Space.")
     }
 
     #[cfg(feature = "object_pinning")]
@@ -96,22 +96,22 @@ impl<VM: VMBinding> SFT for MarkCompactSpace<VM> {
         _object: ObjectReference,
         _worker: GCWorkerMutRef,
     ) -> ObjectReference {
-        // We should not use trace_object for markcompact space.
+        // We should not use trace_object for Lisp2 space.
         // Depending on which trace it is, we should manually call either trace_mark or trace_forward.
         panic!("sft_trace_object() cannot be used with mark compact space")
     }
 
     fn debug_print_object_info(&self, object: ObjectReference) {
-        println!("marked = {}", MarkCompactSpace::<VM>::is_marked(object));
+        println!("marked = {}", Lisp2Space::<VM>::is_marked(object));
         println!(
             "head forwarding pointer = {:?}",
-            MarkCompactSpace::<VM>::get_header_forwarding_pointer(object)
+            Lisp2Space::<VM>::get_header_forwarding_pointer(object)
         );
         self.common.debug_print_object_global_info(object);
     }
 }
 
-impl<VM: VMBinding> Space<VM> for MarkCompactSpace<VM> {
+impl<VM: VMBinding> Space<VM> for Lisp2Space<VM> {
     fn as_space(&self) -> &dyn Space<VM> {
         self
     }
@@ -137,7 +137,7 @@ impl<VM: VMBinding> Space<VM> for MarkCompactSpace<VM> {
     }
 
     fn release_multiple_pages(&mut self, _start: Address) {
-        panic!("markcompactspace only releases pages enmasse")
+        panic!("Lisp2 space only releases pages enmasse")
     }
 
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
@@ -153,7 +153,7 @@ impl<VM: VMBinding> Space<VM> for MarkCompactSpace<VM> {
     }
 }
 
-impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for MarkCompactSpace<VM> {
+impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for Lisp2Space<VM> {
     fn trace_object<Q: ObjectQueue, const KIND: crate::policy::gc_work::TraceKind>(
         &self,
         queue: &mut Q,
@@ -163,7 +163,7 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for MarkCompac
     ) -> ObjectReference {
         debug_assert!(
             KIND != TRACE_KIND_TRANSITIVE_PIN,
-            "MarkCompact does not support transitive pin trace."
+            "Lisp2 does not support transitive pin trace."
         );
         if KIND == TRACE_KIND_MARK {
             self.trace_mark_object(queue, object)
@@ -184,7 +184,7 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for MarkCompac
     }
 }
 
-impl<VM: VMBinding> MarkCompactSpace<VM> {
+impl<VM: VMBinding> Lisp2Space<VM> {
     /// We need one extra header word for each object. Considering the alignment requirement, this is
     /// the actual bytes we need to reserve for each allocation.
     pub const HEADER_RESERVED_IN_BYTES: usize = if VM::MAX_ALIGNMENT > GC_EXTRA_HEADER_BYTES {
@@ -236,7 +236,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         let is_discontiguous = args.vmrequest.is_discontiguous();
         let local_specs = extract_side_metadata(&[*VM::VMObjectModel::LOCAL_MARK_BIT_SPEC]);
         let common = CommonSpace::new(args.into_policy_args(true, false, local_specs));
-        MarkCompactSpace {
+        Lisp2Space {
             pr: if is_discontiguous {
                 MonotonePageResource::new_discontiguous(vm_map)
             } else {
@@ -260,7 +260,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
             "{:x}: VO bit not set",
             object
         );
-        if MarkCompactSpace::<VM>::test_and_mark(object) {
+        if Lisp2Space::<VM>::test_and_mark(object) {
             queue.enqueue(object);
         }
         object
@@ -278,7 +278,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
         );
         // from this stage and onwards, mark bit is no longer needed
         // therefore, it can be reused to save one extra bit in metadata
-        if MarkCompactSpace::<VM>::test_and_clear_mark(object) {
+        if Lisp2Space::<VM>::test_and_clear_mark(object) {
             queue.enqueue(object);
         }
 
@@ -359,7 +359,7 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
 
     /// Linear scan all the live objects in the given memory region
     fn linear_scan_objects(&self, range: Range<Address>) -> impl Iterator<Item = ObjectReference> {
-        crate::util::linear_scan::ObjectIterator::<VM, MarkCompactObjectSize<VM>, true>::new(
+        crate::util::linear_scan::ObjectIterator::<VM, Lisp2ObjectSize<VM>, true>::new(
             range.start,
             range.end,
         )
@@ -447,8 +447,8 @@ impl<VM: VMBinding> MarkCompactSpace<VM> {
     }
 }
 
-struct MarkCompactObjectSize<VM>(std::marker::PhantomData<VM>);
-impl<VM: VMBinding> crate::util::linear_scan::LinearScanObjectSize for MarkCompactObjectSize<VM> {
+struct Lisp2ObjectSize<VM>(std::marker::PhantomData<VM>);
+impl<VM: VMBinding> crate::util::linear_scan::LinearScanObjectSize for Lisp2ObjectSize<VM> {
     fn size(object: ObjectReference) -> usize {
         VM::VMObjectModel::get_current_size(object)
     }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -21,13 +21,13 @@ pub mod gc_work;
 pub mod sft;
 pub mod sft_map;
 
-pub mod compressor;
 pub mod copyspace;
 pub mod immix;
 pub mod immortalspace;
 pub mod largeobjectspace;
+pub mod lisp2space;
 pub mod lockfreeimmortalspace;
-pub mod markcompactspace;
 pub mod marksweepspace;
+pub mod ovc;
 #[cfg(feature = "vm_space")]
 pub mod vmspace;

--- a/src/policy/ovc/forwarding.rs
+++ b/src/policy/ovc/forwarding.rs
@@ -1,6 +1,6 @@
 use crate::util::constants::BYTES_IN_WORD;
 use crate::util::linear_scan::{Region, RegionIterator};
-use crate::util::metadata::side_metadata::spec_defs::{COMPRESSOR_MARK, COMPRESSOR_OFFSET_VECTOR};
+use crate::util::metadata::side_metadata::spec_defs::{OVC_MARK, OVC_OFFSET_VECTOR};
 use crate::util::metadata::side_metadata::SideMetadataSpec;
 use crate::util::{Address, ObjectReference};
 use crate::vm::object_model::ObjectModel;
@@ -9,19 +9,19 @@ use atomic::Ordering;
 use std::marker::PhantomData;
 use std::sync::atomic::AtomicBool;
 
-/// A [`CompressorRegion`] is the granularity at which [`super::CompressorSpace`]
+/// A [`OVCRegion`] is the granularity at which [`super::OVCSpace`]
 /// compacts the heap. Objects are allocated inside one region, and are only ever
 /// moved *within* that region.
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
-pub(crate) struct CompressorRegion(Address);
-impl Region for CompressorRegion {
+pub(crate) struct OVCRegion(Address);
+impl Region for OVCRegion {
     const LOG_BYTES: usize = 20; // 1 MiB
     fn from_aligned_address(address: Address) -> Self {
         assert!(
             address.is_aligned_to(Self::BYTES),
             "{address} is not aligned"
         );
-        CompressorRegion(address)
+        OVCRegion(address)
     }
     fn start(&self) -> Address {
         self.0
@@ -112,8 +112,8 @@ impl Region for Block {
     }
 }
 
-pub(crate) const MARK_SPEC: SideMetadataSpec = COMPRESSOR_MARK;
-pub(crate) const OFFSET_VECTOR_SPEC: SideMetadataSpec = COMPRESSOR_OFFSET_VECTOR;
+pub(crate) const MARK_SPEC: SideMetadataSpec = OVC_MARK;
+pub(crate) const OFFSET_VECTOR_SPEC: SideMetadataSpec = OVC_OFFSET_VECTOR;
 
 impl<VM: VMBinding> ForwardingMetadata<VM> {
     pub fn new() -> ForwardingMetadata<VM> {
@@ -148,7 +148,7 @@ impl<VM: VMBinding> ForwardingMetadata<VM> {
         MARK_SPEC.fetch_or_atomic::<u8>(last_word_of_object, 1, Ordering::Relaxed);
     }
 
-    pub fn calculate_offset_vector(&self, region: CompressorRegion, cursor: Address) {
+    pub fn calculate_offset_vector(&self, region: OVCRegion, cursor: Address) {
         let mut state = Transducer::new(region.start());
         let first_block = Block::from_aligned_address(region.start());
         let last_block = Block::from_aligned_address(cursor);

--- a/src/policy/ovc/mod.rs
+++ b/src/policy/ovc/mod.rs
@@ -1,0 +1,4 @@
+pub mod forwarding;
+pub mod ovcspace;
+
+pub use ovcspace::*;

--- a/src/policy/ovc/ovcspace.rs
+++ b/src/policy/ovc/ovcspace.rs
@@ -1,7 +1,7 @@
 use crate::plan::tracing::OptionObjectQueue;
-use crate::policy::compressor::forwarding;
 use crate::policy::gc_work::{TraceKind, TRACE_KIND_TRANSITIVE_PIN};
 use crate::policy::largeobjectspace::LargeObjectSpace;
+use crate::policy::ovc::forwarding;
 use crate::policy::sft::{GCWorkerMutRef, SFT};
 use crate::policy::space::{CommonSpace, Space};
 use crate::scheduler::{GCWork, GCWorkScheduler, GCWorker, WorkBucketStage};
@@ -24,13 +24,13 @@ use std::sync::Arc;
 pub(crate) const TRACE_KIND_MARK: TraceKind = 0;
 pub(crate) const TRACE_KIND_FORWARD_ROOT: TraceKind = 1;
 
-/// [`CompressorSpace`] is a stop-the-world implementation of
+/// [`OVCSpace`] is a stop-the-world implementation of
 /// the Compressor, as described in Kermany and Petrank,
 /// [The Compressor: concurrent, incremental, and parallel compaction](https://dl.acm.org/doi/10.1145/1133255.1134023).
 ///
-/// [`CompressorSpace`] makes two main diversions from the paper
-/// (aside from [`CompressorSpace`] being stop-the-world):
-/// - The heap is structured into regions ([`forwarding::CompressorRegion`])
+/// [`OVCSpace`] makes two main diversions from the paper
+/// (aside from [`OVCSpace`] being stop-the-world):
+/// - The heap is structured into regions ([`forwarding::OVCRegion`])
 ///   which the collector compacts separately.
 /// - The collector compacts each region in-place, instead of using two virtual
 ///   spaces as in Kermany and Petrank. The virtual spaces side-step a race which
@@ -40,15 +40,15 @@ pub(crate) const TRACE_KIND_FORWARD_ROOT: TraceKind = 1;
 ///   preventing the old objects from being overwritten. (They reclaim memory by unmapping
 ///   pages of the from-virtual space after moving all objects out of said pages.)
 ///   We instead side-step this race by assigning only a single thread to each region, and
-///   running multiple single-threaded Compressors at once.
-pub struct CompressorSpace<VM: VMBinding> {
+///   running multiple single-threaded OVCs at once.
+pub struct OVCSpace<VM: VMBinding> {
     common: CommonSpace<VM>,
-    pr: RegionPageResource<VM, forwarding::CompressorRegion>,
+    pr: RegionPageResource<VM, forwarding::OVCRegion>,
     forwarding: forwarding::ForwardingMetadata<VM>,
     scheduler: Arc<GCWorkScheduler<VM>>,
 }
 
-impl<VM: VMBinding> SFT for CompressorSpace<VM> {
+impl<VM: VMBinding> SFT for OVCSpace<VM> {
     fn name(&self) -> &'static str {
         self.get_name()
     }
@@ -69,12 +69,12 @@ impl<VM: VMBinding> SFT for CompressorSpace<VM> {
 
     #[cfg(feature = "object_pinning")]
     fn pin_object(&self, _object: ObjectReference) -> bool {
-        panic!("Cannot pin/unpin objects of CompressorSpace.")
+        panic!("Cannot pin/unpin objects of OVCSpace.")
     }
 
     #[cfg(feature = "object_pinning")]
     fn unpin_object(&self, _object: ObjectReference) -> bool {
-        panic!("Cannot pin/unpin objects of CompressorSpace.")
+        panic!("Cannot pin/unpin objects of OVCSpace.")
     }
 
     #[cfg(feature = "object_pinning")]
@@ -119,19 +119,19 @@ impl<VM: VMBinding> SFT for CompressorSpace<VM> {
         _object: ObjectReference,
         _worker: GCWorkerMutRef,
     ) -> ObjectReference {
-        // We should not use trace_object for compressor space.
+        // We should not use trace_object for OVC space.
         // Depending on which trace it is, we should manually call either trace_mark or trace_forward.
-        panic!("sft_trace_object() cannot be used with CompressorSpace")
+        panic!("sft_trace_object() cannot be used with OVCSpace")
     }
 
     fn debug_print_object_info(&self, object: ObjectReference) {
-        println!("marked = {}", CompressorSpace::<VM>::is_marked(object));
+        println!("marked = {}", OVCSpace::<VM>::is_marked(object));
         println!("forwarding = {:?}", self.get_forwarded_object(object));
         self.common.debug_print_object_global_info(object);
     }
 }
 
-impl<VM: VMBinding> Space<VM> for CompressorSpace<VM> {
+impl<VM: VMBinding> Space<VM> for OVCSpace<VM> {
     fn as_space(&self) -> &dyn Space<VM> {
         self
     }
@@ -157,7 +157,7 @@ impl<VM: VMBinding> Space<VM> for CompressorSpace<VM> {
     }
 
     fn release_multiple_pages(&mut self, _start: Address) {
-        panic!("compressorspace only releases pages enmasse")
+        panic!("ovc space only releases pages enmasse")
     }
 
     fn enumerate_objects(&self, enumerator: &mut dyn ObjectEnumerator) {
@@ -173,7 +173,7 @@ impl<VM: VMBinding> Space<VM> for CompressorSpace<VM> {
     }
 }
 
-impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for CompressorSpace<VM> {
+impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for OVCSpace<VM> {
     fn trace_object<Q: ObjectQueue, const KIND: crate::policy::gc_work::TraceKind>(
         &self,
         queue: &mut Q,
@@ -183,7 +183,7 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for Compressor
     ) -> ObjectReference {
         debug_assert!(
             KIND != TRACE_KIND_TRANSITIVE_PIN,
-            "Compressor does not support transitive pin trace."
+            "OVC does not support transitive pin trace."
         );
         if KIND == TRACE_KIND_MARK {
             self.trace_mark_object(queue, object)
@@ -204,12 +204,12 @@ impl<VM: VMBinding> crate::policy::gc_work::PolicyTraceObject<VM> for Compressor
     }
 }
 
-impl<VM: VMBinding> CompressorSpace<VM> {
+impl<VM: VMBinding> OVCSpace<VM> {
     pub fn new(args: crate::policy::space::PlanCreateSpaceArgs<VM>) -> Self {
         let vm_map = args.vm_map;
         assert!(
             VM::VMObjectModel::UNIFIED_OBJECT_REFERENCE_ADDRESS,
-            "The Compressor requires a unified object reference address model"
+            "OVC requires a unified object reference address model"
         );
         let local_specs = extract_side_metadata(&[
             MetadataSpec::OnSide(forwarding::MARK_SPEC),
@@ -218,7 +218,7 @@ impl<VM: VMBinding> CompressorSpace<VM> {
         let is_discontiguous = args.vmrequest.is_discontiguous();
         let scheduler = args.scheduler.clone();
         let common = CommonSpace::new(args.into_policy_args(true, false, local_specs));
-        CompressorSpace {
+        OVCSpace {
             pr: if is_discontiguous {
                 RegionPageResource::new_discontiguous(vm_map)
             } else {
@@ -232,7 +232,7 @@ impl<VM: VMBinding> CompressorSpace<VM> {
 
     pub fn prepare(&self) {
         self.pr
-            .enumerate_regions(&mut |r: &AllocatedRegion<forwarding::CompressorRegion>| {
+            .enumerate_regions(&mut |r: &AllocatedRegion<forwarding::OVCRegion>| {
                 forwarding::MARK_SPEC
                     .bzero_metadata(r.region.start(), r.region.end() - r.region.start());
             });
@@ -253,7 +253,7 @@ impl<VM: VMBinding> CompressorSpace<VM> {
             "{:x}: VO bit not set",
             object
         );
-        if CompressorSpace::<VM>::test_and_mark(object) {
+        if OVCSpace::<VM>::test_and_mark(object) {
             queue.enqueue(object);
             self.forwarding.mark_last_word_of_object(object);
         }
@@ -293,7 +293,7 @@ impl<VM: VMBinding> CompressorSpace<VM> {
 
     fn generate_tasks(
         &self,
-        f: &mut impl FnMut(&AllocatedRegion<forwarding::CompressorRegion>, usize) -> Box<dyn GCWork<VM>>,
+        f: &mut impl FnMut(&AllocatedRegion<forwarding::OVCRegion>, usize) -> Box<dyn GCWork<VM>>,
     ) -> Vec<Box<dyn GCWork<VM>>> {
         let mut packets = vec![];
         let mut index = 0;
@@ -314,7 +314,7 @@ impl<VM: VMBinding> CompressorSpace<VM> {
 
     pub fn calculate_offset_vector_for_region(
         &self,
-        region: forwarding::CompressorRegion,
+        region: forwarding::OVCRegion,
         cursor: Address,
     ) {
         self.forwarding.calculate_offset_vector(region, cursor);
@@ -409,7 +409,7 @@ impl<VM: VMBinding> CompressorSpace<VM> {
 
     pub fn after_compact(&self, worker: &mut GCWorker<VM>, los: &LargeObjectSpace<VM>) {
         self.pr.reset_allocator();
-        // Update references from the LOS to Compressor too.
+        // Update references from the LOS to OVC too.
         los.enumerate_to_space_objects(&mut object_enum::ClosureObjectEnumerator::<_, VM>::new(
             &mut |o: ObjectReference| {
                 self.update_references(worker, o);
@@ -420,26 +420,26 @@ impl<VM: VMBinding> CompressorSpace<VM> {
 
 /// Calculate the offset vector for a region.
 pub struct CalculateOffsetVector<VM: VMBinding> {
-    compressor_space: &'static CompressorSpace<VM>,
-    region: forwarding::CompressorRegion,
+    ovc_space: &'static OVCSpace<VM>,
+    region: forwarding::OVCRegion,
     cursor: Address,
 }
 
 impl<VM: VMBinding> GCWork<VM> for CalculateOffsetVector<VM> {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        self.compressor_space
+        self.ovc_space
             .calculate_offset_vector_for_region(self.region, self.cursor);
     }
 }
 
 impl<VM: VMBinding> CalculateOffsetVector<VM> {
     pub fn new(
-        compressor_space: &'static CompressorSpace<VM>,
-        region: forwarding::CompressorRegion,
+        ovc_space: &'static OVCSpace<VM>,
+        region: forwarding::OVCRegion,
         cursor: Address,
     ) -> Self {
         Self {
-            compressor_space,
+            ovc_space,
             region,
             cursor,
         }
@@ -448,21 +448,18 @@ impl<VM: VMBinding> CalculateOffsetVector<VM> {
 
 /// Compact live objects in a region.
 pub struct Compact<VM: VMBinding> {
-    compressor_space: &'static CompressorSpace<VM>,
+    ovc_space: &'static OVCSpace<VM>,
     index: usize,
 }
 
 impl<VM: VMBinding> GCWork<VM> for Compact<VM> {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
-        self.compressor_space.compact_region(worker, self.index);
+        self.ovc_space.compact_region(worker, self.index);
     }
 }
 
 impl<VM: VMBinding> Compact<VM> {
-    pub fn new(compressor_space: &'static CompressorSpace<VM>, index: usize) -> Self {
-        Self {
-            compressor_space,
-            index,
-        }
+    pub fn new(ovc_space: &'static OVCSpace<VM>, index: usize) -> Self {
+        Self { ovc_space, index }
     }
 }

--- a/src/util/alloc/allocators.rs
+++ b/src/util/alloc/allocators.rs
@@ -15,14 +15,14 @@ use crate::MMTK;
 
 use super::allocator::AllocatorContext;
 use super::FreeListAllocator;
-use super::MarkCompactAllocator;
+use super::Lisp2Allocator;
 
 pub(crate) const MAX_BUMP_ALLOCATORS: usize = 6;
 pub(crate) const MAX_LARGE_OBJECT_ALLOCATORS: usize = 2;
 pub(crate) const MAX_MALLOC_ALLOCATORS: usize = 1;
 pub(crate) const MAX_IMMIX_ALLOCATORS: usize = 2;
 pub(crate) const MAX_FREE_LIST_ALLOCATORS: usize = 2;
-pub(crate) const MAX_MARK_COMPACT_ALLOCATORS: usize = 1;
+pub(crate) const MAX_LISP2_ALLOCATORS: usize = 1;
 
 // The allocators set owned by each mutator. We provide a fixed number of allocators for each allocator type in the mutator,
 // and each plan will select part of the allocators to use.
@@ -35,7 +35,7 @@ pub struct Allocators<VM: VMBinding> {
     pub malloc: [MaybeUninit<MallocAllocator<VM>>; MAX_MALLOC_ALLOCATORS],
     pub immix: [MaybeUninit<ImmixAllocator<VM>>; MAX_IMMIX_ALLOCATORS],
     pub free_list: [MaybeUninit<FreeListAllocator<VM>>; MAX_FREE_LIST_ALLOCATORS],
-    pub markcompact: [MaybeUninit<MarkCompactAllocator<VM>>; MAX_MARK_COMPACT_ALLOCATORS],
+    pub lisp2: [MaybeUninit<Lisp2Allocator<VM>>; MAX_LISP2_ALLOCATORS],
 }
 
 impl<VM: VMBinding> Allocators<VM> {
@@ -52,9 +52,7 @@ impl<VM: VMBinding> Allocators<VM> {
             AllocatorSelector::Malloc(index) => self.malloc[index as usize].assume_init_ref(),
             AllocatorSelector::Immix(index) => self.immix[index as usize].assume_init_ref(),
             AllocatorSelector::FreeList(index) => self.free_list[index as usize].assume_init_ref(),
-            AllocatorSelector::MarkCompact(index) => {
-                self.markcompact[index as usize].assume_init_ref()
-            }
+            AllocatorSelector::Lisp2(index) => self.lisp2[index as usize].assume_init_ref(),
             AllocatorSelector::None => panic!("Allocator mapping is not initialized"),
         }
     }
@@ -81,9 +79,7 @@ impl<VM: VMBinding> Allocators<VM> {
             AllocatorSelector::Malloc(index) => self.malloc[index as usize].assume_init_mut(),
             AllocatorSelector::Immix(index) => self.immix[index as usize].assume_init_mut(),
             AllocatorSelector::FreeList(index) => self.free_list[index as usize].assume_init_mut(),
-            AllocatorSelector::MarkCompact(index) => {
-                self.markcompact[index as usize].assume_init_mut()
-            }
+            AllocatorSelector::Lisp2(index) => self.lisp2[index as usize].assume_init_mut(),
             AllocatorSelector::None => panic!("Allocator mapping is not initialized"),
         }
     }
@@ -108,7 +104,7 @@ impl<VM: VMBinding> Allocators<VM> {
             malloc: unsafe { MaybeUninit::uninit().assume_init() },
             immix: unsafe { MaybeUninit::uninit().assume_init() },
             free_list: unsafe { MaybeUninit::uninit().assume_init() },
-            markcompact: unsafe { MaybeUninit::uninit().assume_init() },
+            lisp2: unsafe { MaybeUninit::uninit().assume_init() },
         };
         let context = Arc::new(AllocatorContext::new(mmtk));
 
@@ -150,8 +146,8 @@ impl<VM: VMBinding> Allocators<VM> {
                         context.clone(),
                     ));
                 }
-                AllocatorSelector::MarkCompact(index) => {
-                    ret.markcompact[index as usize].write(MarkCompactAllocator::new(
+                AllocatorSelector::Lisp2(index) => {
+                    ret.lisp2[index as usize].write(Lisp2Allocator::new(
                         mutator_tls.0,
                         space,
                         context.clone(),
@@ -189,8 +185,8 @@ pub enum AllocatorSelector {
     Malloc(u8),
     /// Represents a [`crate::util::alloc::immix_allocator::ImmixAllocator`].
     Immix(u8),
-    /// Represents a [`crate::util::alloc::markcompact_allocator::MarkCompactAllocator`].
-    MarkCompact(u8),
+    /// Represents a [`crate::util::alloc::lisp2_allocator::Lisp2Allocator`].
+    Lisp2(u8),
     /// Represents a [`crate::util::alloc::free_list_allocator::FreeListAllocator`].
     FreeList(u8),
     /// No allocator found.
@@ -241,9 +237,8 @@ impl AllocatorInfo {
                 }
             }
 
-            AllocatorSelector::MarkCompact(_) => {
-                let bump_offset =
-                    base_offset + offset_of!(MarkCompactAllocator<VM>, bump_allocator);
+            AllocatorSelector::Lisp2(_) => {
+                let bump_offset = base_offset + offset_of!(Lisp2Allocator<VM>, bump_allocator);
                 let bump_pointer_offset = offset_of!(BumpAllocator<VM>, bump_pointer);
 
                 AllocatorInfo::BumpPointer {

--- a/src/util/alloc/lisp2_allocator.rs
+++ b/src/util/alloc/lisp2_allocator.rs
@@ -11,11 +11,11 @@ use crate::vm::VMBinding;
 /// A thin wrapper(specific implementation) of bump allocator
 /// reserve extra bytes when allocating
 #[repr(C)]
-pub struct MarkCompactAllocator<VM: VMBinding> {
+pub struct Lisp2Allocator<VM: VMBinding> {
     pub(in crate::util::alloc) bump_allocator: BumpAllocator<VM>,
 }
 
-impl<VM: VMBinding> MarkCompactAllocator<VM> {
+impl<VM: VMBinding> Lisp2Allocator<VM> {
     pub(crate) fn set_limit(&mut self, cursor: Address, limit: Address) {
         self.bump_allocator.set_limit(cursor, limit);
     }
@@ -29,7 +29,7 @@ impl<VM: VMBinding> MarkCompactAllocator<VM> {
     }
 }
 
-impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
+impl<VM: VMBinding> Allocator<VM> for Lisp2Allocator<VM> {
     fn get_space(&self) -> &'static dyn Space<VM> {
         self.bump_allocator.get_space()
     }
@@ -88,16 +88,16 @@ impl<VM: VMBinding> Allocator<VM> for MarkCompactAllocator<VM> {
     }
 }
 
-impl<VM: VMBinding> MarkCompactAllocator<VM> {
+impl<VM: VMBinding> Lisp2Allocator<VM> {
     /// The number of bytes that the allocator reserves for its own header.
     pub const HEADER_RESERVED_IN_BYTES: usize =
-        crate::policy::markcompactspace::MarkCompactSpace::<VM>::HEADER_RESERVED_IN_BYTES;
+        crate::policy::lisp2space::Lisp2Space::<VM>::HEADER_RESERVED_IN_BYTES;
     pub(crate) fn new(
         tls: VMThread,
         space: &'static dyn Space<VM>,
         context: Arc<AllocatorContext<VM>>,
     ) -> Self {
-        MarkCompactAllocator {
+        Lisp2Allocator {
             bump_allocator: BumpAllocator::new(tls, space, context),
         }
     }

--- a/src/util/alloc/mod.rs
+++ b/src/util/alloc/mod.rs
@@ -32,9 +32,9 @@ pub use self::immix_allocator::ImmixAllocator;
 pub mod free_list_allocator;
 pub use free_list_allocator::FreeListAllocator;
 
-/// Mark compact allocator (actually a bump pointer allocator with an extra heade word)
-mod markcompact_allocator;
-pub use markcompact_allocator::MarkCompactAllocator;
+/// Lisp2 allocator (actually a bump pointer allocator with an extra heade word)
+mod lisp2_allocator;
+pub use lisp2_allocator::Lisp2Allocator;
 
 /// Embedded metadata pages
 pub(crate) mod embedded_meta_data;

--- a/src/util/linear_scan.rs
+++ b/src/util/linear_scan.rs
@@ -5,9 +5,9 @@ use crate::vm::ObjectModel;
 use crate::vm::VMBinding;
 use std::marker::PhantomData;
 
-// FIXME: MarkCompact uses linear scanning to discover allocated objects in the MarkCompactSpace.
-// It should use a local metadata (specific to the MarkCompactSpace) for that purpose.
-// In the future, we should let MarkCompact do linear scanning using its local metadata instead.
+// FIXME: Lisp2 uses linear scanning to discover allocated objects in the Lisp2Space.
+// It should use a local metadata (specific to the Lisp2Space) for that purpose.
+// In the future, we should let Lisp2 do linear scanning using its local metadata instead.
 
 /// Iterate over an address range, and find each object by VO bit.
 /// ATOMIC_LOAD_VO_BIT can be set to false if it is known that loading VO bit

--- a/src/util/metadata/side_metadata/spec_defs.rs
+++ b/src/util/metadata/side_metadata/spec_defs.rs
@@ -96,10 +96,10 @@ define_side_metadata_specs!(
     MS_LOCAL_FREE   = (global: false, log_num_of_bits: LOG_BITS_IN_ADDRESS, log_bytes_in_region: crate::policy::marksweepspace::native_ms::Block::LOG_BYTES),
     // First cell of thread free list in block for native mimalloc
     MS_THREAD_FREE  = (global: false, log_num_of_bits: LOG_BITS_IN_ADDRESS, log_bytes_in_region: crate::policy::marksweepspace::native_ms::Block::LOG_BYTES),
-    // Start and end marks by Compressor
-    COMPRESSOR_MARK = (global: false, log_num_of_bits: 0, log_bytes_in_region: LOG_BYTES_IN_WORD as usize),
-    // Block offset vectors by Compressor
-    COMPRESSOR_OFFSET_VECTOR = (global: false, log_num_of_bits: LOG_BITS_IN_ADDRESS, log_bytes_in_region: crate::policy::compressor::forwarding::Block::LOG_BYTES),
+    // Start and end marks by OVC
+    OVC_MARK = (global: false, log_num_of_bits: 0, log_bytes_in_region: LOG_BYTES_IN_WORD as usize),
+    // Block offset vectors by OVC
+    OVC_OFFSET_VECTOR = (global: false, log_num_of_bits: LOG_BITS_IN_ADDRESS, log_bytes_in_region: crate::policy::ovc::forwarding::Block::LOG_BYTES),
 );
 
 #[cfg(test)]

--- a/src/util/metadata/vo_bit/helper.rs
+++ b/src/util/metadata/vo_bit/helper.rs
@@ -4,7 +4,7 @@
 //! | Policy            | When are VO bits of dead objects cleared                      |
 //! |-------------------|---------------------------------------------------------------|
 //! | MarkSweepSpace    | when sweeping cells of dead objects                           |
-//! | MarkCompactSpace  | when compacting                                               |
+//! | Lisp2Space  | when compacting                                               |
 //! | CopySpace         | when releasing the space                                      |
 //!
 //! The policies listed above trivially clear the VO bits for dead objects (individually or in

--- a/src/util/metadata/vo_bit/helper.rs
+++ b/src/util/metadata/vo_bit/helper.rs
@@ -4,7 +4,7 @@
 //! | Policy            | When are VO bits of dead objects cleared                      |
 //! |-------------------|---------------------------------------------------------------|
 //! | MarkSweepSpace    | when sweeping cells of dead objects                           |
-//! | Lisp2Space  | when compacting                                               |
+//! | Lisp2Space        | when compacting                                               |
 //! | CopySpace         | when releasing the space                                      |
 //!
 //! The policies listed above trivially clear the VO bits for dead objects (individually or in

--- a/src/util/metadata/vo_bit/mod.rs
+++ b/src/util/metadata/vo_bit/mod.rs
@@ -41,7 +41,7 @@
 //! [`crate::plan::PlanConstraints::may_trace_duplicate_edges`])*
 
 // FIXME: The entire vo_bit module should only be available if the "vo_bit" feature is enabled.
-// However, the malloc-based MarkSweepSpace and MarkCompactSpace depends on the VO bits regardless
+// However, the malloc-based MarkSweepSpace and Lisp2Space depends on the VO bits regardless
 // of the "vo_bit" feature.
 #[cfg(feature = "vo_bit")]
 pub(crate) mod helper;

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -45,9 +45,9 @@ pub enum PlanSelector {
     /// A mark-region collector that allows an opportunistic defragmentation mechanism.
     Immix,
     /// A mark-compact collector that implements the Lisp-2 compaction algorithm.
-    MarkCompact,
-    /// A mark-compact collector that uses Compressor-style bitmaps.
-    Compressor,
+    Lisp2,
+    /// A mark-compact collector that uses offset-vector bitmaps.
+    OVC,
     /// An Immix collector that uses a sticky mark bit to allow generational behaviors without a copying nursery.
     StickyImmix,
     /// Concurrent non-moving immix using SATB

--- a/src/util/reference_processor.rs
+++ b/src/util/reference_processor.rs
@@ -235,7 +235,7 @@ impl ReferenceProcessor {
 
     // These funcions call `trace_object()`, which will ensure the object and its descendents will
     // be traced.  They are only called in steps that expand the transitive closure.  That include
-    // retaining soft references, and (for MarkCompact) tracing objects for forwarding.
+    // retaining soft references, and (for Lisp2) tracing objects for forwarding.
     // Note that finalizers also expand the transitive closure.
     // These functions are intended to make the code easier to understand.
 
@@ -251,7 +251,7 @@ impl ReferenceProcessor {
         tracer.trace_object(referent)
     }
 
-    /// This function is called when forwarding the references and referents (for MarkCompact). It
+    /// This function is called when forwarding the references and referents (for Lisp2). It
     /// -   adds the reference or the referent to the tracing queue if not yet reached, so that
     ///     the children of the reference or referent will be visited and forwarded, too, and
     /// -   gets the forwarded object reference of the object.

--- a/src/vm/tests/mock_tests/mock_test_allocator_info.rs
+++ b/src/vm/tests/mock_tests/mock_test_allocator_info.rs
@@ -27,8 +27,8 @@ pub fn test_allocator_info() {
                 | PlanSelector::SemiSpace
                 | PlanSelector::GenCopy
                 | PlanSelector::GenImmix
-                | PlanSelector::MarkCompact
-                | PlanSelector::Compressor
+                | PlanSelector::Lisp2
+                | PlanSelector::OVC
                 | PlanSelector::ConcurrentImmix
                 | PlanSelector::StickyImmix => {
                     // These plans all use bump pointer allocator.

--- a/src/vm/tests/mock_tests/mock_test_heap_traversal.rs
+++ b/src/vm/tests/mock_tests/mock_test_heap_traversal.rs
@@ -1,8 +1,8 @@
-// GITHUB-CI: MMTK_PLAN=NoGC,MarkSweep,MarkCompact,SemiSpace,Immix
+// GITHUB-CI: MMTK_PLAN=NoGC,MarkSweep,Lisp2,SemiSpace,Immix
 // GITHUB-CI: FEATURES=vo_bit
 
 // Note on the plans chosen for CI:
-// - Those plans cover the MarkSweepSpace, MarkCompactSpace, CopySpace and ImmixSpace.
+// - Those plans cover the MarkSweepSpace, Lisp2Space, CopySpace and ImmixSpace.
 //   Each plan other than NoGC also include ImmortalSpace and LOS.
 // - PageProtect consumes too much memory and the test will fail with the default heap size
 //   chosen by the MutatorFixture.

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_multi_page.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_multi_page.rs
@@ -1,4 +1,4 @@
-// GITHUB-CI: MMTK_PLAN=Immix,GenImmix,StickyImmix,MarkSweep,MarkCompact
+// GITHUB-CI: MMTK_PLAN=Immix,GenImmix,StickyImmix,MarkSweep,Lisp2
 // GITHUB-CI: FEATURES=vo_bit
 
 // Only test this with plans that use LOS. NoGC does not use large object space.

--- a/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_same_page.rs
+++ b/src/vm/tests/mock_tests/mock_test_internal_ptr_large_object_same_page.rs
@@ -1,4 +1,4 @@
-// GITHUB-CI: MMTK_PLAN=Immix,GenImmix,StickyImmix,MarkSweep,MarkCompact
+// GITHUB-CI: MMTK_PLAN=Immix,GenImmix,StickyImmix,MarkSweep,Lisp2
 // GITHUB-CI: FEATURES=vo_bit
 
 // Only test this with plans that use LOS. NoGC does not use large object space.


### PR DESCRIPTION
Closes https://github.com/mmtk/mmtk-core/issues/1540. Done by Claude.