### PR TITLE
Clean up Line/ObjectReference/Address conversions in RefCountHelper

### DIFF
--- a/src/plan/lxr/gc_work/mature_sweeping.rs
+++ b/src/plan/lxr/gc_work/mature_sweeping.rs
@@ -55,24 +55,31 @@ impl<VM: VMBinding> SweepDeadCycles<VM> {
         let mut cursor = block.start();
         let limit = block.end();
         while cursor < limit {
-            let o = unsafe { cursor.to_object_reference::<VM>() };
+            let cur_cursor = cursor;
             cursor += rc::MIN_OBJECT_SIZE;
-            let c = self.rc.count(o);
-            if c != 0 && !immix_space.is_marked(o) {
-                if Line::is_aligned(o.to_raw_address()) {
-                    if c == 1 && self.rc.is_straddle_line(Line::containing_obj_ref(o)) {
-                        continue;
-                    } else {
-                        std::sync::atomic::fence(Ordering::SeqCst);
-                        if self.rc.count(o) == 0 {
+            let c = self.rc.count_by_address(cur_cursor);
+            if c != 0 {
+                // Safety: cur_cursor is either a valid object reference, or a straddle line
+                let o = unsafe { ObjectReference::from_raw_address_unchecked(cur_cursor) };
+                if !immix_space.is_marked(o) {
+                    if Line::is_aligned(o.to_raw_address()) {
+                        if c == 1 && self.rc.object_is_in_straddle_line_no_rc_check(o) {
+                            // this is a straddle line, skip
                             continue;
+                        } else {
+                            // Now o is a valid object reference
+                            std::sync::atomic::fence(Ordering::SeqCst);
+                            if self.rc.count(o) == 0 {
+                                continue;
+                            }
                         }
                     }
+                    // o is still a valid object here.
+                    self.process_dead_object(o);
+                    has_dead_object = true;
+                } else {
+                    has_live = true;
                 }
-                self.process_dead_object(o);
-                has_dead_object = true;
-            } else if c != 0 {
-                has_live = true;
             }
         }
         if has_dead_object || !has_live {

--- a/src/plan/lxr/gc_work/tracing.rs
+++ b/src/plan/lxr/gc_work/tracing.rs
@@ -384,11 +384,7 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
         );
         let object = object.get_forwarded_object().unwrap_or(object);
         let new_object = if self.lxr.immix_space.in_space(object) {
-            if self
-                .lxr
-                .rc
-                .address_is_in_straddle_line(object.to_raw_address())
-            {
+            if self.lxr.rc.object_is_in_straddle_line(object) {
                 return object;
             }
             let pause = self.pause;

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -819,7 +819,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         if self.attempt_mark(object) {
             let addr = object.to_raw_address().as_usize();
             let straddle = if (addr & 0b11110000) == 0 {
-                self.rc.is_straddle_line(Line::containing_obj_ref(object))
+                self.rc.object_is_in_straddle_line_no_rc_check(object)
             } else {
                 false
             };
@@ -848,7 +848,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
 
         if self.attempt_mark(object) {
             if self.rc_enabled {
-                let straddle = self.rc.is_straddle_line(Line::containing_obj_ref(object));
+                let straddle = self.rc.object_is_in_straddle_line_no_rc_check(object);
                 if straddle {
                     return object;
                 }

--- a/src/policy/immix/line.rs
+++ b/src/policy/immix/line.rs
@@ -41,12 +41,6 @@ impl Line {
     pub const MARK_TABLE: SideMetadataSpec =
         crate::util::metadata::side_metadata::spec_defs::IX_LINE_MARK;
 
-    /// Return the line that contains the starting address of an object.
-    #[allow(unused)]
-    pub fn containing_obj_start<VM: VMBinding>(object: ObjectReference) -> Self {
-        Self::from_unaligned_address(VM::VMObjectModel::ref_to_object_start(object))
-    }
-
     /// Get the block containing the line.
     pub fn block(&self) -> Block {
         debug_assert!(!super::BLOCK_ONLY);

--- a/src/policy/immix/line.rs
+++ b/src/policy/immix/line.rs
@@ -47,11 +47,6 @@ impl Line {
         Self::from_unaligned_address(VM::VMObjectModel::ref_to_object_start(object))
     }
 
-    /// Return the line that contains the raw address of the object reference.
-    pub fn containing_obj_ref(object: ObjectReference) -> Self {
-        Self(object.to_raw_address())
-    }
-
     /// Get the block containing the line.
     pub fn block(&self) -> Block {
         debug_assert!(!super::BLOCK_ONLY);

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -382,13 +382,6 @@ impl Address {
         }
     }
 
-    /// Converts the address to an [`ObjectReference`]. The address must be non-zero and must be
-    /// the raw address of a valid object as defined by the VM's object model.
-    pub fn to_object_reference<VM: VMBinding>(self) -> ObjectReference {
-        debug_assert!(!self.is_zero());
-        unsafe { ObjectReference::from_raw_address_unchecked(self) }
-    }
-
     /// Returns the intersection of the two address ranges. The returned range could
     /// be empty if there is no intersection between the ranges.
     pub fn range_intersection(r1: &Range<Address>, r2: &Range<Address>) -> Range<Address> {

--- a/src/util/rc.rs
+++ b/src/util/rc.rs
@@ -163,9 +163,22 @@ impl<VM: VMBinding> RefCountHelper<VM> {
         unsafe { RC_TABLE.store(o.to_raw_address(), count) }
     }
 
+    /// Sets the reference count for the line containing object `o` to `count` using a non-atomic store,
+    /// for use where the caller can guarantee there is no concurrent access.
+    pub fn set_line_relaxed(&self, line: Line, count: u8) {
+        unsafe { RC_TABLE.store(line.start(), count) }
+    }
+
     /// Returns object `o`'s current reference count.
     pub fn count(&self, o: ObjectReference) -> u8 {
         RC_TABLE.load_atomic(o.to_raw_address(), Ordering::Relaxed)
+    }
+
+    /// Returns the reference count stored in the RC table at address `addr`. If this
+    /// returns a non-zero value, it indicates that `addr` is the address of an object reference,
+    /// or the start of a straddle line.
+    pub fn count_by_address(&self, addr: Address) -> u8 {
+        RC_TABLE.load_atomic(addr, Ordering::Relaxed)
     }
 
     /// Returns `true` if the RC table entry at `o`'s address is zero. Used for both individual
@@ -203,17 +216,18 @@ impl<VM: VMBinding> RefCountHelper<VM> {
         v == 0 || v == MAX_REF_COUNT
     }
 
-    /// Returns `true` if `line` is marked as being straddled by an object that spans multiple lines.
-    pub fn is_straddle_line(&self, line: Line) -> bool {
-        let v: u8 = unsafe { RC_STRADDLE_LINES.load::<u8>(line.start()) };
-        v != 0
+    /// Returns `true` if object `o` is in a straddle line. The function does not check rc table.
+    pub fn object_is_in_straddle_line_no_rc_check(&self, o: ObjectReference) -> bool {
+        // This directly reads line-granularity straddle line metadata with an unaligned address.
+        // It is still correct, but may break side metadata assertions.
+        unsafe { RC_STRADDLE_LINES.load::<u8>(o.to_raw_address()) != 0 }
     }
 
     /// Returns `true` if address `a` falls within a live object whose containing line is marked
     /// as a straddle line.
-    pub fn address_is_in_straddle_line(&self, a: Address) -> bool {
-        let line = Line::from_unaligned_address(a);
-        self.count(a.to_object_reference::<VM>()) != 0 && self.is_straddle_line(line)
+    pub fn object_is_in_straddle_line(&self, o: ObjectReference) -> bool {
+        let line = Line::from_unaligned_address(o.to_raw_address());
+        self.count(o) != 0 && unsafe { RC_STRADDLE_LINES.load::<u8>(line.start()) != 0 }
     }
 
     fn mark_straddle_object_with_size(&self, o: ObjectReference, size: usize) {
@@ -229,7 +243,7 @@ impl<VM: VMBinding> RefCountHelper<VM> {
         let mut line = start_line;
         while line != end_line {
             unsafe { RC_STRADDLE_LINES.store(line.start(), 1u8) };
-            self.set_relaxed(line.start().to_object_reference::<VM>(), 1);
+            self.set_line_relaxed(line, 1);
             line = line.next();
         }
     }
@@ -257,7 +271,7 @@ impl<VM: VMBinding> RefCountHelper<VM> {
             // it always skips the first line in a hole.
             let mut line = start_line;
             while line != end_line {
-                self.set_relaxed(line.start().to_object_reference::<VM>(), 0);
+                self.set_line_relaxed(line, 0);
                 unsafe { RC_STRADDLE_LINES.store(line.start(), 0u8) };
                 line = line.next();
             }
@@ -270,7 +284,7 @@ impl<VM: VMBinding> RefCountHelper<VM> {
         let size = VM::VMObjectModel::get_current_size(o);
         for i in (0..size).step_by(MIN_OBJECT_SIZE) {
             let a = o.to_raw_address() + i;
-            assert_eq!(0, self.count(a.to_object_reference::<VM>()));
+            assert_eq!(0, self.count_by_address(a));
         }
     }
 


### PR DESCRIPTION
This PR cleans up the conversions between `Line`/`ObjectReference`/`Address` in `RefCountHelper`. It does not address the confusion in LXR between object start and object ref.