### PR TITLE
Avoid snapshotting newly allocated objects

### DIFF
--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use super::allocator::{align_allocation_no_fill, fill_alignment_gap, AllocatorContext};
 use super::BumpPointer;
+use crate::policy::immix::block::Block;
 use crate::policy::immix::line::*;
 use crate::policy::immix::ImmixSpace;
 use crate::policy::space::Space;
@@ -271,6 +272,13 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                 if self.immix_space().should_allocate_as_live() {
                     let state = self.space.line_mark_state.load(Ordering::Acquire);
                     Line::eager_mark_lines::<VM>(state, start_line..end_line);
+                    // Objects allocated here are not in the SATB snapshot, log them.
+                    if self.immix_space().common().needs_log_bit {
+                        VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_region_as_logged(
+                            start_line.start(),
+                            end_line.start() - start_line.start(),
+                        );
+                    }
                 }
                 return true;
             } else {
@@ -318,6 +326,11 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     if self.immix_space().should_allocate_as_live() {
                         let state = self.space.line_mark_state.load(Ordering::Acquire);
                         Line::eager_mark_lines::<VM>(state, block.start_line()..block.end_line());
+                        // Objects allocated here are not in the SATB snapshot, log them
+                        if self.immix_space().common().needs_log_bit {
+                            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
+                                .mark_region_as_logged(block.start(), Block::BYTES);
+                        }
                     }
                 }
                 if self.request_for_large {

--- a/src/util/alloc/immix_allocator.rs
+++ b/src/util/alloc/immix_allocator.rs
@@ -274,7 +274,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                     Line::eager_mark_lines::<VM>(state, start_line..end_line);
                     // Objects allocated here are not in the SATB snapshot, log them.
                     if self.immix_space().common().needs_log_bit {
-                        VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_region_as_logged(
+                        VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.bulk_mark_as_logged(
                             start_line.start(),
                             end_line.start() - start_line.start(),
                         );
@@ -329,7 +329,7 @@ impl<VM: VMBinding> ImmixAllocator<VM> {
                         // Objects allocated here are not in the SATB snapshot, log them
                         if self.immix_space().common().needs_log_bit {
                             VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC
-                                .mark_region_as_logged(block.start(), Block::BYTES);
+                                .bulk_mark_as_logged(block.start(), Block::BYTES);
                         }
                     }
                 }

--- a/src/util/metadata/log_bit.rs
+++ b/src/util/metadata/log_bit.rs
@@ -21,8 +21,8 @@ impl VMGlobalLogBitSpec {
         self.store_atomic::<VM, u8>(object, LOGGED_VALUE, None, order)
     }
 
-    /// Clear the unlog bits for a whole region
-    pub fn mark_region_as_logged(&self, start: Address, size: usize) {
+    /// Bulk clear the unlog bits for a memory range
+    pub fn bulk_mark_as_logged(&self, start: Address, size: usize) {
         if let MetadataSpec::OnSide(side) = self.as_spec() {
             side.bzero_metadata(start, size);
         }

--- a/src/util/metadata/log_bit.rs
+++ b/src/util/metadata/log_bit.rs
@@ -21,6 +21,13 @@ impl VMGlobalLogBitSpec {
         self.store_atomic::<VM, u8>(object, LOGGED_VALUE, None, order)
     }
 
+    /// Clear the unlog bits for a whole region
+    pub fn mark_region_as_logged(&self, start: Address, size: usize) {
+        if let MetadataSpec::OnSide(side) = self.as_spec() {
+            side.bzero_metadata(start, size);
+        }
+    }
+
     /// Mark the log bit as unlogged (1 means unlogged)
     pub fn mark_as_unlogged<VM: VMBinding>(&self, object: ObjectReference, order: Ordering) {
         self.store_atomic::<VM, u8>(object, UNLOGGED_VALUE, None, order)


### PR DESCRIPTION
Newly allocated objects don't need to be captured by SATB barriers: they are not in the snapshot, and they don't reference anything in the snapshot. We currently still trigger SATB barriers for newly allocated objects (log bits are bulk set to 1 in InitialMark), but it is benign -- the old references are zeros anyway if we do zeroing in MMTk. However, if we disable zeroing, the SATB barrier will read non-zero 'old values', treat them as references and fail. 