### PR TITLE
Show GC_REQUEST_WAIT time with visualization scripts

### DIFF
--- a/tools/tracing/README.md
+++ b/tools/tracing/README.md
@@ -25,6 +25,9 @@ Currently, the core provides the following tracepoints.
 -   `mmtk:harness_end()`: the timing iteration of a benchmark ends
 -   `mmtk:gcworker_run()`: a GC worker thread enters its work loop
 -   `mmtk:gcworker_exit()`: a GC worker thread exits its work loop
+-   `mmtk:gc_requested()`: a mutator's request for a GC has been accepted (i.e. it won the race to
+    transition MMTk into the "GC requested" state).  This precedes `gc_start()`, usually by a short
+    delay while GC workers park and the last one schedules the collection.
 -   `mmtk:gc_start()`: a collection epoch starts
 -   `mmtk:gc_end()`: a collection epoch ends
 -   `mmtk:gen_full_heap(is_full_heap: bool)`: the generational plan has determined whether the current

--- a/tools/tracing/timeline/README.md
+++ b/tools/tracing/timeline/README.md
@@ -170,6 +170,11 @@ like this:
 
 ![Perfetto UI timeline](./perfetto-example.png)
 
+Immediately to the left of each "GC" slice (on the same virtual thread), you should also see a
+"GC_REQUEST_WAIT" slice.  It spans from the `gc_requested` USDT trace point (when a mutator's
+request for a GC is accepted) to the `gc_start` trace point (when the GC actually begins), so it
+shows how long MMTk took to actually start a GC after one was requested.
+
 ## Extending the timeline tool
 
 VM binding developers can insert USDT trace points, too, and our scripts `capture.py` and

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -34,6 +34,8 @@ usdt:$MMTK:mmtk:harness_end {
 }
 
 usdt:$MMTK:mmtk:gc_start {
+    // Close the "GC_REQUEST_WAIT" span opened at `gc_requested`, right before opening "GC".
+    printf("GC_REQUEST_WAIT,E,%d,%lu\n", tid, nsecs);
     printf("GC,B,%d,%lu\n", tid, nsecs);
     // bpftrace warns that signed `%` operator may have undefiend behavior.
     if ((uint64)@gc_count % $EVERY == 0 && @stats_enabled) {
@@ -152,6 +154,8 @@ usdt:$MMTK:mmtk:concurrent_trace_objects {
 
 usdt:$MMTK:mmtk:gc_requested {
     printf("gc_requested,i,%d,%lu\n", tid, nsecs);
+    // Open a "GC_REQUEST_WAIT" span that lasts until the GC actually starts (see `gc_start`).
+    printf("GC_REQUEST_WAIT,B,%d,%lu\n", tid, nsecs);
 }
 
 usdt:$MMTK:mmtk:add_schedule_collection_packet {

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -174,6 +174,12 @@ class LogProcessor:
             case "gc_requested":
                 result["tid"] = 1
 
+            case "GC_REQUEST_WAIT":
+                # Put the "GC requested but not yet started" span on the same virtual
+                # thread as "GC" so it renders as the slice immediately preceding each
+                # GC on the same timeline row.
+                result["tid"] = 0
+
             case _:
                 if self.enrich_event_extra is not None:
                     # Call ``enrich_event_extra`` in the extension script if defined.


### PR DESCRIPTION
In some bad scenarios where the concurrent marking threads cannot keep pace with allocation, the GC_REQUEST_WAIT (time-to-yield) may dominate. Plot them clearly.
<img width="633" height="678" alt="ScreenShot_2026-08-24_200447_076" src="https://github.com/user-attachments/assets/2c0565b6-a5b8-4997-ae5c-d773e736d09e" />
