### PR TITLE
Update ci-perf-kit to 0.9.1. Check cache before building OpenJDK

### DIFF
--- a/.github/workflows/openjdk-build-reusable.yml
+++ b/.github/workflows/openjdk-build-reusable.yml
@@ -25,6 +25,18 @@ jobs:
     runs-on: [self-hosted, Linux, freq-scaling-off]
     timeout-minutes: 1440
     steps:
+      # check whether a build for this commit is already cached, before
+      # doing any of the expensive checkout/build work below
+      - name: Check OpenJDK+MMTk build cache
+        id: check-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ci-perf-kit/build
+            ci-perf-kit/probes/out
+            ci-perf-kit/openjdk-probe
+          key: ${{ env.OPENJDK_BUILD_CACHE_PREFIX }}${{ github.sha }}-${{ inputs.openjdk_rev }}
+          lookup-only: true
       # checkout perf-kit
       - name: Checkout Perf Kit
         uses: actions/checkout@v4
@@ -38,19 +50,23 @@ jobs:
         with:
           path: mmtk-core
       - name: Checkout OpenJDK Binding
+        if: steps.check-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
           repository: mmtk/mmtk-openjdk
           ref: jdk-21
           path: mmtk-openjdk
       - name: Checkout OpenJDK
+        if: steps.check-cache.outputs.cache-hit != 'true'
         working-directory: mmtk-openjdk
         run: |
           ./.github/scripts/ci-checkout.sh
       - name: Setup Rust Toolchain
+        if: steps.check-cache.outputs.cache-hit != 'true'
         run: echo "RUSTUP_TOOLCHAIN=`cat mmtk-core/rust-toolchain`" >> $GITHUB_ENV
       # setup
       - name: Replace mmtk-core dependency and clean previous build
+        if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
           # Note that ci-replace-mmtk-dep.sh will apply `realpath()` to the `--mmtk-core-path` option.
           # so we specify the relative path from the PWD to the mmtk-core repo.
@@ -60,11 +76,13 @@ jobs:
           rm -rf mmtk-openjdk/repos/openjdk/build
       # build
       - name: Build OpenJDK+MMTk
+        if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
           export JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-amd64/
           ./ci-perf-kit/scripts/openjdk-build.sh ./mmtk-openjdk ./mmtk-core
       # cache the build for openjdk-run-plan-reusable.yml callers
       - name: Cache OpenJDK+MMTk build
+        if: steps.check-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
@@ -73,6 +91,7 @@ jobs:
             ci-perf-kit/openjdk-probe
           key: ${{ env.OPENJDK_BUILD_CACHE_PREFIX }}${{ github.sha }}-${{ inputs.openjdk_rev }}
       - name: Upload build as artifacts
+        if: steps.check-cache.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: openjdk-regression-build

--- a/.github/workflows/openjdk-perf-config.yml
+++ b/.github/workflows/openjdk-perf-config.yml
@@ -34,7 +34,7 @@ jobs:
       RESULT_REPO_BRANCH: 'self-hosted-chopin'
       # Whether we deploy the generated page. Set to true for master.
       DEPLOY: true
-      CI_PERF_KIT_VERSION: '0.9.0'
+      CI_PERF_KIT_VERSION: '0.9.1'
       # heap_modifier passed to run_benchmarks: a multiple of each benchmark's
       # min heap size. NoGC doesn't use either of these (it sets heap_modifier
       # to 0, meaning "use the max heap instead").

--- a/.github/workflows/perf-regression-ci-jikesrvm.yml
+++ b/.github/workflows/perf-regression-ci-jikesrvm.yml
@@ -16,7 +16,7 @@ env:
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
   CI_PERF_KIT_LOG: ci-perf-kit/logs-ng
-  CI_PERF_KIT_VERSION: '0.9.0'
+  CI_PERF_KIT_VERSION: '0.9.1'
 
 jobs:
   # JikesRVM


### PR DESCRIPTION
This PR updates ci-perf-kit to https://github.com/mmtk/ci-perf-kit/releases/tag/0.9.1, which includes some style changes about plots, and the index page.

This PR also fixes a redundant build: we expect CI to build OpenJDK for every commit, but for weekly perf runs, we can get the build from the build cache without having to build it again.