### PR TITLE
Support pinning roots for LXR

### DIFF
--- a/src/plan/lxr/gc_work/mod.rs
+++ b/src/plan/lxr/gc_work/mod.rs
@@ -16,7 +16,7 @@ pub mod prepare;
 pub mod rc;
 pub mod tracing;
 
-use rc::{CollectNodeRoots, CollectRoots};
+use rc::{CollectNodeRoots, CollectSlotRoots};
 
 /// Common base fields shared by LXR's custom root/closure work packets.
 ///
@@ -101,9 +101,9 @@ impl<VM: VMBinding> crate::scheduler::GCWorkContext for LXRGCWorkContext<VM> {
 
 /// The [`RootsWorkFactory`] used by LXR.
 ///
-/// Roots reported as slots are reference-counted through [`CollectRoots`] (which spawns
+/// Roots reported as slots are reference-counted through [`CollectSlotRoots`] (which spawns
 /// `ProcessIncs`) in `RCProcessIncs`; roots reported as objects go through
-/// [`CollectNodeRoots`] one stage earlier, in `RCProcessRootNodes`, so that nothing can move
+/// [`CollectNodeRoots`] one stage earlier, in `RCProcessIncsNonMoving`, so that nothing can move
 /// them. See the two methods below.
 pub struct LXRRootsWorkFactory<VM: VMBinding> {
     mmtk: &'static MMTK<VM>,
@@ -124,56 +124,27 @@ impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
 impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
     fn create_process_roots_work_with_root_kind(&mut self, slots: Vec<VM::VMSlot>, kind: RootKind) {
         // Slot roots may be evacuated, so they run in `RCProcessIncs`, one stage after the
-        // `root_scanning_stage` that discovered them. See `WorkBucketStage::RCProcessRootNodes`.
+        // `root_scanning_stage` that discovered them. See `WorkBucketStage::RCProcessIncsNonMoving`.
         let stage = WorkBucketStage::RCProcessIncs;
-        let mut w = CollectRoots::new(slots, true, self.mmtk, stage);
+        let mut w = CollectSlotRoots::new(slots, true, self.mmtk, stage);
         w.root_kind = Some(kind);
         crate::memory_manager::add_work_packet(self.mmtk, stage, w);
     }
 
-    /// Handle roots reported as objects rather than as slots.
-    ///
-    /// Bindings report these when they cannot hand out the location a reference lives in
-    /// (Julia does so for conservatively scanned stacks), and ask for the referents to be
-    /// pinned. Since there is no slot to write a forwarding pointer back into, nothing in
-    /// this pause may move them:
-    ///
-    /// * They are reference counted in `RCProcessRootNodes`, which drains before
-    ///   `RCProcessIncs` opens. That ordering is what keeps them in place: `RCProcessIncs`
-    ///   processes ordinary slots pointing at the very same objects, and its nursery
-    ///   eviction only spares an object whose reference count is already nonzero.
-    /// * A stop-the-world pause marks them in `PinningRootsTrace`, which drains before
-    ///   `Closure`, using the non-moving [`tracing::LXRStopTheWorldProcessNodes`].
-    ///
-    /// Their children are ordinary references and are handed to the evacuating slot closure
-    /// in `Closure`, which is what makes these non-transitive pinning roots.
-    ///
-    /// Note that `RootsWorkFactory` passes no [`RootKind`] for node roots, so they are always
-    /// treated as [`RootKind::Strong`].
     fn create_process_pinning_roots_work(&mut self, nodes: Vec<ObjectReference>) {
         if nodes.is_empty() {
             return;
         }
         crate::memory_manager::add_work_packet(
             self.mmtk,
-            WorkBucketStage::RCProcessRootNodes,
+            WorkBucketStage::RCProcessIncsNonMoving,
             CollectNodeRoots::<VM>::new(nodes),
         );
     }
 
-    /// Transitive pinning is not implemented.
-    ///
-    /// It requires the entire closure from these roots to stay in a non-moving bucket --
-    /// upstream feeds `TPinningClosure` back into itself for exactly that -- whereas
-    /// [`Self::create_process_pinning_roots_work`] hands the roots' children to the
-    /// evacuating slot closure in `Closure`.
-    ///
-    /// With both evacuation modes compiled out nothing in the pause moves anything, so the
-    /// transitive requirement is met for free and these can take the ordinary node-root path.
-    /// That is how Julia -- the only binding that reports transitive pinning roots, for its
-    /// conservatively scanned mutator stacks -- is built: moving objects makes its C interop
-    /// too difficult. A moving build must not silently drop the requirement.
     fn create_process_tpinning_roots_work(&mut self, nodes: Vec<ObjectReference>) {
+        // Transitive pinning is not supported.
+        // Not sure if we can support it for LXR, as RC collections have no notion of transitive closure.
         if NURSERY_EVACUATION || MATURE_EVACUATION {
             unimplemented!(
                 "LXR does not support transitive pinning roots unless evacuation is compiled out"

--- a/src/plan/lxr/gc_work/mod.rs
+++ b/src/plan/lxr/gc_work/mod.rs
@@ -118,8 +118,7 @@ impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
 
 impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
     fn create_process_roots_work_with_root_kind(&mut self, slots: Vec<VM::VMSlot>, kind: RootKind) {
-        // Slot roots may evacuate, so they run in `RCProcessIncs`, not `root_scanning_stage()`.
-        // See `WorkBucketStage::RCProcessRootNodes`.
+        // Slot roots may evacuate, so they run in `RCProcessIncs`.
         let stage = WorkBucketStage::RCProcessIncs;
         let mut w = CollectRoots::new(slots, true, self.mmtk, stage);
         w.root_kind = Some(kind);
@@ -136,18 +135,32 @@ impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
 }
 
 impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
-    /// Handle roots reported as objects rather than as slots (e.g. Julia's conservatively
-    /// scanned stacks). LXR has no pinning support, so it treats these as ordinary strong
-    /// roots instead -- safe because `RCProcessRootNodes` reference-counts them before
-    /// `RCProcessIncs` (which may evacuate) even opens. See that stage's doc comment.
+    /// Reference-counts and, if needed, traces a set of roots reported as objects rather
+    /// than slots.
+    ///
+    /// This always schedules into `RCProcessRootNodes`, regardless of pause: that stage is
+    /// what reference-counts (and, for a nursery object, promotes) these roots, which is
+    /// what makes them ineligible for nursery eviction. `RCProcessRootNodes` is guaranteed
+    /// to fully drain before `RCProcessIncs` opens, so the counting has to happen there even
+    /// when there's nothing to trace yet -- `RCProcessIncs` processes ordinary slots to the
+    /// very same objects, and its nursery-eviction decision only skips an object once its rc
+    /// count is already nonzero. Scheduling this work into a later stage instead (e.g.
+    /// `PinningRootsTrace`, conditional on pause) would leave that window open for every
+    /// pause but `RefCount`.
+    ///
+    /// The *tracing* of these roots, in contrast, is deferred by
+    /// [`rc::ProcessIncs::process_and_schedule_root_nodes`] to whichever stage suits the
+    /// current pause -- `PinningRootsTrace` for a pause with a `Closure` phase, since nodes,
+    /// unlike slots, are never re-scanned and so must be traced directly before `Closure`
+    /// opens; nothing for `RefCount`, which has no `Closure` phase at all. Only the counting
+    /// has to be this early.
     fn create_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
         if nodes.is_empty() {
             return;
         }
-        let stage = self.mmtk.get_plan().root_scanning_stage();
         crate::memory_manager::add_work_packet(
             self.mmtk,
-            stage,
+            WorkBucketStage::RCProcessRootNodes,
             CollectNodeRoots::<VM>::new(nodes),
         );
     }

--- a/src/plan/lxr/gc_work/mod.rs
+++ b/src/plan/lxr/gc_work/mod.rs
@@ -1,5 +1,4 @@
 use super::global::LXR;
-use crate::plan::lxr::{MATURE_EVACUATION, NURSERY_EVACUATION};
 use crate::plan::tracing::UnsupportedTrace;
 use crate::plan::VectorObjectQueue;
 use crate::scheduler::gc_work::RootKind;
@@ -119,7 +118,11 @@ impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
 
 impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
     fn create_process_roots_work_with_root_kind(&mut self, slots: Vec<VM::VMSlot>, kind: RootKind) {
-        let stage = self.mmtk.get_plan().root_scanning_stage();
+        // Slot roots are processed in `RCProcessIncs`, not `root_scanning_stage()`: unlike node
+        // roots, they may evacuate the objects they point to, so they must run after
+        // `RCProcessRootNodes` has finished reference-counting (and thus pinning in place) every
+        // node root for this pause.
+        let stage = WorkBucketStage::RCProcessIncs;
         let mut w = CollectRoots::new(slots, true, self.mmtk, stage);
         w.root_kind = Some(kind);
         crate::memory_manager::add_work_packet(self.mmtk, stage, w);
@@ -136,15 +139,13 @@ impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
 
 impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
     /// Handle roots reported as objects rather than as slots (e.g. Julia's conservatively
-    /// scanned stacks). LXR has no pinning support, so these are only safe to treat as
-    /// ordinary strong roots because nothing moves; the panic below is the guard for that.
+    /// scanned stacks). LXR has no pinning support, so it treats these as ordinary strong
+    /// roots instead; that's only sound because they are reference-counted in
+    /// `RCProcessRootNodes`, a stage that runs (and fully drains) before `RCProcessIncs` --
+    /// the stage that may evacuate objects via slot roots or nursery edges -- even opens. By
+    /// the time any evacuation-capable code could reach one of these objects, its count is
+    /// already non-zero, and `dont_evacuate` skips it. See `WorkBucketStage::RCProcessRootNodes`.
     fn create_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
-        if NURSERY_EVACUATION || MATURE_EVACUATION {
-            panic!(
-                "LXR cannot honour pinning roots while evacuation is enabled; \
-                 build with the `lxr_no_evac` feature"
-            );
-        }
         if nodes.is_empty() {
             return;
         }

--- a/src/plan/lxr/gc_work/mod.rs
+++ b/src/plan/lxr/gc_work/mod.rs
@@ -144,16 +144,14 @@ impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
     /// to fully drain before `RCProcessIncs` opens, so the counting has to happen there even
     /// when there's nothing to trace yet -- `RCProcessIncs` processes ordinary slots to the
     /// very same objects, and its nursery-eviction decision only skips an object once its rc
-    /// count is already nonzero. Scheduling this work into a later stage instead (e.g.
-    /// `PinningRootsTrace`, conditional on pause) would leave that window open for every
-    /// pause but `RefCount`.
+    /// count is already nonzero. Scheduling this work into a later stage instead, conditional
+    /// on pause, would leave that window open for every pause but `RefCount`.
     ///
     /// The *tracing* of these roots, in contrast, is deferred by
     /// [`rc::ProcessIncs::process_and_schedule_root_nodes`] to whichever stage suits the
-    /// current pause -- `PinningRootsTrace` for a pause with a `Closure` phase, since nodes,
-    /// unlike slots, are never re-scanned and so must be traced directly before `Closure`
-    /// opens; nothing for `RefCount`, which has no `Closure` phase at all. Only the counting
-    /// has to be this early.
+    /// current pause -- `Closure` for a stop-the-world tracing pause, `ConcurrentResumable`
+    /// to seed concurrent marking at `InitialMark`, and nothing at all for `RefCount`, which
+    /// has no marking phase. Only the counting has to be this early.
     fn create_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
         if nodes.is_empty() {
             return;

--- a/src/plan/lxr/gc_work/mod.rs
+++ b/src/plan/lxr/gc_work/mod.rs
@@ -118,10 +118,8 @@ impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
 
 impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
     fn create_process_roots_work_with_root_kind(&mut self, slots: Vec<VM::VMSlot>, kind: RootKind) {
-        // Slot roots are processed in `RCProcessIncs`, not `root_scanning_stage()`: unlike node
-        // roots, they may evacuate the objects they point to, so they must run after
-        // `RCProcessRootNodes` has finished reference-counting (and thus pinning in place) every
-        // node root for this pause.
+        // Slot roots may evacuate, so they run in `RCProcessIncs`, not `root_scanning_stage()`.
+        // See `WorkBucketStage::RCProcessRootNodes`.
         let stage = WorkBucketStage::RCProcessIncs;
         let mut w = CollectRoots::new(slots, true, self.mmtk, stage);
         w.root_kind = Some(kind);
@@ -140,11 +138,8 @@ impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
 impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
     /// Handle roots reported as objects rather than as slots (e.g. Julia's conservatively
     /// scanned stacks). LXR has no pinning support, so it treats these as ordinary strong
-    /// roots instead; that's only sound because they are reference-counted in
-    /// `RCProcessRootNodes`, a stage that runs (and fully drains) before `RCProcessIncs` --
-    /// the stage that may evacuate objects via slot roots or nursery edges -- even opens. By
-    /// the time any evacuation-capable code could reach one of these objects, its count is
-    /// already non-zero, and `dont_evacuate` skips it. See `WorkBucketStage::RCProcessRootNodes`.
+    /// roots instead -- safe because `RCProcessRootNodes` reference-counts them before
+    /// `RCProcessIncs` (which may evacuate) even opens. See that stage's doc comment.
     fn create_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
         if nodes.is_empty() {
             return;

--- a/src/plan/lxr/gc_work/mod.rs
+++ b/src/plan/lxr/gc_work/mod.rs
@@ -1,4 +1,5 @@
 use super::global::LXR;
+use crate::plan::lxr::{MATURE_EVACUATION, NURSERY_EVACUATION};
 use crate::plan::tracing::UnsupportedTrace;
 use crate::plan::VectorObjectQueue;
 use crate::scheduler::gc_work::RootKind;
@@ -15,7 +16,7 @@ pub mod prepare;
 pub mod rc;
 pub mod tracing;
 
-use rc::CollectRoots;
+use rc::{CollectNodeRoots, CollectRoots};
 
 /// Common base fields shared by LXR's custom root/closure work packets.
 ///
@@ -124,11 +125,34 @@ impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
         crate::memory_manager::add_work_packet(self.mmtk, stage, w);
     }
 
-    fn create_process_pinning_roots_work(&mut self, _nodes: Vec<ObjectReference>) {
-        unreachable!("LXR does not support pinning roots");
+    fn create_process_pinning_roots_work(&mut self, nodes: Vec<ObjectReference>) {
+        self.create_node_roots_work(nodes);
     }
 
-    fn create_process_tpinning_roots_work(&mut self, _nodes: Vec<ObjectReference>) {
-        unreachable!("LXR does not support transitive pinning roots");
+    fn create_process_tpinning_roots_work(&mut self, nodes: Vec<ObjectReference>) {
+        self.create_node_roots_work(nodes);
+    }
+}
+
+impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
+    /// Handle roots reported as objects rather than as slots (e.g. Julia's conservatively
+    /// scanned stacks). LXR has no pinning support, so these are only safe to treat as
+    /// ordinary strong roots because nothing moves; the panic below is the guard for that.
+    fn create_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
+        if NURSERY_EVACUATION || MATURE_EVACUATION {
+            panic!(
+                "LXR cannot honour pinning roots while evacuation is enabled; \
+                 build with the `lxr_no_evac` feature"
+            );
+        }
+        if nodes.is_empty() {
+            return;
+        }
+        let stage = self.mmtk.get_plan().root_scanning_stage();
+        crate::memory_manager::add_work_packet(
+            self.mmtk,
+            stage,
+            CollectNodeRoots::<VM>::new(nodes),
+        );
     }
 }

--- a/src/plan/lxr/gc_work/mod.rs
+++ b/src/plan/lxr/gc_work/mod.rs
@@ -1,4 +1,5 @@
 use super::global::LXR;
+use super::{MATURE_EVACUATION, NURSERY_EVACUATION};
 use crate::plan::tracing::UnsupportedTrace;
 use crate::plan::VectorObjectQueue;
 use crate::scheduler::gc_work::RootKind;
@@ -98,8 +99,12 @@ impl<VM: VMBinding> crate::scheduler::GCWorkContext for LXRGCWorkContext<VM> {
     }
 }
 
-/// The [`RootsWorkFactory`] used by LXR. Roots are processed by reference-counting them through
-/// [`CollectRoots`] (which spawns `ProcessIncs`).
+/// The [`RootsWorkFactory`] used by LXR.
+///
+/// Roots reported as slots are reference-counted through [`CollectRoots`] (which spawns
+/// `ProcessIncs`) in `RCProcessIncs`; roots reported as objects go through
+/// [`CollectNodeRoots`] one stage earlier, in `RCProcessRootNodes`, so that nothing can move
+/// them. See the two methods below.
 pub struct LXRRootsWorkFactory<VM: VMBinding> {
     mmtk: &'static MMTK<VM>,
 }
@@ -118,41 +123,34 @@ impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
 
 impl<VM: VMBinding> RootsWorkFactory<VM::VMSlot> for LXRRootsWorkFactory<VM> {
     fn create_process_roots_work_with_root_kind(&mut self, slots: Vec<VM::VMSlot>, kind: RootKind) {
-        // Slot roots may evacuate, so they run in `RCProcessIncs`.
+        // Slot roots may be evacuated, so they run in `RCProcessIncs`, one stage after the
+        // `root_scanning_stage` that discovered them. See `WorkBucketStage::RCProcessRootNodes`.
         let stage = WorkBucketStage::RCProcessIncs;
         let mut w = CollectRoots::new(slots, true, self.mmtk, stage);
         w.root_kind = Some(kind);
         crate::memory_manager::add_work_packet(self.mmtk, stage, w);
     }
 
+    /// Handle roots reported as objects rather than as slots.
+    ///
+    /// Bindings report these when they cannot hand out the location a reference lives in
+    /// (Julia does so for conservatively scanned stacks), and ask for the referents to be
+    /// pinned. Since there is no slot to write a forwarding pointer back into, nothing in
+    /// this pause may move them:
+    ///
+    /// * They are reference counted in `RCProcessRootNodes`, which drains before
+    ///   `RCProcessIncs` opens. That ordering is what keeps them in place: `RCProcessIncs`
+    ///   processes ordinary slots pointing at the very same objects, and its nursery
+    ///   eviction only spares an object whose reference count is already nonzero.
+    /// * A stop-the-world pause marks them in `PinningRootsTrace`, which drains before
+    ///   `Closure`, using the non-moving [`tracing::LXRStopTheWorldProcessNodes`].
+    ///
+    /// Their children are ordinary references and are handed to the evacuating slot closure
+    /// in `Closure`, which is what makes these non-transitive pinning roots.
+    ///
+    /// Note that `RootsWorkFactory` passes no [`RootKind`] for node roots, so they are always
+    /// treated as [`RootKind::Strong`].
     fn create_process_pinning_roots_work(&mut self, nodes: Vec<ObjectReference>) {
-        self.create_node_roots_work(nodes);
-    }
-
-    fn create_process_tpinning_roots_work(&mut self, nodes: Vec<ObjectReference>) {
-        self.create_node_roots_work(nodes);
-    }
-}
-
-impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
-    /// Reference-counts and, if needed, traces a set of roots reported as objects rather
-    /// than slots.
-    ///
-    /// This always schedules into `RCProcessRootNodes`, regardless of pause: that stage is
-    /// what reference-counts (and, for a nursery object, promotes) these roots, which is
-    /// what makes them ineligible for nursery eviction. `RCProcessRootNodes` is guaranteed
-    /// to fully drain before `RCProcessIncs` opens, so the counting has to happen there even
-    /// when there's nothing to trace yet -- `RCProcessIncs` processes ordinary slots to the
-    /// very same objects, and its nursery-eviction decision only skips an object once its rc
-    /// count is already nonzero. Scheduling this work into a later stage instead, conditional
-    /// on pause, would leave that window open for every pause but `RefCount`.
-    ///
-    /// The *tracing* of these roots, in contrast, is deferred by
-    /// [`rc::ProcessIncs::process_and_schedule_root_nodes`] to whichever stage suits the
-    /// current pause -- `Closure` for a stop-the-world tracing pause, `ConcurrentResumable`
-    /// to seed concurrent marking at `InitialMark`, and nothing at all for `RefCount`, which
-    /// has no marking phase. Only the counting has to be this early.
-    fn create_node_roots_work(&mut self, nodes: Vec<ObjectReference>) {
         if nodes.is_empty() {
             return;
         }
@@ -161,5 +159,26 @@ impl<VM: VMBinding> LXRRootsWorkFactory<VM> {
             WorkBucketStage::RCProcessRootNodes,
             CollectNodeRoots::<VM>::new(nodes),
         );
+    }
+
+    /// Transitive pinning is not implemented.
+    ///
+    /// It requires the entire closure from these roots to stay in a non-moving bucket --
+    /// upstream feeds `TPinningClosure` back into itself for exactly that -- whereas
+    /// [`Self::create_process_pinning_roots_work`] hands the roots' children to the
+    /// evacuating slot closure in `Closure`.
+    ///
+    /// With both evacuation modes compiled out nothing in the pause moves anything, so the
+    /// transitive requirement is met for free and these can take the ordinary node-root path.
+    /// That is how Julia -- the only binding that reports transitive pinning roots, for its
+    /// conservatively scanned mutator stacks -- is built: moving objects makes its C interop
+    /// too difficult. A moving build must not silently drop the requirement.
+    fn create_process_tpinning_roots_work(&mut self, nodes: Vec<ObjectReference>) {
+        if NURSERY_EVACUATION || MATURE_EVACUATION {
+            unimplemented!(
+                "LXR does not support transitive pinning roots unless evacuation is compiled out"
+            );
+        }
+        self.create_process_pinning_roots_work(nodes);
     }
 }

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -4,6 +4,7 @@ use super::super::LXR;
 use super::super::{LAZY_DECREMENTS, MATURE_EVACUATION, NO_EVAC, NURSERY_EVACUATION};
 use super::tracing::LXRConcurrentTraceObjects;
 use super::tracing::LXRStopTheWorldProcessEdges;
+use super::tracing::ProcessModBufSATB;
 use super::ProcessEdgesBase;
 use crate::plan::VectorQueue;
 use crate::policy::immix::block::BlockState;
@@ -23,6 +24,7 @@ use crate::{
     MMTK,
 };
 use atomic::Ordering;
+use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
@@ -78,6 +80,79 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
         Self {
             incs,
             ..Self::__default(lxr)
+        }
+    }
+
+    /// Increment root objects reported as objects rather than as slots.
+    pub fn process_root_nodes(
+        &mut self,
+        worker: &mut GCWorker<VM>,
+        nodes: Vec<ObjectReference>,
+    ) -> (Vec<ObjectReference>, Vec<ObjectReference>) {
+        self.pause = self.lxr.current_pause().unwrap();
+        self.in_cm = self.lxr.concurrent_work_in_progress();
+        let mut roots = Vec::with_capacity(nodes.len());
+        let mut uncounted = vec![];
+        for o in nodes {
+            if !self.lxr.is_rc_object(o) {
+                uncounted.push(o);
+                continue;
+            }
+            let los = self.lxr.los().in_space(o);
+            if self.inc(o) {
+                self.promote(worker, o, false, los, 0);
+            }
+            roots.push(o);
+        }
+        // Promotion above can queue further increments; hand them on rather than
+        // dropping them.
+        self.flush(worker);
+        (roots, uncounted)
+    }
+
+    /// Increment, promote and schedule tracing/decrementing for a set of root objects
+    /// reported as nodes.
+    pub fn process_and_schedule_root_nodes(
+        &mut self,
+        worker: &mut GCWorker<VM>,
+        mmtk: &'static MMTK<VM>,
+        nodes: Vec<ObjectReference>,
+    ) {
+        let lxr = self.lxr;
+        // `uncounted` must not reach `curr_roots`: no count was raised for it, so a
+        // decrement recorded against it would be unmatched. Both sets still need tracing.
+        let (roots, uncounted) = self.process_root_nodes(worker, nodes);
+        let mut to_trace = roots.clone();
+        to_trace.extend_from_slice(&uncounted);
+        if to_trace.is_empty() {
+            return;
+        }
+        // Roots arriving mid-cycle must also enter the SATB snapshot, or the cycle
+        // collector can conclude their subgraphs are unreachable.
+        if lxr.cm_enabled() && lxr.concurrent_work_in_progress() {
+            worker.add_work(
+                WorkBucketStage::FinishConcurrentWork,
+                ProcessModBufSATB::new(to_trace.clone()),
+            );
+        }
+        let pause = lxr.current_pause().unwrap();
+        if pause == Pause::Full || pause == Pause::FinalMark {
+            // Nodes, unlike slots, are never re-scanned, so a stop-the-world pause has to
+            // trace them directly here or they're never marked.
+            worker.add_work(
+                WorkBucketStage::Closure,
+                LXRConcurrentTraceObjects::new(to_trace, mmtk),
+            );
+        } else if lxr.cm_enabled() && pause == Pause::InitialMark {
+            // Seed concurrent marking with these roots, same as `ProcessIncs::do_work`
+            // does for root slots. Without this, `InitialMark` seeds nothing for node
+            // roots, and the whole trace would fall onto the `FinalMark` pause instead.
+            worker.scheduler().work_buckets[WorkBucketStage::ConcurrentResumable]
+                .add(LXRConcurrentTraceObjects::new(to_trace, mmtk));
+        }
+        // Recorded so the matching decrements are applied in the next pause.
+        if !roots.is_empty() {
+            lxr.curr_roots.read().unwrap().push(roots);
         }
     }
 
@@ -771,5 +846,30 @@ impl<VM: VMBinding> Deref for CollectRoots<VM> {
 impl<VM: VMBinding> DerefMut for CollectRoots<VM> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.base
+    }
+}
+
+/// Reference-counts a set of root objects reported as nodes rather than as slots.
+/// Node counterpart of [`CollectRoots`].
+pub struct CollectNodeRoots<VM: VMBinding> {
+    nodes: Vec<ObjectReference>,
+    _p: PhantomData<VM>,
+}
+
+impl<VM: VMBinding> CollectNodeRoots<VM> {
+    pub fn new(nodes: Vec<ObjectReference>) -> Self {
+        Self {
+            nodes,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<VM: VMBinding> GCWork<VM> for CollectNodeRoots<VM> {
+    fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
+        let lxr = mmtk.get_plan().downcast_ref::<LXR<VM>>().unwrap();
+        let nodes = std::mem::take(&mut self.nodes);
+        let mut incs = ProcessIncs::<VM, EDGE_KIND_ROOT>::new(vec![], lxr);
+        incs.process_and_schedule_root_nodes(worker, mmtk, nodes);
     }
 }

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -85,14 +85,7 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
     }
 
     /// Reference-count root objects reported as objects rather than as slots.
-    ///
-    /// Node counterpart of `process_incs::<EDGE_KIND_ROOT>`. Nothing here may move an object:
-    /// the caller has no slot to write a forwarding pointer back into, so a promotion is
-    /// always in place.
-    ///
-    /// Returns the roots this plan reference counts and, separately, the roots it does not.
-    /// Both still have to be traced, but only the former may be recorded as a root set --
-    /// a decrement against an object whose count was never raised would be unmatched.
+    /// Node counterpart of `process_incs::<EDGE_KIND_ROOT>`. Nothing here may move an object.
     fn process_root_nodes(
         &mut self,
         worker: &mut GCWorker<VM>,
@@ -101,19 +94,6 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
         let mut roots = Vec::with_capacity(nodes.len());
         let mut uncounted = vec![];
         for o in nodes {
-            // A root node has no slot, so nothing could ever update it if `o` had already
-            // moved by the time it got here. Catch that rather than silently register a
-            // stale reference as this pause's root set.
-            //
-            // Only in the Immix space: it is the one space that both moves objects and
-            // registers forwarding metadata for its chunks. Asking a LOS or common-space
-            // object for its forwarding bits reads side metadata that was never mapped for
-            // that address.
-            debug_assert!(
-                !self.lxr.immix_space.in_space(o) || !object_forwarding::is_forwarded::<VM>(o),
-                "root node {:?} was already forwarded",
-                o
-            );
             if !self.lxr.is_rc_object(o) {
                 uncounted.push(o);
                 continue;
@@ -132,18 +112,8 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
     }
 
     /// Node-shaped counterpart of [`GCWork::do_work`] below for `KIND == EDGE_KIND_ROOT`.
-    ///
-    /// Both reference-count a root set and then decide, from the current pause, whether to
-    /// seed concurrent marking, trace immediately, or only record the set for later
-    /// decrementing. The two differences both follow from the roots being objects rather than
-    /// slots:
-    ///
-    /// * Nothing may move them. The stop-the-world closure is therefore
-    ///   [`LXRStopTheWorldProcessNodes`], not [`LXRStopTheWorldProcessEdges`], and it runs in
-    ///   `PinningRootsTrace` -- before `Closure`, where the slot closure could evacuate them.
-    /// * The root set is recorded in `curr_roots` here, in every pause. The slot path leaves
-    ///   that to `LXRStopTheWorldProcessEdges` during `FinalMark`/`Full` because it has to
-    ///   record the *forwarded* root; these roots never forward.
+    /// However, the major difference is that we cannot move any of these objects here, as
+    /// we don't know their slots.
     pub fn do_work_root_nodes(
         &mut self,
         nodes: Vec<ObjectReference>,
@@ -852,11 +822,11 @@ impl<VM: VMBinding> GCWork<VM> for ProcessDecs<VM> {
     }
 }
 
-pub struct CollectRoots<VM: VMBinding> {
+pub struct CollectSlotRoots<VM: VMBinding> {
     base: ProcessEdgesBase<VM>,
 }
 
-impl<VM: VMBinding> CollectRoots<VM> {
+impl<VM: VMBinding> CollectSlotRoots<VM> {
     pub fn new(
         slots: Vec<VM::VMSlot>,
         roots: bool,
@@ -869,7 +839,7 @@ impl<VM: VMBinding> CollectRoots<VM> {
     }
 }
 
-impl<VM: VMBinding> GCWork<VM> for CollectRoots<VM> {
+impl<VM: VMBinding> GCWork<VM> for CollectSlotRoots<VM> {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
         self.set_worker(worker);
         if !self.slots.is_empty() {
@@ -882,25 +852,21 @@ impl<VM: VMBinding> GCWork<VM> for CollectRoots<VM> {
     }
 }
 
-impl<VM: VMBinding> Deref for CollectRoots<VM> {
+impl<VM: VMBinding> Deref for CollectSlotRoots<VM> {
     type Target = ProcessEdgesBase<VM>;
     fn deref(&self) -> &Self::Target {
         &self.base
     }
 }
 
-impl<VM: VMBinding> DerefMut for CollectRoots<VM> {
+impl<VM: VMBinding> DerefMut for CollectSlotRoots<VM> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.base
     }
 }
 
 /// Collects roots reported as objects rather than as slots. Node counterpart of
-/// [`CollectRoots`].
-///
-/// Scheduled into [`WorkBucketStage::RCProcessRootNodes`] by
-/// [`super::LXRRootsWorkFactory::create_process_pinning_roots_work`], which explains why that
-/// stage rather than `RCProcessIncs`.
+/// [`CollectSlotRoots`].
 pub struct CollectNodeRoots<VM: VMBinding> {
     nodes: Vec<ObjectReference>,
     _p: PhantomData<VM>,

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -4,7 +4,6 @@ use super::super::LXR;
 use super::super::{LAZY_DECREMENTS, MATURE_EVACUATION, NO_EVAC, NURSERY_EVACUATION};
 use super::tracing::LXRConcurrentTraceObjects;
 use super::tracing::LXRStopTheWorldProcessEdges;
-use super::tracing::LXRStopTheWorldProcessNodes;
 use super::tracing::ProcessModBufSATB;
 use super::ProcessEdgesBase;
 use crate::plan::VectorQueue;
@@ -98,8 +97,13 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
             // A root node has no slot, so nothing could ever update it if `o` had already
             // moved by the time it got here. Catch that rather than silently register a
             // stale reference as this pause's root set.
+            //
+            // Only in the Immix space: it is the one space that both moves objects and
+            // registers forwarding metadata for its chunks. Asking a LOS or common-space
+            // object for its forwarding bits reads side metadata that was never mapped for
+            // that address.
             debug_assert!(
-                !object_forwarding::is_forwarded::<VM>(o),
+                !self.lxr.immix_space.in_space(o) || !object_forwarding::is_forwarded::<VM>(o),
                 "root node {:?} was already forwarded",
                 o
             );
@@ -122,6 +126,16 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
 
     /// Increment, promote and schedule tracing/decrementing for a set of root objects
     /// reported as nodes.
+    ///
+    /// A node root is traced with [`LXRConcurrentTraceObjects`], not with the slot-based
+    /// [`LXRStopTheWorldProcessEdges`]. That tracer dispatches per space -- Immix via
+    /// `trace_object_without_moving_rc`, LOS via the LOS policy's own `trace_object`, and
+    /// anything else via the common plan -- so it never moves an object, which is what a
+    /// node root needs: there is no slot to write a forwarding pointer back into. The
+    /// slot-based closure would instead reach for object sizes and forwarding bits, neither
+    /// of which a large object has -- `LargeObjectSpace` registers no forwarding metadata
+    /// for its chunks at all, and its objects' sizes are not recoverable through the VM's
+    /// object model.
     pub fn process_and_schedule_root_nodes(
         &mut self,
         worker: &mut GCWorker<VM>,
@@ -145,29 +159,15 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
             );
         }
         let pause = lxr.current_pause().unwrap();
-        if pause == Pause::FinalMark {
+        if pause == Pause::Full || pause == Pause::FinalMark {
             // Nodes, unlike slots, are never re-scanned, so a stop-the-world pause has to
-            // trace them directly here or they're never marked. Uses
-            // `LXRStopTheWorldProcessNodes` in `PinningRootsTrace` -- which always runs
-            // (and drains) before `Closure` opens -- not `LXRConcurrentTraceObjects`,
-            // whose continuations resume in `ConcurrentResumable`, not guaranteed to drain
-            // before this pause ends.
+            // trace them directly here or they're never marked. `Closure` is where that
+            // belongs, and it is also where `LXRConcurrentTraceObjects::flush` sends its
+            // own continuations during these two pauses, so the closure this seeds drains
+            // before the pause ends rather than resuming in `ConcurrentResumable`.
             worker.add_work(
-                WorkBucketStage::PinningRootsTrace,
-                LXRStopTheWorldProcessNodes::<VM, false>::new(
-                    to_trace,
-                    mmtk,
-                    WorkBucketStage::PinningRootsTrace,
-                ),
-            );
-        } else if pause == Pause::Full {
-            worker.add_work(
-                WorkBucketStage::PinningRootsTrace,
-                LXRStopTheWorldProcessNodes::<VM, true>::new(
-                    to_trace,
-                    mmtk,
-                    WorkBucketStage::PinningRootsTrace,
-                ),
+                WorkBucketStage::Closure,
+                LXRConcurrentTraceObjects::new(to_trace, mmtk),
             );
         } else if lxr.cm_enabled() && pause == Pause::InitialMark {
             // Seed concurrent marking with these roots, like `ProcessIncs::do_work` does

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -119,8 +119,7 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
         nodes: Vec<ObjectReference>,
     ) {
         let lxr = self.lxr;
-        // `uncounted` must not reach `curr_roots`: no count was raised for it, so a
-        // decrement recorded against it would be unmatched. Both sets still need tracing.
+        // `uncounted` must not reach `curr_roots`: no count was raised for it.
         let (roots, uncounted) = self.process_root_nodes(worker, nodes);
         let mut to_trace = roots.clone();
         to_trace.extend_from_slice(&uncounted);
@@ -144,9 +143,8 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
                 LXRConcurrentTraceObjects::new(to_trace, mmtk),
             );
         } else if lxr.cm_enabled() && pause == Pause::InitialMark {
-            // Seed concurrent marking with these roots, same as `ProcessIncs::do_work`
-            // does for root slots. Without this, `InitialMark` seeds nothing for node
-            // roots, and the whole trace would fall onto the `FinalMark` pause instead.
+            // Seed concurrent marking with these roots, like `ProcessIncs::do_work` does
+            // for root slots -- otherwise node roots seed nothing until `FinalMark`.
             worker.scheduler().work_buckets[WorkBucketStage::ConcurrentResumable]
                 .add(LXRConcurrentTraceObjects::new(to_trace, mmtk));
         }

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -4,6 +4,7 @@ use super::super::LXR;
 use super::super::{LAZY_DECREMENTS, MATURE_EVACUATION, NO_EVAC, NURSERY_EVACUATION};
 use super::tracing::LXRConcurrentTraceObjects;
 use super::tracing::LXRStopTheWorldProcessEdges;
+use super::tracing::LXRStopTheWorldProcessNodes;
 use super::tracing::ProcessModBufSATB;
 use super::ProcessEdgesBase;
 use crate::plan::VectorQueue;
@@ -94,12 +95,21 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
         let mut roots = Vec::with_capacity(nodes.len());
         let mut uncounted = vec![];
         for o in nodes {
+            // A root node has no slot, so nothing could ever update it if `o` had already
+            // moved by the time it got here. Catch that rather than silently register a
+            // stale reference as this pause's root set.
+            debug_assert!(
+                !object_forwarding::is_forwarded::<VM>(o),
+                "root node {:?} was already forwarded",
+                o
+            );
             if !self.lxr.is_rc_object(o) {
                 uncounted.push(o);
                 continue;
             }
             let los = self.lxr.los().in_space(o);
             if self.inc(o) {
+                // Promote without moving
                 self.promote(worker, o, false, los, 0);
             }
             roots.push(o);
@@ -135,12 +145,29 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
             );
         }
         let pause = lxr.current_pause().unwrap();
-        if pause == Pause::Full || pause == Pause::FinalMark {
+        if pause == Pause::FinalMark {
             // Nodes, unlike slots, are never re-scanned, so a stop-the-world pause has to
-            // trace them directly here or they're never marked.
+            // trace them directly here or they're never marked. Uses
+            // `LXRStopTheWorldProcessNodes` in `PinningRootsTrace` -- which always runs
+            // (and drains) before `Closure` opens -- not `LXRConcurrentTraceObjects`,
+            // whose continuations resume in `ConcurrentResumable`, not guaranteed to drain
+            // before this pause ends.
             worker.add_work(
-                WorkBucketStage::Closure,
-                LXRConcurrentTraceObjects::new(to_trace, mmtk),
+                WorkBucketStage::PinningRootsTrace,
+                LXRStopTheWorldProcessNodes::<VM, false>::new(
+                    to_trace,
+                    mmtk,
+                    WorkBucketStage::PinningRootsTrace,
+                ),
+            );
+        } else if pause == Pause::Full {
+            worker.add_work(
+                WorkBucketStage::PinningRootsTrace,
+                LXRStopTheWorldProcessNodes::<VM, true>::new(
+                    to_trace,
+                    mmtk,
+                    WorkBucketStage::PinningRootsTrace,
+                ),
             );
         } else if lxr.cm_enabled() && pause == Pause::InitialMark {
             // Seed concurrent marking with these roots, like `ProcessIncs::do_work` does

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -4,6 +4,7 @@ use super::super::LXR;
 use super::super::{LAZY_DECREMENTS, MATURE_EVACUATION, NO_EVAC, NURSERY_EVACUATION};
 use super::tracing::LXRConcurrentTraceObjects;
 use super::tracing::LXRStopTheWorldProcessEdges;
+use super::tracing::LXRStopTheWorldProcessNodes;
 use super::tracing::ProcessModBufSATB;
 use super::ProcessEdgesBase;
 use crate::plan::VectorQueue;
@@ -83,14 +84,20 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
         }
     }
 
-    /// Increment root objects reported as objects rather than as slots.
-    pub fn process_root_nodes(
+    /// Reference-count root objects reported as objects rather than as slots.
+    ///
+    /// Node counterpart of `process_incs::<EDGE_KIND_ROOT>`. Nothing here may move an object:
+    /// the caller has no slot to write a forwarding pointer back into, so a promotion is
+    /// always in place.
+    ///
+    /// Returns the roots this plan reference counts and, separately, the roots it does not.
+    /// Both still have to be traced, but only the former may be recorded as a root set --
+    /// a decrement against an object whose count was never raised would be unmatched.
+    fn process_root_nodes(
         &mut self,
         worker: &mut GCWorker<VM>,
         nodes: Vec<ObjectReference>,
     ) -> (Vec<ObjectReference>, Vec<ObjectReference>) {
-        self.pause = self.lxr.current_pause().unwrap();
-        self.in_cm = self.lxr.concurrent_work_in_progress();
         let mut roots = Vec::with_capacity(nodes.len());
         let mut uncounted = vec![];
         for o in nodes {
@@ -113,7 +120,7 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
             }
             let los = self.lxr.los().in_space(o);
             if self.inc(o) {
-                // Promote without moving
+                // Promote without moving.
                 self.promote(worker, o, false, los, 0);
             }
             roots.push(o);
@@ -124,26 +131,29 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
         (roots, uncounted)
     }
 
-    /// Increment, promote and schedule tracing/decrementing for a set of root objects
-    /// reported as nodes.
+    /// Node-shaped counterpart of [`GCWork::do_work`] below for `KIND == EDGE_KIND_ROOT`.
     ///
-    /// A node root is traced with [`LXRConcurrentTraceObjects`], not with the slot-based
-    /// [`LXRStopTheWorldProcessEdges`]. That tracer dispatches per space -- Immix via
-    /// `trace_object_without_moving_rc`, LOS via the LOS policy's own `trace_object`, and
-    /// anything else via the common plan -- so it never moves an object, which is what a
-    /// node root needs: there is no slot to write a forwarding pointer back into. The
-    /// slot-based closure would instead reach for object sizes and forwarding bits, neither
-    /// of which a large object has -- `LargeObjectSpace` registers no forwarding metadata
-    /// for its chunks at all, and its objects' sizes are not recoverable through the VM's
-    /// object model.
-    pub fn process_and_schedule_root_nodes(
+    /// Both reference-count a root set and then decide, from the current pause, whether to
+    /// seed concurrent marking, trace immediately, or only record the set for later
+    /// decrementing. The two differences both follow from the roots being objects rather than
+    /// slots:
+    ///
+    /// * Nothing may move them. The stop-the-world closure is therefore
+    ///   [`LXRStopTheWorldProcessNodes`], not [`LXRStopTheWorldProcessEdges`], and it runs in
+    ///   `PinningRootsTrace` -- before `Closure`, where the slot closure could evacuate them.
+    /// * The root set is recorded in `curr_roots` here, in every pause. The slot path leaves
+    ///   that to `LXRStopTheWorldProcessEdges` during `FinalMark`/`Full` because it has to
+    ///   record the *forwarded* root; these roots never forward.
+    pub fn do_work_root_nodes(
         &mut self,
+        nodes: Vec<ObjectReference>,
         worker: &mut GCWorker<VM>,
         mmtk: &'static MMTK<VM>,
-        nodes: Vec<ObjectReference>,
     ) {
+        debug_assert_eq!(KIND, EDGE_KIND_ROOT);
         let lxr = self.lxr;
-        // `uncounted` must not reach `curr_roots`: no count was raised for it.
+        self.pause = lxr.current_pause().unwrap();
+        self.in_cm = lxr.concurrent_work_in_progress();
         let (roots, uncounted) = self.process_root_nodes(worker, nodes);
         let mut to_trace = roots.clone();
         to_trace.extend_from_slice(&uncounted);
@@ -152,28 +162,39 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
         }
         // Roots arriving mid-cycle must also enter the SATB snapshot, or the cycle
         // collector can conclude their subgraphs are unreachable.
-        if lxr.cm_enabled() && lxr.concurrent_work_in_progress() {
+        if lxr.cm_enabled() && self.in_cm {
             worker.add_work(
                 WorkBucketStage::FinishConcurrentWork,
                 ProcessModBufSATB::new(to_trace.clone()),
             );
         }
-        let pause = lxr.current_pause().unwrap();
-        if pause == Pause::Full || pause == Pause::FinalMark {
-            // Nodes, unlike slots, are never re-scanned, so a stop-the-world pause has to
-            // trace them directly here or they're never marked. `Closure` is where that
-            // belongs, and it is also where `LXRConcurrentTraceObjects::flush` sends its
-            // own continuations during these two pauses, so the closure this seeds drains
-            // before the pause ends rather than resuming in `ConcurrentResumable`.
-            worker.add_work(
-                WorkBucketStage::Closure,
-                LXRConcurrentTraceObjects::new(to_trace, mmtk),
-            );
-        } else if lxr.cm_enabled() && pause == Pause::InitialMark {
-            // Seed concurrent marking with these roots, like `ProcessIncs::do_work` does
-            // for root slots -- otherwise node roots seed nothing until `FinalMark`.
-            worker.scheduler().work_buckets[WorkBucketStage::ConcurrentResumable]
-                .add(LXRConcurrentTraceObjects::new(to_trace, mmtk));
+        // Nodes, unlike slots, are never re-scanned, so a stop-the-world tracing pause has to
+        // mark from them here or they are never marked at all.
+        match self.pause {
+            Pause::Full => worker.add_work(
+                WorkBucketStage::PinningRootsTrace,
+                LXRStopTheWorldProcessNodes::<VM, true>::new(
+                    to_trace,
+                    mmtk,
+                    WorkBucketStage::Closure,
+                ),
+            ),
+            Pause::FinalMark => worker.add_work(
+                WorkBucketStage::PinningRootsTrace,
+                LXRStopTheWorldProcessNodes::<VM, false>::new(
+                    to_trace,
+                    mmtk,
+                    WorkBucketStage::Closure,
+                ),
+            ),
+            // Seed concurrent marking with these roots, exactly as the slot path does --
+            // otherwise node roots seed nothing until `FinalMark`.
+            Pause::InitialMark if lxr.cm_enabled() => {
+                worker.scheduler().work_buckets[WorkBucketStage::ConcurrentResumable]
+                    .add(LXRConcurrentTraceObjects::new(to_trace, mmtk));
+            }
+            // `RefCount` has no marking phase.
+            _ => {}
         }
         // Recorded so the matching decrements are applied in the next pause.
         if !roots.is_empty() {
@@ -874,8 +895,12 @@ impl<VM: VMBinding> DerefMut for CollectRoots<VM> {
     }
 }
 
-/// Reference-counts a set of root objects reported as nodes rather than as slots.
-/// Node counterpart of [`CollectRoots`].
+/// Collects roots reported as objects rather than as slots. Node counterpart of
+/// [`CollectRoots`].
+///
+/// Scheduled into [`WorkBucketStage::RCProcessRootNodes`] by
+/// [`super::LXRRootsWorkFactory::create_process_pinning_roots_work`], which explains why that
+/// stage rather than `RCProcessIncs`.
 pub struct CollectNodeRoots<VM: VMBinding> {
     nodes: Vec<ObjectReference>,
     _p: PhantomData<VM>,
@@ -892,9 +917,13 @@ impl<VM: VMBinding> CollectNodeRoots<VM> {
 
 impl<VM: VMBinding> GCWork<VM> for CollectNodeRoots<VM> {
     fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
-        let lxr = mmtk.get_plan().downcast_ref::<LXR<VM>>().unwrap();
-        let nodes = std::mem::take(&mut self.nodes);
-        let mut incs = ProcessIncs::<VM, EDGE_KIND_ROOT>::new(vec![], lxr);
-        incs.process_and_schedule_root_nodes(worker, mmtk, nodes);
+        if !self.nodes.is_empty() {
+            let lxr = mmtk.get_plan().downcast_ref::<LXR<VM>>().unwrap();
+            let roots = std::mem::take(&mut self.nodes);
+            let mut w = ProcessIncs::<_, EDGE_KIND_ROOT>::new(vec![], lxr);
+            // `RootsWorkFactory` passes no `RootKind` for node roots; they are strong roots.
+            w.root_kind = Some(RootKind::Strong);
+            w.do_work_root_nodes(roots, worker, mmtk);
+        }
     }
 }

--- a/src/plan/lxr/gc_work/tracing.rs
+++ b/src/plan/lxr/gc_work/tracing.rs
@@ -338,7 +338,7 @@ impl<VM: VMBinding, const FULL_GC: bool> GCWork<VM> for LXRStopTheWorldProcessEd
 
 impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC> {
     #[inline]
-    fn full_gc_trace_object<const WEAK_ROOT: bool>(
+    fn full_gc_trace_object<const WEAK_ROOT: bool, const NO_MOVE: bool>(
         &mut self,
         object: ObjectReference,
     ) -> ObjectReference {
@@ -353,14 +353,23 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
         let x = if in_immix_space {
             let pause = self.pause;
             let worker = self.worker();
-            self.lxr.immix_space.rc_trace_object(
-                self,
-                object,
-                CopySemantics::DefaultCopy,
-                pause,
-                true,
-                worker,
-            )
+            if NO_MOVE {
+                // Mark only: never consult `is_defrag_source()`, so a caller that cannot
+                // update a stale reference (there's no slot to write into) is safe
+                // regardless of whether this object's block was picked for defrag.
+                self.lxr
+                    .immix_space
+                    .trace_mark_rc_mature_object(self, object, pause, true)
+            } else {
+                self.lxr.immix_space.rc_trace_object(
+                    self,
+                    object,
+                    CopySemantics::DefaultCopy,
+                    pause,
+                    true,
+                    worker,
+                )
+            }
         } else if self.lxr.los().in_space(object) {
             self.lxr.los().trace_object(self, object)
         } else {
@@ -376,7 +385,7 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
     }
 
     #[inline]
-    fn mature_evac_trace_object<const WEAK_ROOT: bool, const REMSET: bool>(
+    fn mature_evac_trace_object<const WEAK_ROOT: bool, const REMSET: bool, const NO_MOVE: bool>(
         &mut self,
         object: ObjectReference,
     ) -> ObjectReference {
@@ -410,14 +419,21 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
             }
             let pause = self.pause;
             let worker = self.worker();
-            self.lxr.immix_space.rc_trace_object(
-                self,
-                object,
-                CopySemantics::DefaultCopy,
-                pause,
-                true,
-                worker,
-            )
+            if NO_MOVE {
+                // See the matching branch in `full_gc_trace_object`.
+                self.lxr
+                    .immix_space
+                    .trace_mark_rc_mature_object(self, object, pause, true)
+            } else {
+                self.lxr.immix_space.rc_trace_object(
+                    self,
+                    object,
+                    CopySemantics::DefaultCopy,
+                    pause,
+                    true,
+                    worker,
+                )
+            }
         } else if self.lxr.los().in_space(object) {
             self.lxr.los().trace_object(self, object)
         } else {
@@ -438,9 +454,9 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
             return;
         };
         let new_object = if !FULL_GC {
-            self.mature_evac_trace_object::<WEAK_ROOT, REMSET>(object)
+            self.mature_evac_trace_object::<WEAK_ROOT, REMSET, false>(object)
         } else {
-            self.full_gc_trace_object::<WEAK_ROOT>(object)
+            self.full_gc_trace_object::<WEAK_ROOT, false>(object)
         };
         if Self::OVERWRITE_REFERENCE && new_object != object {
             slot.store(new_object);
@@ -487,5 +503,71 @@ impl<VM: VMBinding, const FULL_GC: bool> Deref for LXRStopTheWorldProcessEdges<V
 impl<VM: VMBinding, const FULL_GC: bool> DerefMut for LXRStopTheWorldProcessEdges<VM, FULL_GC> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.base
+    }
+}
+
+/// Traces a set of root objects reported as nodes rather than as slots, inside a
+/// stop-the-world tracing pause (`FinalMark`/`Full`). There is no slot to update if one
+/// moved, so callers must guarantee none of them can be evacuated by this trace -- LXR's
+/// node roots are reference-counted before this ever runs, which makes `dont_evacuate`
+/// treat them as ineligible for nursery eviction, and the tracing here always runs with
+/// `NO_MOVE = true`, which makes mature evacuation ineligible too.
+///
+/// Node-shaped counterpart of [`LXRStopTheWorldProcessEdges`]: wraps one (with no slots of
+/// its own) and reuses its per-object tracing directly, rather than going through a slot.
+/// Once a node's fields are discovered they're ordinary slots, so the rest of the closure
+/// -- and any continuation past this pass -- runs as plain `LXRStopTheWorldProcessEdges`.
+pub struct LXRStopTheWorldProcessNodes<VM: VMBinding, const FULL_GC: bool> {
+    inner: LXRStopTheWorldProcessEdges<VM, FULL_GC>,
+    nodes: Vec<ObjectReference>,
+}
+
+impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessNodes<VM, FULL_GC> {
+    pub fn new(
+        nodes: Vec<ObjectReference>,
+        mmtk: &'static MMTK<VM>,
+        bucket: WorkBucketStage,
+    ) -> Self {
+        Self {
+            inner: LXRStopTheWorldProcessEdges::new(vec![], false, mmtk, bucket),
+            nodes,
+        }
+    }
+}
+
+impl<VM: VMBinding, const FULL_GC: bool> GCWork<VM> for LXRStopTheWorldProcessNodes<VM, FULL_GC> {
+    fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
+        self.inner.set_worker(worker);
+        self.inner.pause = self.inner.lxr.current_pause().unwrap();
+        for o in std::mem::take(&mut self.nodes) {
+            // A node root has no slot to update if it moves, so its block must never be
+            // evacuated while it's a live root -- not just by *this* trace (`NO_MOVE`,
+            // below), but by any other edge that reaches the same object later in this
+            // pause. Mature defrag-source selection happens earlier than this (in
+            // `Prepare` for `InitialMark`/`Full`, or an entirely earlier pause for
+            // `FinalMark`, since defrag selection doesn't rerun there), so it can't already
+            // know about this pause's roots; deselecting the block here, strictly before
+            // `Closure` (or anything else in this pause) can start evacuating anything,
+            // makes every such edge take the mark-only path instead. Sweeping at the end of
+            // the pause already tolerates a block whose `is_defrag_source` flag no longer
+            // matches its `defrag_blocks` bookkeeping (see `sweep_mature_evac_candidates`).
+            if self.inner.lxr.immix_space.in_space(o) {
+                let block = Block::containing(o);
+                if block.is_defrag_source() {
+                    block.set_as_defrag_source(false);
+                }
+            }
+            // `NO_MOVE = true`: there's no slot to update if this moved, so the trace must
+            // never evacuate it, regardless of whether its block was picked for defrag.
+            let new_object = if FULL_GC {
+                self.inner.full_gc_trace_object::<false, true>(o)
+            } else {
+                self.inner.mature_evac_trace_object::<false, false, true>(o)
+            };
+            // Catches the object having already been moved by some other path before we
+            // got to it (e.g. reached and evacuated through an ordinary, movable edge).
+            debug_assert_eq!(new_object, o, "root node {:?} was moved", o);
+        }
+        GCWork::do_work(&mut self.inner, worker, mmtk);
     }
 }

--- a/src/plan/lxr/gc_work/tracing.rs
+++ b/src/plan/lxr/gc_work/tracing.rs
@@ -460,14 +460,6 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
 impl<VM: VMBinding, const FULL_GC: bool> ObjectQueue for LXRStopTheWorldProcessEdges<VM, FULL_GC> {
     fn enqueue(&mut self, object: ObjectReference) {
         let limit: usize = if FULL_GC { 8192 } else { 1024 };
-        // A target that is already marked, and cannot move, has been visited: skip the slot.
-        //
-        // The `is_rc_object` test is what makes that reasoning valid. `LXR::is_marked` answers
-        // `true` for anything in a common-plan space, because LXR keeps no mark state for those
-        // -- so without it this would skip every reference *into* the immortal/VM space, and
-        // the closure would never scan those objects' own fields. Everything reachable only
-        // from there (for Julia, the whole loaded sysimage) would then go unmarked, and
-        // `SweepDeadCycles` reclaims a counted object it finds unmarked.
         // TODO: Use actual TLS.
         object.iterate_fields::<VM, _>(VMThread::UNINITIALIZED, |s| {
             let Some(o) = s.load() else {
@@ -499,22 +491,6 @@ impl<VM: VMBinding, const FULL_GC: bool> DerefMut for LXRStopTheWorldProcessEdge
 }
 
 /// Stop-the-world tracing of roots reported as objects rather than as slots.
-///
-/// Node counterpart of [`LXRStopTheWorldProcessEdges`]. A binding reports a root this way when
-/// it cannot hand out the location the reference lives in (Julia does so for conservatively
-/// scanned stacks). There is therefore no slot to write a forwarding pointer back into, and
-/// these objects must not move: every path below marks in place, and the trace of each root is
-/// asserted to return the object unchanged.
-///
-/// The roots' *children*, in contrast, are ordinary slots and may be evacuated, so they are
-/// handed to [`LXRStopTheWorldProcessEdges`] in `closure_bucket`. That is what makes these
-/// non-transitive pinning roots. Transitive pinning would instead have to keep the whole
-/// closure in a non-moving bucket, and is not supported (see
-/// [`crate::plan::lxr::gc_work::LXRRootsWorkFactory`]).
-///
-/// Note that only the roots themselves are kept in place. Nothing pins them against *mature*
-/// evacuation: a root that is already mature and sits in a defrag source block can still be
-/// forwarded by the slot closure in `Closure` if some ordinary slot also points at it.
 pub struct LXRStopTheWorldProcessNodes<VM: VMBinding, const FULL_GC: bool> {
     lxr: &'static LXR<VM>,
     mmtk: &'static MMTK<VM>,
@@ -554,10 +530,6 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessNodes<VM, FULL_GC
         unsafe { &mut *self.worker }
     }
 
-    /// Hand the fields collected so far to the slot-based closure. Unlike
-    /// [`LXRStopTheWorldProcessEdges::flush`], which continues its own closure in
-    /// `Unconstrained`, this has to go through `closure_bucket`: children may be evacuated,
-    /// and that must not happen until every node root has been marked in place.
     #[cold]
     fn flush(&mut self) {
         if !self.next_slots.is_empty() {
@@ -570,13 +542,9 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessNodes<VM, FULL_GC
         self.next_slot_count = 0;
     }
 
-    /// Mark `object` without moving it.
-    ///
-    /// This mirrors the per-space dispatch of
+    /// Mark `object` without moving it. This mirrors the per-space dispatch of
     /// [`LXRStopTheWorldProcessEdges::mature_evac_trace_object`] minus every path that could
-    /// evacuate. Dispatching on the space first also keeps this off metadata a space does not
-    /// have: the slot closure reads forwarding bits before it knows which space the object is
-    /// in, which is not something a large object has.
+    /// evacuate.
     fn trace_object(&mut self, object: ObjectReference) -> ObjectReference {
         debug_assert!(object.is_in_any_space(), "Invalid {:?}", object);
         let in_immix_space = self.lxr.immix_space.in_space(object);

--- a/src/plan/lxr/gc_work/tracing.rs
+++ b/src/plan/lxr/gc_work/tracing.rs
@@ -460,12 +460,20 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
 impl<VM: VMBinding, const FULL_GC: bool> ObjectQueue for LXRStopTheWorldProcessEdges<VM, FULL_GC> {
     fn enqueue(&mut self, object: ObjectReference) {
         let limit: usize = if FULL_GC { 8192 } else { 1024 };
+        // A target that is already marked, and cannot move, has been visited: skip the slot.
+        //
+        // The `is_rc_object` test is what makes that reasoning valid. `LXR::is_marked` answers
+        // `true` for anything in a common-plan space, because LXR keeps no mark state for those
+        // -- so without it this would skip every reference *into* the immortal/VM space, and
+        // the closure would never scan those objects' own fields. Everything reachable only
+        // from there (for Julia, the whole loaded sysimage) would then go unmarked, and
+        // `SweepDeadCycles` reclaims a counted object it finds unmarked.
         // TODO: Use actual TLS.
         object.iterate_fields::<VM, _>(VMThread::UNINITIALIZED, |s| {
             let Some(o) = s.load() else {
                 return;
             };
-            if self.lxr.is_marked(o) && !self.lxr.in_defrag(o) {
+            if self.lxr.is_rc_object(o) && self.lxr.is_marked(o) && !self.lxr.in_defrag(o) {
                 return;
             }
             self.next_slots.push(s);
@@ -487,5 +495,145 @@ impl<VM: VMBinding, const FULL_GC: bool> Deref for LXRStopTheWorldProcessEdges<V
 impl<VM: VMBinding, const FULL_GC: bool> DerefMut for LXRStopTheWorldProcessEdges<VM, FULL_GC> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.base
+    }
+}
+
+/// Stop-the-world tracing of roots reported as objects rather than as slots.
+///
+/// Node counterpart of [`LXRStopTheWorldProcessEdges`]. A binding reports a root this way when
+/// it cannot hand out the location the reference lives in (Julia does so for conservatively
+/// scanned stacks). There is therefore no slot to write a forwarding pointer back into, and
+/// these objects must not move: every path below marks in place, and the trace of each root is
+/// asserted to return the object unchanged.
+///
+/// The roots' *children*, in contrast, are ordinary slots and may be evacuated, so they are
+/// handed to [`LXRStopTheWorldProcessEdges`] in `closure_bucket`. That is what makes these
+/// non-transitive pinning roots. Transitive pinning would instead have to keep the whole
+/// closure in a non-moving bucket, and is not supported (see
+/// [`crate::plan::lxr::gc_work::LXRRootsWorkFactory`]).
+///
+/// Note that only the roots themselves are kept in place. Nothing pins them against *mature*
+/// evacuation: a root that is already mature and sits in a defrag source block can still be
+/// forwarded by the slot closure in `Closure` if some ordinary slot also points at it.
+pub struct LXRStopTheWorldProcessNodes<VM: VMBinding, const FULL_GC: bool> {
+    lxr: &'static LXR<VM>,
+    mmtk: &'static MMTK<VM>,
+    // Use a raw pointer for the same reason `ProcessEdgesBase` does: this is dereferenced on
+    // every traced object.
+    worker: *mut GCWorker<VM>,
+    /// The root objects to mark. These must not move.
+    nodes: Vec<ObjectReference>,
+    /// Fields of the marked roots, handed on to the slot-based closure.
+    next_slots: VectorQueue<VM::VMSlot>,
+    next_slot_count: u32,
+    /// The bucket the slot closure over the roots' children runs in.
+    closure_bucket: WorkBucketStage,
+}
+
+unsafe impl<VM: VMBinding, const FULL_GC: bool> Send for LXRStopTheWorldProcessNodes<VM, FULL_GC> {}
+
+impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessNodes<VM, FULL_GC> {
+    pub fn new(
+        nodes: Vec<ObjectReference>,
+        mmtk: &'static MMTK<VM>,
+        closure_bucket: WorkBucketStage,
+    ) -> Self {
+        let lxr = mmtk.get_plan().downcast_ref::<LXR<VM>>().unwrap();
+        Self {
+            lxr,
+            mmtk,
+            worker: std::ptr::null_mut(),
+            nodes,
+            next_slots: VectorQueue::new(),
+            next_slot_count: 0,
+            closure_bucket,
+        }
+    }
+
+    fn worker(&self) -> &'static mut GCWorker<VM> {
+        unsafe { &mut *self.worker }
+    }
+
+    /// Hand the fields collected so far to the slot-based closure. Unlike
+    /// [`LXRStopTheWorldProcessEdges::flush`], which continues its own closure in
+    /// `Unconstrained`, this has to go through `closure_bucket`: children may be evacuated,
+    /// and that must not happen until every node root has been marked in place.
+    #[cold]
+    fn flush(&mut self) {
+        if !self.next_slots.is_empty() {
+            let slots = self.next_slots.take();
+            let bucket = self.closure_bucket;
+            let w =
+                LXRStopTheWorldProcessEdges::<VM, FULL_GC>::new(slots, false, self.mmtk, bucket);
+            self.worker().add_work(bucket, w);
+        }
+        self.next_slot_count = 0;
+    }
+
+    /// Mark `object` without moving it.
+    ///
+    /// This mirrors the per-space dispatch of
+    /// [`LXRStopTheWorldProcessEdges::mature_evac_trace_object`] minus every path that could
+    /// evacuate. Dispatching on the space first also keeps this off metadata a space does not
+    /// have: the slot closure reads forwarding bits before it knows which space the object is
+    /// in, which is not something a large object has.
+    fn trace_object(&mut self, object: ObjectReference) -> ObjectReference {
+        debug_assert!(object.is_in_any_space(), "Invalid {:?}", object);
+        let in_immix_space = self.lxr.immix_space.in_space(object);
+        let in_common_space = !in_immix_space && !self.lxr.los().in_space(object);
+        // A zero reference count means the object is dead, but only for the spaces LXR
+        // reference counts.
+        if !in_common_space && self.lxr.rc.count(object) == 0 {
+            return object;
+        }
+        if in_immix_space {
+            self.lxr
+                .immix_space
+                .trace_object_without_moving_rc(self, object)
+        } else if !in_common_space {
+            self.lxr.los().trace_object(self, object)
+        } else {
+            // Not reference counted. Forward to the common plan.
+            let worker = self.worker();
+            self.lxr
+                .common
+                .trace_object::<Self, DEFAULT_TRACE>(self, object, worker)
+        }
+    }
+}
+
+impl<VM: VMBinding, const FULL_GC: bool> ObjectQueue for LXRStopTheWorldProcessNodes<VM, FULL_GC> {
+    fn enqueue(&mut self, object: ObjectReference) {
+        let limit: usize = if FULL_GC { 8192 } else { 1024 };
+        // TODO: Use actual TLS.
+        object.iterate_fields::<VM, _>(VMThread::UNINITIALIZED, |s| {
+            let Some(o) = s.load() else {
+                return;
+            };
+            if self.lxr.is_rc_object(o) && self.lxr.is_marked(o) && !self.lxr.in_defrag(o) {
+                return;
+            }
+            self.next_slots.push(s);
+            self.next_slot_count += 1;
+            if self.next_slot_count as usize >= limit {
+                self.flush();
+            }
+        });
+    }
+}
+
+impl<VM: VMBinding, const FULL_GC: bool> GCWork<VM> for LXRStopTheWorldProcessNodes<VM, FULL_GC> {
+    fn do_work(&mut self, worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
+        self.worker = worker;
+        let nodes = std::mem::take(&mut self.nodes);
+        for object in nodes {
+            let new_object = self.trace_object(object);
+            debug_assert_eq!(
+                object, new_object,
+                "Root node {} moved to {}: a root reported as an object has no slot to update",
+                object, new_object
+            );
+        }
+        self.flush();
     }
 }

--- a/src/plan/lxr/gc_work/tracing.rs
+++ b/src/plan/lxr/gc_work/tracing.rs
@@ -338,7 +338,7 @@ impl<VM: VMBinding, const FULL_GC: bool> GCWork<VM> for LXRStopTheWorldProcessEd
 
 impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC> {
     #[inline]
-    fn full_gc_trace_object<const WEAK_ROOT: bool, const NO_MOVE: bool>(
+    fn full_gc_trace_object<const WEAK_ROOT: bool>(
         &mut self,
         object: ObjectReference,
     ) -> ObjectReference {
@@ -353,23 +353,14 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
         let x = if in_immix_space {
             let pause = self.pause;
             let worker = self.worker();
-            if NO_MOVE {
-                // Mark only: never consult `is_defrag_source()`, so a caller that cannot
-                // update a stale reference (there's no slot to write into) is safe
-                // regardless of whether this object's block was picked for defrag.
-                self.lxr
-                    .immix_space
-                    .trace_mark_rc_mature_object(self, object, pause, true)
-            } else {
-                self.lxr.immix_space.rc_trace_object(
-                    self,
-                    object,
-                    CopySemantics::DefaultCopy,
-                    pause,
-                    true,
-                    worker,
-                )
-            }
+            self.lxr.immix_space.rc_trace_object(
+                self,
+                object,
+                CopySemantics::DefaultCopy,
+                pause,
+                true,
+                worker,
+            )
         } else if self.lxr.los().in_space(object) {
             self.lxr.los().trace_object(self, object)
         } else {
@@ -385,7 +376,7 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
     }
 
     #[inline]
-    fn mature_evac_trace_object<const WEAK_ROOT: bool, const REMSET: bool, const NO_MOVE: bool>(
+    fn mature_evac_trace_object<const WEAK_ROOT: bool, const REMSET: bool>(
         &mut self,
         object: ObjectReference,
     ) -> ObjectReference {
@@ -419,21 +410,14 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
             }
             let pause = self.pause;
             let worker = self.worker();
-            if NO_MOVE {
-                // See the matching branch in `full_gc_trace_object`.
-                self.lxr
-                    .immix_space
-                    .trace_mark_rc_mature_object(self, object, pause, true)
-            } else {
-                self.lxr.immix_space.rc_trace_object(
-                    self,
-                    object,
-                    CopySemantics::DefaultCopy,
-                    pause,
-                    true,
-                    worker,
-                )
-            }
+            self.lxr.immix_space.rc_trace_object(
+                self,
+                object,
+                CopySemantics::DefaultCopy,
+                pause,
+                true,
+                worker,
+            )
         } else if self.lxr.los().in_space(object) {
             self.lxr.los().trace_object(self, object)
         } else {
@@ -454,9 +438,9 @@ impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessEdges<VM, FULL_GC
             return;
         };
         let new_object = if !FULL_GC {
-            self.mature_evac_trace_object::<WEAK_ROOT, REMSET, false>(object)
+            self.mature_evac_trace_object::<WEAK_ROOT, REMSET>(object)
         } else {
-            self.full_gc_trace_object::<WEAK_ROOT, false>(object)
+            self.full_gc_trace_object::<WEAK_ROOT>(object)
         };
         if Self::OVERWRITE_REFERENCE && new_object != object {
             slot.store(new_object);
@@ -503,71 +487,5 @@ impl<VM: VMBinding, const FULL_GC: bool> Deref for LXRStopTheWorldProcessEdges<V
 impl<VM: VMBinding, const FULL_GC: bool> DerefMut for LXRStopTheWorldProcessEdges<VM, FULL_GC> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.base
-    }
-}
-
-/// Traces a set of root objects reported as nodes rather than as slots, inside a
-/// stop-the-world tracing pause (`FinalMark`/`Full`). There is no slot to update if one
-/// moved, so callers must guarantee none of them can be evacuated by this trace -- LXR's
-/// node roots are reference-counted before this ever runs, which makes `dont_evacuate`
-/// treat them as ineligible for nursery eviction, and the tracing here always runs with
-/// `NO_MOVE = true`, which makes mature evacuation ineligible too.
-///
-/// Node-shaped counterpart of [`LXRStopTheWorldProcessEdges`]: wraps one (with no slots of
-/// its own) and reuses its per-object tracing directly, rather than going through a slot.
-/// Once a node's fields are discovered they're ordinary slots, so the rest of the closure
-/// -- and any continuation past this pass -- runs as plain `LXRStopTheWorldProcessEdges`.
-pub struct LXRStopTheWorldProcessNodes<VM: VMBinding, const FULL_GC: bool> {
-    inner: LXRStopTheWorldProcessEdges<VM, FULL_GC>,
-    nodes: Vec<ObjectReference>,
-}
-
-impl<VM: VMBinding, const FULL_GC: bool> LXRStopTheWorldProcessNodes<VM, FULL_GC> {
-    pub fn new(
-        nodes: Vec<ObjectReference>,
-        mmtk: &'static MMTK<VM>,
-        bucket: WorkBucketStage,
-    ) -> Self {
-        Self {
-            inner: LXRStopTheWorldProcessEdges::new(vec![], false, mmtk, bucket),
-            nodes,
-        }
-    }
-}
-
-impl<VM: VMBinding, const FULL_GC: bool> GCWork<VM> for LXRStopTheWorldProcessNodes<VM, FULL_GC> {
-    fn do_work(&mut self, worker: &mut GCWorker<VM>, mmtk: &'static MMTK<VM>) {
-        self.inner.set_worker(worker);
-        self.inner.pause = self.inner.lxr.current_pause().unwrap();
-        for o in std::mem::take(&mut self.nodes) {
-            // A node root has no slot to update if it moves, so its block must never be
-            // evacuated while it's a live root -- not just by *this* trace (`NO_MOVE`,
-            // below), but by any other edge that reaches the same object later in this
-            // pause. Mature defrag-source selection happens earlier than this (in
-            // `Prepare` for `InitialMark`/`Full`, or an entirely earlier pause for
-            // `FinalMark`, since defrag selection doesn't rerun there), so it can't already
-            // know about this pause's roots; deselecting the block here, strictly before
-            // `Closure` (or anything else in this pause) can start evacuating anything,
-            // makes every such edge take the mark-only path instead. Sweeping at the end of
-            // the pause already tolerates a block whose `is_defrag_source` flag no longer
-            // matches its `defrag_blocks` bookkeeping (see `sweep_mature_evac_candidates`).
-            if self.inner.lxr.immix_space.in_space(o) {
-                let block = Block::containing(o);
-                if block.is_defrag_source() {
-                    block.set_as_defrag_source(false);
-                }
-            }
-            // `NO_MOVE = true`: there's no slot to update if this moved, so the trace must
-            // never evacuate it, regardless of whether its block was picked for defrag.
-            let new_object = if FULL_GC {
-                self.inner.full_gc_trace_object::<false, true>(o)
-            } else {
-                self.inner.mature_evac_trace_object::<false, false, true>(o)
-            };
-            // Catches the object having already been moved by some other path before we
-            // got to it (e.g. reached and evacuated through an ordinary, movable edge).
-            debug_assert_eq!(new_object, o, "root node {:?} was moved", o);
-        }
-        GCWork::do_work(&mut self.inner, worker, mmtk);
     }
 }

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -356,7 +356,7 @@ impl<VM: VMBinding> Plan for LXR<VM> {
     }
 
     fn root_scanning_stage(&self) -> WorkBucketStage {
-        WorkBucketStage::RCProcessIncs
+        WorkBucketStage::RCProcessRootNodes
     }
 
     fn concurrent(&self) -> Option<&dyn ConcurrentPlan<VM = VM>> {
@@ -656,6 +656,7 @@ impl<VM: VMBinding> LXR<VM> {
 
     fn disable_unnecessary_buckets(&'static self, scheduler: &GCWorkScheduler<VM>, pause: Pause) {
         // Set conditional buckets
+        scheduler.work_buckets[WorkBucketStage::RCProcessRootNodes].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::RCProcessIncs].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::Prepare].set_enabled(pause != Pause::RefCount);
         let final_mark_or_full = pause == Pause::FinalMark || pause == Pause::Full;

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -659,6 +659,11 @@ impl<VM: VMBinding> LXR<VM> {
         scheduler.work_buckets[WorkBucketStage::RCProcessRootNodes].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::RCProcessIncs].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::Prepare].set_enabled(pause != Pause::RefCount);
+        // Node roots for any pause other than `RefCount` are processed here (see
+        // `LXRRootsWorkFactory::create_node_roots_work`), including `InitialMark`, which has
+        // no `Closure` phase of its own but still needs this bucket open to run them.
+        scheduler.work_buckets[WorkBucketStage::PinningRootsTrace]
+            .set_enabled(pause != Pause::RefCount);
         let final_mark_or_full = pause == Pause::FinalMark || pause == Pause::Full;
         scheduler.work_buckets[WorkBucketStage::Closure].set_enabled(final_mark_or_full);
         scheduler.work_buckets[WorkBucketStage::WeakRefClosure].set_enabled(final_mark_or_full);
@@ -671,7 +676,6 @@ impl<VM: VMBinding> LXR<VM> {
         scheduler.work_buckets[WorkBucketStage::ConcurrentResumable].set_enabled(true);
         // Always disabled
         scheduler.work_buckets[WorkBucketStage::TPinningClosure].set_enabled(false);
-        scheduler.work_buckets[WorkBucketStage::PinningRootsTrace].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::VMRefClosure].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::VMRefForwarding].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::SoftRefClosure].set_enabled(false);

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -660,6 +660,8 @@ impl<VM: VMBinding> LXR<VM> {
         scheduler.work_buckets[WorkBucketStage::RCProcessIncs].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::Prepare].set_enabled(pause != Pause::RefCount);
         let final_mark_or_full = pause == Pause::FinalMark || pause == Pause::Full;
+        // Marks roots reported as objects, before `Closure` can evacuate anything.
+        scheduler.work_buckets[WorkBucketStage::PinningRootsTrace].set_enabled(final_mark_or_full);
         scheduler.work_buckets[WorkBucketStage::Closure].set_enabled(final_mark_or_full);
         scheduler.work_buckets[WorkBucketStage::WeakRefClosure].set_enabled(final_mark_or_full);
         scheduler.work_buckets[WorkBucketStage::FinalRefClosure].set_enabled(final_mark_or_full);
@@ -670,8 +672,9 @@ impl<VM: VMBinding> LXR<VM> {
         scheduler.work_buckets[WorkBucketStage::Concurrent].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::ConcurrentResumable].set_enabled(true);
         // Always disabled
+        // LXR never routes work here: it has no transitively pinning closure. Transitive
+        // pinning roots, where accepted at all, take the ordinary node-root path instead.
         scheduler.work_buckets[WorkBucketStage::TPinningClosure].set_enabled(false);
-        scheduler.work_buckets[WorkBucketStage::PinningRootsTrace].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::VMRefClosure].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::VMRefForwarding].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::SoftRefClosure].set_enabled(false);

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -659,11 +659,6 @@ impl<VM: VMBinding> LXR<VM> {
         scheduler.work_buckets[WorkBucketStage::RCProcessRootNodes].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::RCProcessIncs].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::Prepare].set_enabled(pause != Pause::RefCount);
-        // Node roots for any pause other than `RefCount` are processed here (see
-        // `LXRRootsWorkFactory::create_node_roots_work`), including `InitialMark`, which has
-        // no `Closure` phase of its own but still needs this bucket open to run them.
-        scheduler.work_buckets[WorkBucketStage::PinningRootsTrace]
-            .set_enabled(pause != Pause::RefCount);
         let final_mark_or_full = pause == Pause::FinalMark || pause == Pause::Full;
         scheduler.work_buckets[WorkBucketStage::Closure].set_enabled(final_mark_or_full);
         scheduler.work_buckets[WorkBucketStage::WeakRefClosure].set_enabled(final_mark_or_full);
@@ -676,6 +671,7 @@ impl<VM: VMBinding> LXR<VM> {
         scheduler.work_buckets[WorkBucketStage::ConcurrentResumable].set_enabled(true);
         // Always disabled
         scheduler.work_buckets[WorkBucketStage::TPinningClosure].set_enabled(false);
+        scheduler.work_buckets[WorkBucketStage::PinningRootsTrace].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::VMRefClosure].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::VMRefForwarding].set_enabled(false);
         scheduler.work_buckets[WorkBucketStage::SoftRefClosure].set_enabled(false);

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -806,6 +806,12 @@ impl<VM: VMBinding> LXR<VM> {
         &self.common.los
     }
 
+    /// Whether `o` lives in a space LXR reference-counts (immix space or LOS). Objects
+    /// elsewhere (e.g. Julia's sysimage in the immortal/VM space) carry no reference count.
+    pub fn is_rc_object(&self, o: ObjectReference) -> bool {
+        self.immix_space.in_space(o) || self.common.los.in_space(o)
+    }
+
     fn on_lazy_decs_finished(&self, c: LazySweepingJobsCounter) {
         self.schedule_rc_block_sweeping_tasks(c);
     }

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -356,7 +356,7 @@ impl<VM: VMBinding> Plan for LXR<VM> {
     }
 
     fn root_scanning_stage(&self) -> WorkBucketStage {
-        WorkBucketStage::RCProcessRootNodes
+        WorkBucketStage::RCProcessIncsNonMoving
     }
 
     fn concurrent(&self) -> Option<&dyn ConcurrentPlan<VM = VM>> {
@@ -656,7 +656,7 @@ impl<VM: VMBinding> LXR<VM> {
 
     fn disable_unnecessary_buckets(&'static self, scheduler: &GCWorkScheduler<VM>, pause: Pause) {
         // Set conditional buckets
-        scheduler.work_buckets[WorkBucketStage::RCProcessRootNodes].set_enabled(true);
+        scheduler.work_buckets[WorkBucketStage::RCProcessIncsNonMoving].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::RCProcessIncs].set_enabled(true);
         scheduler.work_buckets[WorkBucketStage::Prepare].set_enabled(pause != Pause::RefCount);
         let final_mark_or_full = pause == Pause::FinalMark || pause == Pause::Full;

--- a/src/scheduler/work_bucket.rs
+++ b/src/scheduler/work_bucket.rs
@@ -391,13 +391,13 @@ pub enum WorkBucketStage {
     /// outstanding concurrent work, e.g. flushing SATB mod-buffer packets recorded by the LXR
     /// barrier, before the rest of the STW stages proceed.
     FinishConcurrentWork,
-    /// LXR scans roots here (see `root_scanning_stage`) and reference-counts the roots that are
-    /// reported as objects rather than as slots.  Counting them before `RCProcessIncs` opens is
-    /// what keeps them in place: `RCProcessIncs` evacuates nursery objects, and it only spares
-    /// an object whose reference count is already nonzero.
-    RCProcessRootNodes,
+    /// Process the reference-count increments that must not move their objects.  LXR also scans
+    /// roots here (see `root_scanning_stage`); the roots a binding reports as objects rather than
+    /// as slots are counted in this stage because there is no slot to write a forwarding pointer
+    /// back into.  Counting them before `RCProcessIncs` opens is what keeps them in place.
+    RCProcessIncsNonMoving,
     /// Process reference-count increments from the LXR barrier and from root slots.  May
-    /// evacuate nursery objects, so it must run after `RCProcessRootNodes`.
+    /// evacuate nursery objects, so it must run after `RCProcessIncsNonMoving`.
     RCProcessIncs,
     /// Preparation work.  Plans, spaces, GC workers, mutators, etc. should be prepared for GC at
     /// this stage.

--- a/src/scheduler/work_bucket.rs
+++ b/src/scheduler/work_bucket.rs
@@ -391,14 +391,12 @@ pub enum WorkBucketStage {
     /// outstanding concurrent work, e.g. flushing SATB mod-buffer packets recorded by the LXR
     /// barrier, before the rest of the STW stages proceed.
     FinishConcurrentWork,
-    /// LXR scans roots at this stage (see `root_scanning_stage`), including pinning/transitive-
-    /// pinning roots reported as objects rather than slots. Those must be reference-counted here
-    /// -- before `RCProcessIncs` opens -- so that they are already non-evictable
-    /// (`RefCountHelper::count` non-zero) by the time anything in `RCProcessIncs` could otherwise
-    /// evacuate the same object via a different, movable root or edge.
+    /// LXR scans roots here (see `root_scanning_stage`), including pinning/transitive-pinning
+    /// roots reported as objects. Reference-counting them here, before `RCProcessIncs` opens,
+    /// makes them non-evictable by the time anything there could otherwise move them.
     RCProcessRootNodes,
-    /// Process reference-count increments recorded by the LXR barrier and by root slots (see
-    /// `root_scanning_stage`). May evacuate nursery objects; must run after `RCProcessRootNodes`.
+    /// Process reference-count increments from the LXR barrier and from root slots. May
+    /// evacuate nursery objects, so must run after `RCProcessRootNodes`.
     RCProcessIncs,
     /// Preparation work.  Plans, spaces, GC workers, mutators, etc. should be prepared for GC at
     /// this stage.

--- a/src/scheduler/work_bucket.rs
+++ b/src/scheduler/work_bucket.rs
@@ -391,8 +391,14 @@ pub enum WorkBucketStage {
     /// outstanding concurrent work, e.g. flushing SATB mod-buffer packets recorded by the LXR
     /// barrier, before the rest of the STW stages proceed.
     FinishConcurrentWork,
-    /// Process reference-count increments recorded by the LXR barrier.  LXR also uses this stage
-    /// to scan roots (see `root_scanning_stage`).
+    /// LXR scans roots at this stage (see `root_scanning_stage`), including pinning/transitive-
+    /// pinning roots reported as objects rather than slots. Those must be reference-counted here
+    /// -- before `RCProcessIncs` opens -- so that they are already non-evictable
+    /// (`RefCountHelper::count` non-zero) by the time anything in `RCProcessIncs` could otherwise
+    /// evacuate the same object via a different, movable root or edge.
+    RCProcessRootNodes,
+    /// Process reference-count increments recorded by the LXR barrier and by root slots (see
+    /// `root_scanning_stage`). May evacuate nursery objects; must run after `RCProcessRootNodes`.
     RCProcessIncs,
     /// Preparation work.  Plans, spaces, GC workers, mutators, etc. should be prepared for GC at
     /// this stage.

--- a/src/scheduler/work_bucket.rs
+++ b/src/scheduler/work_bucket.rs
@@ -391,12 +391,13 @@ pub enum WorkBucketStage {
     /// outstanding concurrent work, e.g. flushing SATB mod-buffer packets recorded by the LXR
     /// barrier, before the rest of the STW stages proceed.
     FinishConcurrentWork,
-    /// LXR scans roots here (see `root_scanning_stage`), including pinning/transitive-pinning
-    /// roots reported as objects. Reference-counting them here, before `RCProcessIncs` opens,
-    /// makes them non-evictable by the time anything there could otherwise move them.
+    /// LXR scans roots here (see `root_scanning_stage`) and reference-counts the roots that are
+    /// reported as objects rather than as slots.  Counting them before `RCProcessIncs` opens is
+    /// what keeps them in place: `RCProcessIncs` evacuates nursery objects, and it only spares
+    /// an object whose reference count is already nonzero.
     RCProcessRootNodes,
-    /// Process reference-count increments from the LXR barrier and from root slots. May
-    /// evacuate nursery objects, so must run after `RCProcessRootNodes`.
+    /// Process reference-count increments from the LXR barrier and from root slots.  May
+    /// evacuate nursery objects, so it must run after `RCProcessRootNodes`.
     RCProcessIncs,
     /// Preparation work.  Plans, spaces, GC workers, mutators, etc. should be prepared for GC at
     /// this stage.


### PR DESCRIPTION
This PR implements `create_process_pinning_roots_work` for `LXRRootsWorkFactory`, and adds a bucket before the normal `ProcessIncs` to handle pinning roots. Changes are originated from https://github.com/mmtk/mmtk-core/pull/1564. Mostly done by Claude.