### PR TITLE
List LXR features in the section CI scripts parse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,6 @@ builtin_env_logger = ["dep:env_logger"]
 # Enable this feature if you want to use nightly features and compiler
 nightly = []
 
-# LXR Features
-lxr_no_cm = []
-lxr_no_lazy = []
-lxr_stw = ["lxr_no_cm", "lxr_no_lazy"]
-lxr_no_nursery_evac = []
-lxr_no_mature_evac = []
-lxr_no_evac = ["lxr_no_nursery_evac", "lxr_no_mature_evac"]
-
 # This feature is only supported on x86-64 for now
 # It's manually added to CI scripts
 perf_counter = ["dep:pfm"]
@@ -210,6 +202,14 @@ nogc_multi_space = []
 # slower for large objects and will be outright incorrect for bindings which allocate
 # non-moving objects; but compacting all objects will be more space-efficient.
 ovc_single_space = []
+
+# LXR Features
+lxr_no_cm = []
+lxr_no_lazy = []
+lxr_stw = ["lxr_no_cm", "lxr_no_lazy"]
+lxr_no_nursery_evac = []
+lxr_no_mature_evac = []
+lxr_no_evac = ["lxr_no_nursery_evac", "lxr_no_mature_evac"]
 
 # To collect statistics for each GC work packet. Enabling this may introduce a small overhead (several percentage slowdown on benchmark time).
 work_packet_stats = []

--- a/src/policy/immix/immixspace.rs
+++ b/src/policy/immix/immixspace.rs
@@ -837,7 +837,9 @@ impl<VM: VMBinding> ImmixSpace<VM> {
         object: ObjectReference,
     ) -> ObjectReference {
         // This function should not be called during RC if mature evacuation is not enabled.
-        debug_assert!(!LXR_MATURE_EVACUATION || !self.rc_enabled);
+        if LXR_MATURE_EVACUATION {
+            debug_assert!(!self.rc_enabled);
+        }
 
         #[cfg(feature = "vo_bit")]
         if !self.rc_enabled {


### PR DESCRIPTION
Our CI scripts iterate all combinations of features and do checks. LXR features are not in the section that the scripts would parse. This PR moves LXR features below `# -- Non mutually exclusive features --`.