### PR TITLE
Always allow copy and forward_object to fail

### DIFF
--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -285,7 +285,7 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
             let is_nursery = self.rc.count(o) == 0;
             if is_nursery && !self.no_evac {
                 // Evacuate the object
-                let new = object_forwarding::try_forward_object::<VM>(
+                let new = object_forwarding::forward_object::<VM>(
                     o,
                     CopySemantics::DefaultCopy,
                     worker.get_copy_context_mut(),

--- a/src/policy/copyspace.rs
+++ b/src/policy/copyspace.rs
@@ -275,7 +275,7 @@ impl<VM: VMBinding> CopySpace<VM> {
                     #[cfg(feature = "vo_bit")]
                     crate::util::metadata::vo_bit::set_vo_bit(_new_object);
                 },
-            );
+            ).expect("to-space exhausted");
 
             trace!("Forwarding pointer");
             queue.enqueue(new_object);

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -962,7 +962,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                 // mark the block. So we do not need to explicitly mark it here.
                 // Clippy complains if the "vo_bit" feature is not enabled.
                 #[allow(clippy::let_and_return)]
-                let new_object = object_forwarding::try_forward_object::<VM>(
+                let new_object = object_forwarding::forward_object::<VM>(
                     object,
                     semantics,
                     copy_context,
@@ -978,7 +978,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                         vo_bit::helper::on_object_forwarded::<VM>(new_object);
                     },
                 )
-                .expect("to-space overflow");
+                .expect("to-space overflow"); // TODO: Fall back to non-moving marking.
 
                 new_object
             };
