### PR TITLE
Extra statistics on eBPF timeline

### DIFF
--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -1402,6 +1402,9 @@ impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
         // Clear object mark table for this chunk
         self.reset_object_mark();
+        // The number of defrag source blocks.  For debugging.
+        let mut num_defrag_source_blocks = 0;
+        let mut num_blocks_prepared = 0;
         // Iterate over all blocks in this chunk
         for block in self.chunk.iter_region::<Block>() {
             let state = block.get_state();
@@ -1409,6 +1412,7 @@ impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
             if state == BlockState::Unallocated {
                 continue;
             }
+            num_blocks_prepared += 1;
             // Check if this block needs to be defragmented.
             let is_defrag_source = if !self.space.is_defrag_enabled() {
                 // Do not set any block as defrag source if defrag is disabled.
@@ -1423,12 +1427,22 @@ impl<VM: VMBinding> GCWork<VM> for PrepareBlockState<VM> {
                 // Not a defrag GC.
                 false
             };
+            if is_defrag_source {
+                num_defrag_source_blocks += 1;
+            }
             block.set_as_defrag_source(is_defrag_source);
             // Clear block mark data.
             block.set_state(BlockState::Unmarked);
             debug_assert!(!block.get_state().is_reusable());
             debug_assert_ne!(block.get_state(), BlockState::Marked);
         }
+
+        probe!(
+            mmtk,
+            immix_prepare_block_state,
+            num_blocks_prepared,
+            num_defrag_source_blocks
+        );
 
         self.unlog_bits_op
             .execute::<VM>(self.chunk.start(), Chunk::BYTES);

--- a/src/scheduler/gc_work.rs
+++ b/src/scheduler/gc_work.rs
@@ -281,6 +281,11 @@ impl<C: GCWorkContext> GCWork<C::VM> for StopMutators<C> {
         mmtk.stats
             .record_time_to_yield(mmtk.state.take_time_to_yield());
         mmtk.state.record_pause_start_time();
+
+        let reserved_pages = mmtk.get_plan().get_reserved_pages();
+        let total_pages = mmtk.get_plan().get_total_pages();
+        probe!(mmtk, heap_stats, reserved_pages, total_pages);
+
         // This also tells the GC trigger whether a new GC cycle has started (see `Plan::gc_pause_start`).
         mmtk.get_plan().on_pause_start(mmtk);
         mmtk.scheduler.notify_mutators_paused(mmtk);

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -642,12 +642,17 @@ impl<VM: VMBinding> GCWorkScheduler<VM> {
             .expect("Pause start time was not recorded")
             .elapsed();
 
+        let reserved_pages = mmtk.get_plan().get_reserved_pages();
+        let total_pages = mmtk.get_plan().get_total_pages();
+
         info!(
             "End of Pause ({}/{} pages, took {:.2} ms)",
-            mmtk.get_plan().get_reserved_pages(),
-            mmtk.get_plan().get_total_pages(),
+            reserved_pages,
+            total_pages,
             elapsed.as_secs_f64() * 1000.0
         );
+
+        probe!(mmtk, heap_stats, reserved_pages, total_pages);
 
         // USDT tracepoint for the end of GC.
         probe!(mmtk, gc_end);

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -186,3 +186,9 @@ usdt:$MMTK:mmtk:reference_retained {
         printf("reference_retained,meta,%d,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2);
     }
 }
+
+usdt:$MMTK:mmtk:heap_stats {
+    // It is printed per GC and per pause, so the volume is low.
+    // We ignore @enable_print.
+    printf("heap_stats,C,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
+}

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -192,3 +192,27 @@ usdt:$MMTK:mmtk:heap_stats {
     // We ignore @enable_print.
     printf("heap_stats,C,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
 }
+
+usdt:$MMTK:mmtk:defrag_prepare {
+    // It is printed per defrag GC which rarely happens.
+    // We ignore @enable_print.
+    printf("defrag_prepare,meta,%d,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2);
+}
+
+usdt:$MMTK:mmtk:immix_stats {
+    // It is printed per Immix full heap GC which rarely happens.
+    // We ignore @enable_print.
+    printf("immix_stats,C,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
+}
+
+usdt:$MMTK:mmtk:immix_copied {
+    // It is printed per Immix full heap GC which rarely happens.
+    // We ignore @enable_print.
+    printf("immix_copied,C,%d,%lu,%lu\n", tid, nsecs, arg0);
+}
+
+usdt:$MMTK:mmtk:immix_prepare_block_state {
+    // It is printed per Immix defrag GC which rarely happens.
+    // We ignore @enable_print.
+    printf("immix_prepare_block_state,meta,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
+}

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -95,9 +95,11 @@ usdt:$MMTK:mmtk:immix_defrag {
 }
 
 usdt:$MMTK:mmtk:roots {
-    if (@enable_print) {
-        printf("roots,meta,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
-    }
+    // Roots are relatively few compared to the work packets for transitive closure.
+    // When @enable_print is false, we don't emit events for the root scanning work packets,
+    // but we can emit the statistics so that we can aggregate the number of roots to the GC bar on the timeline.
+    // So we ignore @enable_print here.
+    printf("roots,meta,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
 }
 
 //////// BEGIN:PROCESS_ROOT_NODES
@@ -141,9 +143,11 @@ usdt:$MMTK:mmtk:sweep_chunk_ms {
 //////// END:SWEEP_CHUNK_MS
 
 usdt:$MMTK:mmtk:sweep_chunk_immix {
-    if (@enable_print) {
-        printf("sweep_chunk_immix,meta,%d,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2);
-    }
+    // Swept chunks are relatively few compared to the work packets for transitive closure.
+    // When @enable_print is false, we don't emit events for the sweep chunk work packets,
+    // but we can emit the statistics so that we can aggregate the number of chunks to the GC bar on the timeline.
+    // So we ignore @enable_print here.
+    printf("sweep_chunk_immix,meta,%d,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2);
 }
 
 usdt:$MMTK:mmtk:concurrent_trace_objects {

--- a/tools/tracing/timeline/capture.bt
+++ b/tools/tracing/timeline/capture.bt
@@ -193,24 +193,6 @@ usdt:$MMTK:mmtk:heap_stats {
     printf("heap_stats,C,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
 }
 
-usdt:$MMTK:mmtk:defrag_prepare {
-    // It is printed per defrag GC which rarely happens.
-    // We ignore @enable_print.
-    printf("defrag_prepare,meta,%d,%lu,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1, arg2);
-}
-
-usdt:$MMTK:mmtk:immix_stats {
-    // It is printed per Immix full heap GC which rarely happens.
-    // We ignore @enable_print.
-    printf("immix_stats,C,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
-}
-
-usdt:$MMTK:mmtk:immix_copied {
-    // It is printed per Immix full heap GC which rarely happens.
-    // We ignore @enable_print.
-    printf("immix_copied,C,%d,%lu,%lu\n", tid, nsecs, arg0);
-}
-
 usdt:$MMTK:mmtk:immix_prepare_block_state {
     // It is printed per Immix defrag GC which rarely happens.
     // We ignore @enable_print.

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -180,6 +180,12 @@ class LogProcessor:
                 # GC on the same timeline row.
                 result["tid"] = 0
 
+            case "heap_stats":
+                result["args"] |= {
+                    "reserved_pages": int(args[0]),
+                    "total_pages": int(args[1]),
+                }
+
             case _:
                 if self.enrich_event_extra is not None:
                     # Call ``enrich_event_extra`` in the extension script if defined.

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -269,6 +269,21 @@ class LogProcessor:
 
                     roots_list.append(root_dict)
 
+                    if gc is not None:
+                        if "roots" not in gc["args"]:
+                            gc["args"]["roots"] = {
+                                "normal_roots": 0,
+                                "pinning_roots": 0,
+                                "tpinning_roots": 0,
+                            }
+                        match kind_id:
+                            case RootsKind.NORMAL.value:
+                                gc["args"]["roots"]["normal_roots"] += num
+                            case RootsKind.PINNING.value:
+                                gc["args"]["roots"]["pinning_roots"] += num
+                            case RootsKind.TPINNING.value:
+                                gc["args"]["roots"]["tpinning_roots"] += num
+
                 case "process_root_nodes":
                     wp["args"] |= {
                         "num_roots": int(args[0]),
@@ -314,11 +329,23 @@ class LogProcessor:
                     }
 
                 case "sweep_chunk_immix":
+                    swept_blocks, reused_blocks, unreused_blocks = [int(arg) for arg in args]
                     wp["args"] |= {
-                        "swept_blocks": int(args[0]),
-                        "reused_blocks": int(args[1]),
-                        "unreused_blocks": int(args[2]),
+                        "swept_blocks": swept_blocks,
+                        "reused_blocks": reused_blocks,
+                        "unreused_blocks": unreused_blocks,
                     }
+
+                    if gc is not None:
+                        if "sweep_chunk_immix" not in gc["args"]:
+                            gc["args"]["sweep_chunk_immix"] = {
+                                "swept_blocks": 0,
+                                "reused_blocks": 0,
+                                "unreused_blocks": 0,
+                            }
+                        gc["args"]["sweep_chunk_immix"]["swept_blocks"] += swept_blocks
+                        gc["args"]["sweep_chunk_immix"]["reused_blocks"] += reused_blocks
+                        gc["args"]["sweep_chunk_immix"]["unreused_blocks"] += unreused_blocks
 
                 case "finalization":
                     wp["args"] |= {

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -245,15 +245,6 @@ class LogProcessor:
                         "pause": pause,
                     }
 
-                case "defrag_prepare":
-                    gc["args"] |= {
-                        "defrag_prepare": {
-                            "defrag_spill_threshold": int(args[0]),
-                            "available_clean_pages_for_defrag": int(args[1]),
-                            "new_available_clean_pages_for_defrag": int(args[2]),
-                        },
-                    }
-
                 case _:
                     processed_for_gc = False
         else:

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -245,6 +245,15 @@ class LogProcessor:
                         "pause": pause,
                     }
 
+                case "defrag_prepare":
+                    gc["args"] |= {
+                        "defrag_prepare": {
+                            "defrag_spill_threshold": int(args[0]),
+                            "available_clean_pages_for_defrag": int(args[1]),
+                            "new_available_clean_pages_for_defrag": int(args[2]),
+                        },
+                    }
+
                 case _:
                     processed_for_gc = False
         else:
@@ -377,15 +386,6 @@ class LogProcessor:
                         "num_refs": int(args[0]),
                         "num_live": int(args[1]),
                         "num_retained": int(args[2]),
-                    }
-
-                case "defrag_prepare":
-                    gc["args"] |= {
-                        "defrag_prepare": {
-                            "defrag_spill_threshold": int(args[0]),
-                            "available_clean_pages_for_defrag": int(args[1]),
-                            "new_available_clean_pages_for_defrag": int(args[2]),
-                        },
                     }
 
                 case "immix_prepare_block_state":

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -210,9 +210,8 @@ class LogProcessor:
         parameters of this function, including `self` as the first argument.
         """
 
-        processed_for_gc = True
-        processed_for_wp = True
-
+        # The following meta events enrich the GC bar.
+        # Only process them when the current thread is in the middle of a GC.
         # bpftrace may drop events.  Be conservative.
         if gc is not None:
             match name:
@@ -245,45 +244,11 @@ class LogProcessor:
                         "pause": pause,
                     }
 
-                case _:
-                    processed_for_gc = False
-        else:
-            processed_for_gc = False
-
+        # The following meta events enrich the work packet.
+        # Only process them when the current thread is in the middle of a work packet.
         # bpftrace may drop events.  Be conservative.
         if wp is not None:
             match name:
-                case "roots":
-                    if "roots" not in wp["args"]:
-                        wp["args"]["roots"] = []
-                    roots_list = wp["args"]["roots"]
-                    kind_id = int(args[0])
-                    num = int(args[1])
-                    match kind_id:
-                        case RootsKind.NORMAL.value:
-                            root_dict = {"kind": "normal_roots", "num_slots": num}
-                        case RootsKind.PINNING.value:
-                            root_dict = {"kind": "pinning_roots", "num_nodes": num}
-                        case RootsKind.TPINNING.value:
-                            root_dict = {"kind": "tpinning_roots", "num_nodes": num}
-
-                    roots_list.append(root_dict)
-
-                    if gc is not None:
-                        if "roots" not in gc["args"]:
-                            gc["args"]["roots"] = {
-                                "normal_roots": 0,
-                                "pinning_roots": 0,
-                                "tpinning_roots": 0,
-                            }
-                        match kind_id:
-                            case RootsKind.NORMAL.value:
-                                gc["args"]["roots"]["normal_roots"] += num
-                            case RootsKind.PINNING.value:
-                                gc["args"]["roots"]["pinning_roots"] += num
-                            case RootsKind.TPINNING.value:
-                                gc["args"]["roots"]["tpinning_roots"] += num
-
                 case "process_root_nodes":
                     wp["args"] |= {
                         "num_roots": int(args[0]),
@@ -328,25 +293,6 @@ class LogProcessor:
                         "allocated_blocks": int(args[0]),
                     }
 
-                case "sweep_chunk_immix":
-                    swept_blocks, reused_blocks, unreused_blocks = [int(arg) for arg in args]
-                    wp["args"] |= {
-                        "swept_blocks": swept_blocks,
-                        "reused_blocks": reused_blocks,
-                        "unreused_blocks": unreused_blocks,
-                    }
-
-                    if gc is not None:
-                        if "sweep_chunk_immix" not in gc["args"]:
-                            gc["args"]["sweep_chunk_immix"] = {
-                                "swept_blocks": 0,
-                                "reused_blocks": 0,
-                                "unreused_blocks": 0,
-                            }
-                        gc["args"]["sweep_chunk_immix"]["swept_blocks"] += swept_blocks
-                        gc["args"]["sweep_chunk_immix"]["reused_blocks"] += reused_blocks
-                        gc["args"]["sweep_chunk_immix"]["unreused_blocks"] += unreused_blocks
-
                 case "finalization":
                     wp["args"] |= {
                         "num_candidates": begin_end_diff_dict(int(args[0]), int(args[1])),
@@ -379,33 +325,91 @@ class LogProcessor:
                         "num_retained": int(args[2]),
                     }
 
-                case "immix_prepare_block_state":
-                    num_blocks_prepared, num_defrag_source_blocks = [int(x) for x in args]
+        # The following meta events may enrich both GC and the work packet.
+        # Let them decide which one to update.
+        #
+        # Because bpftrace can drop events, we always need to check if gc and wp are None or not.
+        #
+        # If we set the -e option of capture.py,
+        # it will not emit individual work packet bars during GCs when @enable_print is false.
+        # But we can still aggregate the statistic data to the GC bar.
+        match name:
+            case "roots":
+                kind_id = int(args[0])
+                num = int(args[1])
+
+                if wp is not None:
+                    if "roots" not in wp["args"]:
+                        wp["args"]["roots"] = []
+                    roots_list = wp["args"]["roots"]
+                    match kind_id:
+                        case RootsKind.NORMAL.value:
+                            root_dict = {"kind": "normal_roots", "num_slots": num}
+                        case RootsKind.PINNING.value:
+                            root_dict = {"kind": "pinning_roots", "num_nodes": num}
+                        case RootsKind.TPINNING.value:
+                            root_dict = {"kind": "tpinning_roots", "num_nodes": num}
+                    roots_list.append(root_dict)
+
+                if gc is not None:
+                    if "roots" not in gc["args"]:
+                        gc["args"]["roots"] = {
+                            "normal_roots": 0,
+                            "pinning_roots": 0,
+                            "tpinning_roots": 0,
+                        }
+                    match kind_id:
+                        case RootsKind.NORMAL.value:
+                            gc["args"]["roots"]["normal_roots"] += num
+                        case RootsKind.PINNING.value:
+                            gc["args"]["roots"]["pinning_roots"] += num
+                        case RootsKind.TPINNING.value:
+                            gc["args"]["roots"]["tpinning_roots"] += num
+
+            case "immix_prepare_block_state":
+                num_blocks_prepared, num_defrag_source_blocks = [int(arg) for arg in args]
+
+                if wp is not None:
                     wp["args"] |= {
                         "num_blocks_prepared": num_blocks_prepared,
                         "num_defrag_source_blocks": num_defrag_source_blocks,
                     }
 
-                    if gc is not None:
-                        if "immix_prepare_block_state" not in gc["args"]:
-                            gc["args"]["immix_prepare_block_state"] = {
-                                "num_blocks_prepared": 0,
-                                "num_defrag_source_blocks": 0,
-                            }
-                        gc["args"]["immix_prepare_block_state"]["num_blocks_prepared"] += num_blocks_prepared
-                        gc["args"]["immix_prepare_block_state"]["num_defrag_source_blocks"] += num_defrag_source_blocks
+                if gc is not None:
+                    if "immix_prepare_block_state" not in gc["args"]:
+                        gc["args"]["immix_prepare_block_state"] = {
+                            "num_blocks_prepared": 0,
+                            "num_defrag_source_blocks": 0,
+                        }
+                    gc["args"]["immix_prepare_block_state"]["num_blocks_prepared"] += num_blocks_prepared
+                    gc["args"]["immix_prepare_block_state"]["num_defrag_source_blocks"] += num_defrag_source_blocks
 
+            case "sweep_chunk_immix":
+                swept_blocks, reused_blocks, unreused_blocks = [int(arg) for arg in args]
 
-                case _:
-                    processed_for_wp = False
-        else:
-            processed_for_wp = False
+                if wp is not None:
+                    wp["args"] |= {
+                        "swept_blocks": swept_blocks,
+                        "reused_blocks": reused_blocks,
+                        "unreused_blocks": unreused_blocks,
+                    }
 
-        if not processed_for_gc and not processed_for_wp:
-            # If we haven't touched an event, we offload it to the extension.
-            if self.enrich_meta_extra is not None:
-                # Call ``enrich_meta_extra`` in the extension script if defined.
-                self.enrich_meta_extra(self, name, tid, ts, gc, wp, args)
+                if gc is not None:
+                    if "sweep_chunk_immix" not in gc["args"]:
+                        gc["args"]["sweep_chunk_immix"] = {
+                            "swept_blocks": 0,
+                            "reused_blocks": 0,
+                            "unreused_blocks": 0,
+                        }
+                    gc["args"]["sweep_chunk_immix"]["swept_blocks"] += swept_blocks
+                    gc["args"]["sweep_chunk_immix"]["reused_blocks"] += reused_blocks
+                    gc["args"]["sweep_chunk_immix"]["unreused_blocks"] += unreused_blocks
+
+        # Regardless whether we have processed the GC or work packet blocks,
+        # we always give the extension script a chance to inspect them.
+        if self.enrich_meta_extra is not None:
+            # Call ``enrich_meta_extra`` in the extension script if defined.
+            self.enrich_meta_extra(self, name, tid, ts, gc, wp, args)
 
     def resolve_results(self):
         for result in self.results:

--- a/tools/tracing/timeline/visualize.py
+++ b/tools/tracing/timeline/visualize.py
@@ -379,6 +379,32 @@ class LogProcessor:
                         "num_retained": int(args[2]),
                     }
 
+                case "defrag_prepare":
+                    gc["args"] |= {
+                        "defrag_prepare": {
+                            "defrag_spill_threshold": int(args[0]),
+                            "available_clean_pages_for_defrag": int(args[1]),
+                            "new_available_clean_pages_for_defrag": int(args[2]),
+                        },
+                    }
+
+                case "immix_prepare_block_state":
+                    num_blocks_prepared, num_defrag_source_blocks = [int(x) for x in args]
+                    wp["args"] |= {
+                        "num_blocks_prepared": num_blocks_prepared,
+                        "num_defrag_source_blocks": num_defrag_source_blocks,
+                    }
+
+                    if gc is not None:
+                        if "immix_prepare_block_state" not in gc["args"]:
+                            gc["args"]["immix_prepare_block_state"] = {
+                                "num_blocks_prepared": 0,
+                                "num_defrag_source_blocks": 0,
+                            }
+                        gc["args"]["immix_prepare_block_state"]["num_blocks_prepared"] += num_blocks_prepared
+                        gc["args"]["immix_prepare_block_state"]["num_defrag_source_blocks"] += num_defrag_source_blocks
+
+
                 case _:
                     processed_for_wp = False
         else:


### PR DESCRIPTION
We show the reserved pages and total pages as two curves on the timeline.  This can show the heap pressure and the effectiveness of each GC.  Currently we only collect the data at two times: (1) when all mutator have stopped and (2) at the end of a pause.  We don't interpolate the data, but we may find convenient places to collect the data during mutator time without reducing performance.

In the `PrepareBlockState` work packet of Immix-based plans, we show the number of blocks prepared and the number of blocks prepared and the number of defrag source blocks selected.  This is useful for debugging defragmentation.

We aggregate the following data from individual work packets to the GC bar in the eBPF timeline:

-   The number and kind (normal, pinning or tpinning) of roots scanned.
-   The number of prepared blocks and defrag sources in Immix.
-   The number of blocks swept, reused and unreused during the release stage in Immix.

We still collect those data when the user specified `capture.py -e N` to skip some collections.  In skipped collections, the statistics on individual work packets will not be shown, but the aggregated numbers on the GC bar will still be shown.