### PR TITLE
Update ci-perf-kit to 0.9.2 (latency plots)

### DIFF
--- a/.github/workflows/openjdk-perf-config.yml
+++ b/.github/workflows/openjdk-perf-config.yml
@@ -34,7 +34,7 @@ jobs:
       RESULT_REPO_BRANCH: 'self-hosted-chopin'
       # Whether we deploy the generated page. Set to true for master.
       DEPLOY: true
-      CI_PERF_KIT_VERSION: '0.9.1'
+      CI_PERF_KIT_VERSION: '0.9.2'
       # heap_modifier passed to run_benchmarks: a multiple of each benchmark's
       # min heap size. NoGC doesn't use either of these (it sets heap_modifier
       # to 0, meaning "use the max heap instead").

--- a/.github/workflows/perf-regression-ci-jikesrvm.yml
+++ b/.github/workflows/perf-regression-ci-jikesrvm.yml
@@ -15,7 +15,7 @@ env:
   DEPLOY: true
   # Directories in ci-perf-kit that will be uploaded as artifacts. The dirs can be found in ci-perf-kit/scripts/common.sh
   CI_PERF_KIT_BUILD: ci-perf-kit/upload
-  CI_PERF_KIT_VERSION: '0.9.1'
+  CI_PERF_KIT_VERSION: '0.9.2'
 
 jobs:
   # JikesRVM


### PR DESCRIPTION
Update `ci-perf-kit` to https://github.com/mmtk/ci-perf-kit/releases/tag/0.9.2:
* Plot latency graphs for concurrent Immix for benchmarks that report latency.
* Minor restyling
  * Different styles for primary data (total time, 99.99p latency), and secondary data (stw/mutator time, 50/90/99/99.9p latency)
  * Shorter labels for the graphs for better readability