### PR TITLE
LXR: set straddle line mark at obj ref

### DIFF
--- a/src/util/rc.rs
+++ b/src/util/rc.rs
@@ -234,14 +234,19 @@ impl<VM: VMBinding> RefCountHelper<VM> {
         debug_assert!(size > Line::BYTES);
         let start = o.to_object_start::<VM>();
         let end = start + size;
-        let start_line = Line::from_unaligned_address(start).next();
+        // Skip the line holding the object's reference address. As we currently conservatively skip
+        // the last line in a hole and do not use that line, we don't need to mark lines at object start here
+        // (as the line would be convervatively kept alive). See: https://github.com/mmtk/mmtk-core/pull/1576
+        // TODO: if we use a different solution to handle object start, we may need to mark lines
+        // at object start here.
+        let start_line = Line::from_unaligned_address(o.to_raw_address()).next();
         let end_line = Line::from_unaligned_address(end);
         // Note that `end_line` may be the last line overlapping with `o`.
         // In that case, `end_line` will not be marked.
         // It is OK because when searching for available lines (`rc_get_next_available_lines`),
         // it always skips the first line in a hole.
         let mut line = start_line;
-        while line != end_line {
+        while line < end_line {
             unsafe { RC_STRADDLE_LINES.store(line.start(), 1u8) };
             self.set_line_relaxed(line, 1);
             line = line.next();
@@ -263,14 +268,15 @@ impl<VM: VMBinding> RefCountHelper<VM> {
         if size > Line::BYTES {
             let start = o.to_object_start::<VM>();
             let end = start + size;
-            let start_line = Line::from_unaligned_address(start).next();
+            // Must match `mark_straddle_object_with_size` exactly; see the comments there.
+            let start_line = Line::from_unaligned_address(o.to_raw_address()).next();
             let end_line = Line::from_unaligned_address(end);
             // Note that `end_line` may be the last line overlapping with `o`.
             // In that case, `end_line` will not be marked.
             // It is OK because when searching for available lines (`rc_get_next_available_lines`),
             // it always skips the first line in a hole.
             let mut line = start_line;
-            while line != end_line {
+            while line < end_line {
                 self.set_line_relaxed(line, 0);
                 unsafe { RC_STRADDLE_LINES.store(line.start(), 0u8) };
                 line = line.next();


### PR DESCRIPTION
`RC_STRADDLE_LINE` is read from obj ref address.
https://github.com/mmtk/mmtk-core/blob/4011008057599f2e795562d4129061b7b91f1797/src/util/rc.rs#L220-L231

We should also set it at obj ref address. The object start line is handled by https://github.com/mmtk/mmtk-core/pull/1576.