### PR TITLE
Measure time-to-yield and pause-time

### DIFF
--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -15,8 +15,6 @@ use std::time::{Duration, Instant};
 pub struct GlobalState {
     /// The current GC status.
     pub(crate) gc_status: GcStatusWord,
-    /// When did the last GC start? Only accessed by the last parked worker.
-    pub(crate) gc_start_time: AtomicRefCell<Option<Instant>>,
     /// The time when a GC pause is requested. Used to calculate the time-to-yield metric.
     pub(crate) pause_requested_time: AtomicRefCell<Option<Instant>>,
     /// When did the current GC pause begin, i.e. when did all mutators finish stopping (see
@@ -247,7 +245,6 @@ impl Default for GlobalState {
     fn default() -> Self {
         Self {
             gc_status: GcStatusWord::new(GcStatus::Uninitialized),
-            gc_start_time: AtomicRefCell::new(None),
             pause_requested_time: AtomicRefCell::new(None),
             pause_start_time: AtomicRefCell::new(None),
             stacks_prepared: AtomicBool::new(false),

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -17,10 +17,7 @@ pub struct GlobalState {
     pub(crate) gc_status: GcStatusWord,
     /// When did the last GC start? Only accessed by the last parked worker.
     pub(crate) gc_start_time: AtomicRefCell<Option<Instant>>,
-    /// When was a GC pause last successfully requested (`GCTrigger::request()` winning the race
-    /// to transition the GC status to `PauseRequested`)? Consumed once all mutators have stopped
-    /// to compute the "time-to-yield" statistic: the latency between requesting a pause and the
-    /// point all threads are actually stopped.
+    /// The time when a GC pause is requested. Used to calculate the time-to-yield metric.
     pub(crate) pause_requested_time: AtomicRefCell<Option<Instant>>,
     /// When did the current GC pause begin, i.e. when did all mutators finish stopping (see
     /// `pause_requested_time`)? Consumed once the pause ends (mutators are about to resume) to

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -1,7 +1,7 @@
 use atomic_refcell::AtomicRefCell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// This stores some global states for an MMTK instance.
 /// Some MMTK components like plans and allocators may keep an reference to the struct, and can access it.
@@ -17,6 +17,15 @@ pub struct GlobalState {
     pub(crate) gc_status: GcStatusWord,
     /// When did the last GC start? Only accessed by the last parked worker.
     pub(crate) gc_start_time: AtomicRefCell<Option<Instant>>,
+    /// When was a GC pause last successfully requested (`GCTrigger::request()` winning the race
+    /// to transition the GC status to `PauseRequested`)? Consumed once all mutators have stopped
+    /// to compute the "time-to-yield" statistic: the latency between requesting a pause and the
+    /// point all threads are actually stopped.
+    pub(crate) pause_requested_time: AtomicRefCell<Option<Instant>>,
+    /// When did the current GC pause begin, i.e. when did all mutators finish stopping (see
+    /// `pause_requested_time`)? Consumed once the pause ends (mutators are about to resume) to
+    /// compute the "pause time" statistic: the duration mutators spend stopped for the pause.
+    pub(crate) pause_start_time: AtomicRefCell<Option<Instant>>,
     /// Is the current GC an emergency collection? Emergency means we may run out of memory soon, and we should
     /// attempt to collect as much as we can.
     pub(crate) emergency_collection: AtomicBool,
@@ -192,6 +201,49 @@ impl GlobalState {
     pub(crate) fn get_used_pages_after_last_gc(&self) -> usize {
         self.used_pages_after_last_gc.load(Ordering::Relaxed)
     }
+
+    /// Record that a GC pause has just been successfully requested. Called by `GCTrigger::request()`
+    /// on the thread that won the race to move the GC status to `PauseRequested`.
+    pub(crate) fn record_pause_requested_time(&self) {
+        let mut pause_requested_time = self.pause_requested_time.borrow_mut();
+        assert!(
+            pause_requested_time.is_none(),
+            "A pause was requested while a previous pause request time is still pending"
+        );
+        *pause_requested_time = Some(Instant::now());
+    }
+
+    /// Take the time-to-yield duration: the time elapsed since the pause was requested (i.e.
+    /// since `record_pause_requested_time` was last called). This should be called exactly once
+    /// all mutators have stopped for the pause.
+    pub(crate) fn take_time_to_yield(&self) -> Duration {
+        self.pause_requested_time
+            .borrow_mut()
+            .take()
+            .expect("Pause requested time was not recorded")
+            .elapsed()
+    }
+
+    /// Record that a GC pause has just begun, i.e. all mutators have just finished stopping.
+    pub(crate) fn record_pause_start_time(&self) {
+        let mut pause_start_time = self.pause_start_time.borrow_mut();
+        assert!(
+            pause_start_time.is_none(),
+            "A pause was started while a previous pause start time is still pending"
+        );
+        *pause_start_time = Some(Instant::now());
+    }
+
+    /// Take the pause time duration: the time elapsed since the pause began (i.e. since
+    /// `record_pause_start_time` was last called). This should be called exactly once the pause
+    /// is about to end, i.e. right before mutators are resumed.
+    pub(crate) fn take_pause_time(&self) -> Duration {
+        self.pause_start_time
+            .borrow_mut()
+            .take()
+            .expect("Pause start time was not recorded")
+            .elapsed()
+    }
 }
 
 impl Default for GlobalState {
@@ -199,6 +251,8 @@ impl Default for GlobalState {
         Self {
             gc_status: GcStatusWord::new(GcStatus::Uninitialized),
             gc_start_time: AtomicRefCell::new(None),
+            pause_requested_time: AtomicRefCell::new(None),
+            pause_start_time: AtomicRefCell::new(None),
             stacks_prepared: AtomicBool::new(false),
             emergency_collection: AtomicBool::new(false),
             user_triggered_collection: AtomicBool::new(false),

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -277,6 +277,12 @@ impl<C: GCWorkContext> GCWork<C::VM> for StopMutators<C> {
             }
         });
         trace!("stop_all_mutators end");
+        // All mutators have just stopped: this is the end of the "time-to-yield" window that
+        // started when the pause was successfully requested (see `GCTrigger::request()`), and
+        // the start of the "pause time" window that ends when mutators are resumed (see
+        // `GCWorkScheduler::on_gc_finished`).
+        mmtk.stats.record_time_to_yield(mmtk.state.take_time_to_yield());
+        mmtk.state.record_pause_start_time();
         // This also tells the GC trigger whether a new GC cycle has started (see `Plan::gc_pause_start`).
         mmtk.get_plan().on_pause_start(mmtk);
         mmtk.scheduler.notify_mutators_paused(mmtk);

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -277,11 +277,9 @@ impl<C: GCWorkContext> GCWork<C::VM> for StopMutators<C> {
             }
         });
         trace!("stop_all_mutators end");
-        // All mutators have just stopped: this is the end of the "time-to-yield" window that
-        // started when the pause was successfully requested (see `GCTrigger::request()`), and
-        // the start of the "pause time" window that ends when mutators are resumed (see
-        // `GCWorkScheduler::on_gc_finished`).
-        mmtk.stats.record_time_to_yield(mmtk.state.take_time_to_yield());
+        // All mutators have just stopped: this is the end of the "time-to-yield" window
+        mmtk.stats
+            .record_time_to_yield(mmtk.state.take_time_to_yield());
         mmtk.state.record_pause_start_time();
         // This also tells the GC trigger whether a new GC cycle has started (see `Plan::gc_pause_start`).
         mmtk.get_plan().on_pause_start(mmtk);

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -22,7 +22,6 @@ use crossbeam::deque::Steal;
 use enum_map::{Enum, EnumMap};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
 
 pub struct GCWorkScheduler<VM: VMBinding> {
     /// Work buckets
@@ -568,12 +567,6 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
                 // work packet events before the `ScheduleCollection` work packet starts.
                 probe!(mmtk, gc_start);
 
-                {
-                    let mut gc_start_time = worker.mmtk.state.gc_start_time.borrow_mut();
-                    assert!(gc_start_time.is_none(), "GC already started?");
-                    *gc_start_time = Some(Instant::now());
-                }
-
                 self.add_schedule_collection_packet();
                 LastParkedResult::WakeSelf
             }
@@ -639,15 +632,18 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         plan_mut.on_pause_end(mmtk, worker.tls);
         probe!(mmtk, plan_end_of_gc_end);
 
-        // Compute the elapsed time of the GC.
-        let start_time = {
-            let mut gc_start_time = worker.mmtk.state.gc_start_time.borrow_mut();
-            gc_start_time.take().expect("GC not started yet?")
-        };
-        let elapsed = start_time.elapsed();
+        // Compute the elapsed time of the pause so far. `pause_start_time` is taken (and the
+        // "pause-time" stat recorded) further down, once the pause is truly about to end.
+        let elapsed = mmtk
+            .state
+            .pause_start_time
+            .borrow()
+            .as_ref()
+            .expect("Pause start time was not recorded")
+            .elapsed();
 
         info!(
-            "End of GC ({}/{} pages, took {:.2} ms)",
+            "End of Pause ({}/{} pages, took {:.2} ms)",
             mmtk.get_plan().get_reserved_pages(),
             mmtk.get_plan().get_total_pages(),
             elapsed.as_secs_f64() * 1000.0

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -695,10 +695,7 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         } else {
             mmtk.state.gc_status.set_not_in_gc();
         }
-        // The pause is about to end (mutators are about to resume): this is the end of the
-        // "pause time" window that started when all mutators finished stopping (see
-        // `StopMutators::do_work`). Record it before `end_gc()` flips the phase, so the sample
-        // lands in the current (STW) phase's counter slot.
+        // The pause is about to end (mutators are about to resume)
         mmtk.stats.record_pause_time(mmtk.state.take_pause_time());
         if mmtk.stats.get_gathering_stats() {
             mmtk.stats.end_gc();

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -695,6 +695,11 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
         } else {
             mmtk.state.gc_status.set_not_in_gc();
         }
+        // The pause is about to end (mutators are about to resume): this is the end of the
+        // "pause time" window that started when all mutators finished stopping (see
+        // `StopMutators::do_work`). Record it before `end_gc()` flips the phase, so the sample
+        // lands in the current (STW) phase's counter slot.
+        mmtk.stats.record_pause_time(mmtk.state.take_pause_time());
         if mmtk.stats.get_gathering_stats() {
             mmtk.stats.end_gc();
         }

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -194,6 +194,7 @@ impl<VM: VMBinding> GCTrigger<VM> {
                 // we end up with deadlock. So we just return true to the caller, and let the caller do the request.
                 Ok(_) => {
                     probe!(mmtk, gc_requested);
+                    self.state.record_pause_requested_time();
                     info!(
                         "[POLL] Requesting a concurrent GC's closing pause from the last parked GC worker"
                     );

--- a/src/util/heap/gc_trigger.rs
+++ b/src/util/heap/gc_trigger.rs
@@ -87,6 +87,7 @@ impl<VM: VMBinding> GCTrigger<VM> {
         match self.state.gc_status.try_request_pause() {
             Ok(_) => {
                 probe!(mmtk, gc_requested);
+                self.state.record_pause_requested_time();
                 self.scheduler.request_schedule_collection();
                 true
             },

--- a/src/util/statistics/counter/event_counter.rs
+++ b/src/util/statistics/counter/event_counter.rs
@@ -10,7 +10,10 @@ pub struct EventCounter {
     name: String,
     pub implicitly_start: bool,
     merge_phases: bool,
-    count: Vec<u64>,
+    /// The raw per-phase counts, in phase order (index 0 = phase 0, etc). Visible within the
+    /// `counter` module so [`super::LatencySampler`] can compute derived statistics (average,
+    /// percentiles) directly from the raw per-pause samples accumulated here.
+    pub(super) count: Vec<u64>,
     current_count: u64,
     running: bool,
     stats: Arc<SharedStats>,

--- a/src/util/statistics/counter/event_counter.rs
+++ b/src/util/statistics/counter/event_counter.rs
@@ -11,8 +11,7 @@ pub struct EventCounter {
     pub implicitly_start: bool,
     merge_phases: bool,
     /// The raw per-phase counts, in phase order (index 0 = phase 0, etc). Visible within the
-    /// `counter` module so [`super::LatencySampler`] can compute derived statistics (average,
-    /// percentiles) directly from the raw per-pause samples accumulated here.
+    /// `counter` module so [`super::LatencySampler`] can compute derived statistics.
     pub(super) count: Vec<u64>,
     current_count: u64,
     running: bool,

--- a/src/util/statistics/counter/latency_sampler.rs
+++ b/src/util/statistics/counter/latency_sampler.rs
@@ -1,0 +1,111 @@
+use super::*;
+use crate::util::statistics::stats::SharedStats;
+use std::sync::Arc;
+
+/// A [`Counter`] that records one latency sample per event (e.g. one per GC pause, for things
+/// like time-to-yield or pause time) and reports it as `avg`/`p9999` columns instead of a raw
+/// per-phase total.
+///
+/// This is a thin wrapper around an [`EventCounter`]: it reuses the inner counter's
+/// `start`/`stop`/`phase_change` machinery unchanged to accumulate one sample per pause into the
+/// per-phase array (always recorded in the STW phase). It only overrides how the counter is
+/// named and printed, bending two parts of the [`Counter`] contract to do so:
+///
+/// - [`Counter::merge_phases`] always returns `true`.
+/// - [`Counter::name`] returns a compound, tab-separated pair of column names (e.g.
+///   `"pause-time.avg\tpause-time.p9999"`), so the single `print!("{}\t", c.name())` call site
+///   in [`crate::util::statistics::stats::Stats::print_column_names`] prints both headers.
+/// - [`Counter::print_total`] prints `"{avg}\t{p9999}"` (two tab-separated values, ignoring the
+///   `other` argument), so the single `c.print_total(None)` call site in
+///   [`crate::util::statistics::stats::Stats::print_stats`] prints both values.
+///
+/// This trick only works because `Counter::name()` has a single caller (`Stats`'s own printing
+/// code) anywhere in the codebase; if that changes, this would need revisiting.
+pub struct LatencySampler {
+    inner: EventCounter,
+    /// A compound `"{name}.avg\t{name}.p9999"` string, returned by `name()`.
+    display_name: String,
+}
+
+impl LatencySampler {
+    pub fn new(name: &str, stats: Arc<SharedStats>, implicitly_start: bool) -> Self {
+        LatencySampler {
+            inner: EventCounter::new(name.to_string(), stats, implicitly_start, false),
+            display_name: format!("{name}.avg\t{name}.p9999"),
+        }
+    }
+
+    /// Record one latency sample (e.g. a duration in nanoseconds).
+    pub fn record(&mut self, value: u64) {
+        self.inner.inc_by(value);
+    }
+
+    /// The recorded samples, one per pause. Every sample is recorded during the STW phase (see
+    /// `record`), so only the odd-indexed phase counts hold real values; the even-indexed
+    /// (mutator-phase) ones are always 0 and are skipped here.
+    fn samples(&self) -> Vec<u64> {
+        self.inner.count.iter().skip(1).step_by(2).copied().collect()
+    }
+}
+
+impl Counter for LatencySampler {
+    fn start(&mut self) {
+        self.inner.start();
+    }
+
+    fn stop(&mut self) {
+        self.inner.stop();
+    }
+
+    fn phase_change(&mut self, old_phase: usize) {
+        self.inner.phase_change(old_phase);
+    }
+
+    fn print_count(&self, phase: usize) {
+        self.inner.print_count(phase);
+    }
+
+    fn get_total(&self, other: Option<bool>) -> u64 {
+        self.inner.get_total(other)
+    }
+
+    fn print_total(&self, _other: Option<bool>) {
+        let mut samples = self.samples();
+        if samples.is_empty() {
+            print!("n/a\tn/a");
+            return;
+        }
+        let avg_ns = samples.iter().sum::<u64>() as f64 / samples.len() as f64;
+        // Exact p9999 (99.99th percentile), computed by sorting all samples and using the
+        // nearest-rank method. Note that with fewer than 10,000 samples, this is guaranteed to
+        // just return the maximum.
+        samples.sort_unstable();
+        let rank = ((99.99 / 100.0) * samples.len() as f64).ceil() as usize;
+        let p9999_ns = samples[rank.clamp(1, samples.len()) - 1];
+        print!("{:.2}\t{:.2}", avg_ns / 1e6, p9999_ns as f64 / 1e6);
+    }
+
+    fn print_min(&self, other: bool) {
+        self.inner.print_min(other);
+    }
+
+    fn print_max(&self, other: bool) {
+        self.inner.print_max(other);
+    }
+
+    fn print_last(&self) {
+        self.inner.print_last();
+    }
+
+    fn merge_phases(&self) -> bool {
+        true
+    }
+
+    fn implicitly_start(&self) -> bool {
+        self.inner.implicitly_start()
+    }
+
+    fn name(&self) -> &String {
+        &self.display_name
+    }
+}

--- a/src/util/statistics/counter/latency_sampler.rs
+++ b/src/util/statistics/counter/latency_sampler.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 ///
 /// This is a thin wrapper around an [`EventCounter`]: it reuses the inner counter's
 /// `start`/`stop`/`phase_change` machinery unchanged to accumulate one sample per pause into the
-/// per-phase array (always recorded in the STW phase). It only overrides how the counter is
+/// per-phase array. It only overrides how the counter is
 /// named and printed, bending two parts of the [`Counter`] contract to do so:
 ///
 /// - [`Counter::merge_phases`] always returns `true`.
@@ -44,7 +44,13 @@ impl LatencySampler {
     /// `record`), so only the odd-indexed phase counts hold real values; the even-indexed
     /// (mutator-phase) ones are always 0 and are skipped here.
     fn samples(&self) -> Vec<u64> {
-        self.inner.count.iter().skip(1).step_by(2).copied().collect()
+        self.inner
+            .count
+            .iter()
+            .skip(1)
+            .step_by(2)
+            .copied()
+            .collect()
     }
 }
 

--- a/src/util/statistics/counter/mod.rs
+++ b/src/util/statistics/counter/mod.rs
@@ -1,12 +1,14 @@
 use std::time::Instant;
 
 mod event_counter;
+mod latency_sampler;
 mod long_counter;
 #[cfg(feature = "perf_counter")]
 mod perf_event;
 mod size_counter;
 
 pub use self::event_counter::EventCounter;
+pub use self::latency_sampler::LatencySampler;
 pub use self::long_counter::{LongCounter, Timer};
 #[cfg(feature = "perf_counter")]
 pub use self::perf_event::PerfEventDiffable;

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
 
 /// The default number of phases for statistics.
 pub const DEFAULT_NUM_PHASES: usize = 1 << 12;
@@ -52,6 +53,12 @@ pub struct Stats {
     perfmon: Perfmon,
     pub shared: Arc<SharedStats>,
     counters: Mutex<Vec<Arc<Mutex<dyn Counter + Send>>>>,
+    /// Tracks "time-to-yield": the latency, for each GC pause, between MMTk successfully
+    /// requesting the pause and the point all mutators have actually stopped.
+    time_to_yield: Arc<Mutex<LatencySampler>>,
+    /// Tracks "pause time": the duration, for each GC pause, that mutators spend stopped (from
+    /// the point all mutators have stopped to the point they are resumed).
+    pause_time: Arc<Mutex<LatencySampler>>,
 }
 
 impl Stats {
@@ -79,6 +86,20 @@ impl Stats {
             MonotoneNanoTime {},
         )));
         counters.push(t.clone());
+        // We always have a time-to-yield counter enabled
+        let time_to_yield = Arc::new(Mutex::new(LatencySampler::new(
+            "time-to-yield",
+            shared.clone(),
+            true,
+        )));
+        counters.push(time_to_yield.clone());
+        // We always have a pause-time counter enabled
+        let pause_time = Arc::new(Mutex::new(LatencySampler::new(
+            "pause-time",
+            shared.clone(),
+            true,
+        )));
+        counters.push(pause_time.clone());
         // Read from the MMTK option for a list of perf events we want to
         // measure, and create corresponding counters
         #[cfg(feature = "perf_counter")]
@@ -98,7 +119,27 @@ impl Stats {
             perfmon,
             shared,
             counters: Mutex::new(counters),
+            time_to_yield,
+            pause_time,
         }
+    }
+
+    /// Record a "time-to-yield" sample: the time elapsed between MMTk successfully requesting a
+    /// GC pause and the point all mutators have stopped for that pause.
+    pub fn record_time_to_yield(&self, duration: Duration) {
+        self.time_to_yield
+            .lock()
+            .unwrap()
+            .record(duration.as_nanos() as u64);
+    }
+
+    /// Record a "pause time" sample: the duration mutators spent stopped for a GC pause, from
+    /// the point all mutators stopped to the point they are resumed.
+    pub fn record_pause_time(&self, duration: Duration) {
+        self.pause_time
+            .lock()
+            .unwrap()
+            .record(duration.as_nanos() as u64);
     }
 
     pub fn new_event_counter(

--- a/src/util/statistics/stats.rs
+++ b/src/util/statistics/stats.rs
@@ -53,11 +53,7 @@ pub struct Stats {
     perfmon: Perfmon,
     pub shared: Arc<SharedStats>,
     counters: Mutex<Vec<Arc<Mutex<dyn Counter + Send>>>>,
-    /// Tracks "time-to-yield": the latency, for each GC pause, between MMTk successfully
-    /// requesting the pause and the point all mutators have actually stopped.
     time_to_yield: Arc<Mutex<LatencySampler>>,
-    /// Tracks "pause time": the duration, for each GC pause, that mutators spend stopped (from
-    /// the point all mutators have stopped to the point they are resumed).
     pause_time: Arc<Mutex<LatencySampler>>,
 }
 


### PR DESCRIPTION
This adds a `LatencySampler` Counter for us to measure time-to-yield and pause-time. When we merge this, time-to-yield and pause-time data will be recorded with our CI. We just need to modify render scripts to render them for certain plans.