@@ -1045,7 +1045,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
             object_forwarding::spin_and_get_forwarded_object::<VM>(object, forwarding_status)
         } else {
             // Evacuate the mature object
-            let new = object_forwarding::try_forward_object::<VM>(
+            let new = object_forwarding::forward_object::<VM>(
                 object,
                 CopySemantics::DefaultCopy,
                 copy_context,
@@ -1055,7 +1055,7 @@ impl<VM: VMBinding> ImmixSpace<VM> {
                     vo_bit::set_vo_bit(_new_object);
                 },
             )
-            .expect("to-space overflow");
+            .expect("to-space overflow"); // TODO: Stop evacuating if out of space.
             // Transfer RC count
             if new.get_size::<VM>() > Line::BYTES {
                 self.rc.mark_straddle_object(new);

--- a/src/util/object_forwarding.rs
+++ b/src/util/object_forwarding.rs
@@ -74,33 +74,6 @@ pub fn spin_and_get_forwarded_object<VM: VMBinding>(
     }
 }
 
-pub fn try_forward_object<VM: VMBinding>(
-    object: ObjectReference,
-    semantics: CopySemantics,
-    copy_context: &mut GCWorkerCopyContext<VM>,
-    on_after_forwarding: impl FnOnce(ObjectReference),
-) -> Option<ObjectReference> {
-    let new_object = VM::VMObjectModel::try_copy(object, semantics, copy_context)?;
-    on_after_forwarding(new_object);
-    if let Some(shift) = forwarding_bits_offset_in_forwarding_pointer::<VM>() {
-        VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC.store_atomic::<VM, usize>(
-            object,
-            new_object.to_raw_address().as_usize() | ((FORWARDED as usize) << shift),
-            None,
-            Ordering::SeqCst,
-        )
-    } else {
-        write_forwarding_pointer::<VM>(object, new_object);
-        VM::VMObjectModel::LOCAL_FORWARDING_BITS_SPEC.store_atomic::<VM, u8>(
-            object,
-            FORWARDED,
-            None,
-            Ordering::SeqCst,
-        );
-    }
-    Some(new_object)
-}
-
 /// Copy an object and set the forwarding state.
 ///
 /// The caller can use `on_after_forwarding` to set extra metadata (including VO bits, mark bits,
@@ -122,8 +95,8 @@ pub fn forward_object<VM: VMBinding>(
     semantics: CopySemantics,
     copy_context: &mut GCWorkerCopyContext<VM>,
     on_after_forwarding: impl FnOnce(ObjectReference),
-) -> ObjectReference {
-    let new_object = VM::VMObjectModel::copy(object, semantics, copy_context);
+) -> Option<ObjectReference> {
+    let new_object = VM::VMObjectModel::copy(object, semantics, copy_context)?;
     on_after_forwarding(new_object);
     if let Some(shift) = forwarding_bits_offset_in_forwarding_pointer::<VM>() {
         VM::VMObjectModel::LOCAL_FORWARDING_POINTER_SPEC.store_atomic::<VM, usize>(
@@ -141,7 +114,7 @@ pub fn forward_object<VM: VMBinding>(
             Ordering::SeqCst,
         );
     }
-    new_object
+    Some(new_object)
 }
 
 /// Return the forwarding bits for a given `ObjectReference`.

--- a/src/vm/object_model.rs
+++ b/src/vm/object_model.rs
@@ -363,9 +363,13 @@ pub trait ObjectModel<VM: VMBinding> {
         metadata_spec.fetch_update::<T, F>(object.to_header::<VM>(), set_order, fetch_order, f)
     }
 
-    /// Copy an object and return the address of the new object. Usually in the implementation of this method,
-    /// `alloc_copy()` and `post_copy()` from [`GCWorkerCopyContext`](util/copy/struct.GCWorkerCopyContext.html)
-    /// are used for copying.
+    /// Allocate a new copy of an object and copy the object to that location.  This is required for
+    /// evacuating collectors such as SemiSpace, generational plans with a CopySpace nursery, and
+    /// Immix-based plans.  The implementation of this method shall use `copy_context.alloc_copy()`
+    /// for copying and `copy_context.alloc_copy.post_copy()` after copying.
+    ///
+    /// When `copy_context.alloc_copy()` fails, this function should return `None`. Otherwise,
+    /// return `Some(new_objref)` where `new_objref` is the new object reference of the object.
     ///
     /// Arguments:
     /// * `from`: The address of the object to be copied.
@@ -375,28 +379,15 @@ pub trait ObjectModel<VM: VMBinding> {
         from: ObjectReference,
         semantics: CopySemantics,
         copy_context: &mut GCWorkerCopyContext<VM>,
-    ) -> ObjectReference;
-
-    /// Attempt to copy an object, allowing the copy to fail (e.g. under concurrent copying, where
-    /// another GC worker may already be copying the same object). Returns the address of the new
-    /// object on success, or `None` if the copy could not be performed.
-    ///
-    /// Arguments:
-    /// * `from`: The address of the object to be copied.
-    /// * `semantics`: The copy semantic to use.
-    /// * `copy_context`: The `GCWorkerCopyContext` for the GC thread.
-    fn try_copy(
-        from: ObjectReference,
-        semantics: CopySemantics,
-        copy_context: &mut GCWorkerCopyContext<VM>,
     ) -> Option<ObjectReference>;
 
-    /// Copy an object. This is required
-    /// for delayed-copy collectors such as compacting collectors. During the
-    /// collection, MMTk reserves a region in the heap for an object as per
-    /// requirements found from `ObjectModel` and then asks `ObjectModel` to
-    /// determine what the object's reference will be post-copy. Return the address
-    /// past the end of the copied object.
+    /// Copy an object to a given location. This is required for delayed-copy collectors such as
+    /// compacting collectors. During the collection, MMTk reserves a region in the heap for an
+    /// object as per requirements found from `ObjectModel` and then asks `ObjectModel` to determine
+    /// what the object's reference will be post-copy.
+    ///
+    /// Return the address past the end of the copied object.  Unlike [`ObjectModel::copy`], this
+    /// method should not fail because there is no allocation happening in this function.
     ///
     /// Arguments:
     /// * `from`: The address of the object to be copied.


### PR DESCRIPTION
**DRAFT: VM bindings need to be changed accordingly.**

We introduced the `try_copy` and `try_forward_object` methods in the LXR pull request.  We now let them replace their existing counterparts, namely `copy` and `forward_object`, so that they are always allowed to fail.  This is a preparatory step for subsequent changes which will make Immix-based plans handle copy failure gracefully by falling back to non-moving marking.

This pull request only changes the API to the VM binding and the internal API for forwarding objects.  All plans should behave exactly as before.  For example, if the virtual address space runs out, it will still panic.  They will be refactored in the future.