### PR TITLE
LXR: use object log bit for probable write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,14 @@ lxr_stw = ["lxr_no_cm", "lxr_no_lazy"]
 lxr_no_nursery_evac = []
 lxr_no_mature_evac = []
 lxr_no_evac = ["lxr_no_nursery_evac", "lxr_no_mature_evac"]
+# Use the per-object log bit for LXR's barriers if no field is given.
+#
+# LXR uses a field write barrier. However, for APIs like `object_probable_write` where no
+# field is given, LXR's barrier would go through every field of the object every time the
+# barrier is called. In a runtime where this API is used often (such as Julia), we see
+# huge slowdown (10x) due to repetitively scan those objects in every barrier. In those cases,
+# this feature introduces per object log bit for LXR to address the pathological case.
+lxr-object-log = []
 
 # To collect statistics for each GC work packet. Enabling this may introduce a small overhead (several percentage slowdown on benchmark time).
 work_packet_stats = []

--- a/src/plan/barriers.rs
+++ b/src/plan/barriers.rs
@@ -300,14 +300,6 @@ impl<S: BarrierSemantics> Barrier<S::VM> for FieldBarrier<S> {
     }
 
     fn object_probable_write(&mut self, obj: ObjectReference) {
-        // The slow path snapshots every field of `obj`, so a second call in the same epoch
-        // records nothing: the field bits stop it enqueueing a field twice, but not the walk
-        // itself, and the walk is the cost. With `lxr-object-log` the slow path logs the
-        // per-object bit once it has walked, so test that bit and skip.
-        //
-        // A binding that gates on the same bit in its own inlined fast path never reaches
-        // here twice; one that calls this through the API does. Without the feature there is
-        // no bit to test, so the call stays unconditional.
         #[cfg(feature = "lxr-object-log")]
         if !self.object_is_unlogged(obj) {
             return;

--- a/src/plan/barriers.rs
+++ b/src/plan/barriers.rs
@@ -282,6 +282,12 @@ impl<S: BarrierSemantics> FieldBarrier<S> {
     pub fn new(semantics: S) -> Self {
         Self { semantics }
     }
+
+    /// Returns true if the object is not logged.
+    #[cfg(feature = "lxr-object-log")]
+    fn object_is_unlogged(&self, object: ObjectReference) -> bool {
+        S::UNLOG_BIT_SPEC.load_atomic::<S::VM, u8>(object, None, Ordering::SeqCst) != 0
+    }
 }
 
 impl<S: BarrierSemantics> Barrier<S::VM> for FieldBarrier<S> {
@@ -294,6 +300,18 @@ impl<S: BarrierSemantics> Barrier<S::VM> for FieldBarrier<S> {
     }
 
     fn object_probable_write(&mut self, obj: ObjectReference) {
+        // The slow path snapshots every field of `obj`, so a second call in the same epoch
+        // records nothing: the field bits stop it enqueueing a field twice, but not the walk
+        // itself, and the walk is the cost. With `lxr-object-log` the slow path logs the
+        // per-object bit once it has walked, so test that bit and skip.
+        //
+        // A binding that gates on the same bit in its own inlined fast path never reaches
+        // here twice; one that calls this through the API does. Without the feature there is
+        // no bit to test, so the call stays unconditional.
+        #[cfg(feature = "lxr-object-log")]
+        if !self.object_is_unlogged(obj) {
+            return;
+        }
         self.semantics.object_probable_write_slow(obj);
     }
 

--- a/src/plan/lxr/barrier.rs
+++ b/src/plan/lxr/barrier.rs
@@ -24,6 +24,33 @@ use crate::vm::slot::Slot;
 use crate::vm::*;
 use crate::MMTK;
 
+/// Re-arm the per-object log bits that one mutator's barrier cleared, so the next epoch's first
+/// store to each of those objects reaches the barrier again.
+#[cfg(feature = "lxr-object-log")]
+pub struct RearmLoggedObjects<VM: VMBinding> {
+    objects: Vec<ObjectReference>,
+    _p: std::marker::PhantomData<VM>,
+}
+
+#[cfg(feature = "lxr-object-log")]
+impl<VM: VMBinding> RearmLoggedObjects<VM> {
+    pub fn new(objects: Vec<ObjectReference>) -> Self {
+        Self {
+            objects,
+            _p: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "lxr-object-log")]
+impl<VM: VMBinding> crate::scheduler::GCWork<VM> for RearmLoggedObjects<VM> {
+    fn do_work(&mut self, _worker: &mut crate::scheduler::GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
+        for obj in &self.objects {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(*obj, Ordering::SeqCst);
+        }
+    }
+}
+
 pub struct LXRFieldBarrierSemantics<VM: VMBinding> {
     mmtk: &'static MMTK<VM>,
     tls: VMMutatorThread,
@@ -61,9 +88,12 @@ impl<VM: VMBinding> LXRFieldBarrierSemantics<VM> {
     #[cfg(feature = "lxr-object-log")]
     #[cold]
     fn clear_and_reset_logged_objects(&mut self) {
-        for obj in self.logged_objs.take() {
-            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(obj, Ordering::SeqCst);
+        let objects = self.logged_objs.take();
+        if objects.is_empty() {
+            return;
         }
+        self.mmtk.scheduler.work_buckets[WorkBucketStage::FIRST_STW_STAGE]
+            .add(RearmLoggedObjects::<VM>::new(objects));
     }
 
     fn get_slot_logging_state(&self, slot: VM::VMSlot) -> u8 {
@@ -266,9 +296,6 @@ impl<VM: VMBinding> BarrierSemantics for LXRFieldBarrierSemantics<VM> {
                 Ordering::SeqCst,
             );
             self.logged_objs.push(obj);
-            // Try keep the logged objects queue small.
-            // We can remove this check, and only clear logged objects during flush.
-            // This would cause logged object queue to grow unboundedly.
             if self.logged_objs.is_full() {
                 self.clear_and_reset_logged_objects();
             }

--- a/src/plan/lxr/barrier.rs
+++ b/src/plan/lxr/barrier.rs
@@ -31,6 +31,10 @@ pub struct LXRFieldBarrierSemantics<VM: VMBinding> {
     decs: VectorQueue<ObjectReference>,
     refs: VectorQueue<ObjectReference>,
     lxr: &'static LXR<VM>,
+    /// Objects logged by [`Self::object_probable_write_slow`], to be re-armed at the end of
+    /// the epoch. See there.
+    #[cfg(feature = "lxr-object-log")]
+    logged_objs: VectorQueue<ObjectReference>,
 }
 
 impl<VM: VMBinding> LXRFieldBarrierSemantics<VM> {
@@ -47,6 +51,18 @@ impl<VM: VMBinding> LXRFieldBarrierSemantics<VM> {
             decs: VectorQueue::default(),
             refs: VectorQueue::default(),
             lxr: mmtk.get_plan().downcast_ref::<LXR<VM>>().unwrap(),
+            #[cfg(feature = "lxr-object-log")]
+            logged_objs: VectorQueue::default(),
+        }
+    }
+
+    /// Undo the object logging done by [`Self::object_probable_write_slow`], so the next
+    /// epoch's first store to each of these objects reaches the barrier again.
+    #[cfg(feature = "lxr-object-log")]
+    #[cold]
+    fn clear_and_reset_logged_objects(&mut self) {
+        for obj in self.logged_objs.take() {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(obj, Ordering::SeqCst);
         }
     }
 
@@ -185,6 +201,10 @@ impl<VM: VMBinding> BarrierSemantics for LXRFieldBarrierSemantics<VM> {
         self.flush_weak_refs();
         self.flush_incs();
         self.flush_decs_and_satb();
+        // Ends the coalescing epoch for the objects this mutator logged: each is armed
+        // again, so the next store to it is recorded.
+        #[cfg(feature = "lxr-object-log")]
+        self.clear_and_reset_logged_objects();
     }
 
     fn object_reference_write_slow(
@@ -235,5 +255,23 @@ impl<VM: VMBinding> BarrierSemantics for LXRFieldBarrierSemantics<VM> {
         obj.iterate_fields::<VM, _>(self.tls.0, |s| {
             let _succ = self.enqueue_node(Some(obj), s, None);
         });
+        // Every field of `obj` is now logged. Also log the object log bit,
+        // so next time we don't hvae to scan the object again. This is a performance optimization.
+        #[cfg(feature = "lxr-object-log")]
+        {
+            VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.store_atomic::<VM, u8>(
+                obj,
+                LOGGED_VALUE,
+                None,
+                Ordering::SeqCst,
+            );
+            self.logged_objs.push(obj);
+            // Try keep the logged objects queue small.
+            // We can remove this check, and only clear logged objects during flush.
+            // This would cause logged object queue to grow unboundedly.
+            if self.logged_objs.is_full() {
+                self.clear_and_reset_logged_objects();
+            }
+        }
     }
 }

--- a/src/plan/lxr/barrier.rs
+++ b/src/plan/lxr/barrier.rs
@@ -83,11 +83,9 @@ impl<VM: VMBinding> LXRFieldBarrierSemantics<VM> {
         }
     }
 
-    /// Undo the object logging done by [`Self::object_probable_write_slow`], so the next
-    /// epoch's first store to each of these objects reaches the barrier again.
     #[cfg(feature = "lxr-object-log")]
     #[cold]
-    fn clear_and_reset_logged_objects(&mut self) {
+    fn flush_logged_objects(&mut self) {
         let objects = self.logged_objs.take();
         if objects.is_empty() {
             return;
@@ -234,7 +232,7 @@ impl<VM: VMBinding> BarrierSemantics for LXRFieldBarrierSemantics<VM> {
         // Ends the coalescing epoch for the objects this mutator logged: each is armed
         // again, so the next store to it is recorded.
         #[cfg(feature = "lxr-object-log")]
-        self.clear_and_reset_logged_objects();
+        self.flush_logged_objects();
     }
 
     fn object_reference_write_slow(
@@ -297,7 +295,7 @@ impl<VM: VMBinding> BarrierSemantics for LXRFieldBarrierSemantics<VM> {
             );
             self.logged_objs.push(obj);
             if self.logged_objs.is_full() {
-                self.clear_and_reset_logged_objects();
+                self.flush_logged_objects();
             }
         }
     }

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -270,12 +270,7 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
                 cursor += step;
             }
         };
-        // Promotion above arms the per-field unlog bits, which is what LXR's own barrier
-        // consults. Bindings whose inlined write-barrier fast path cannot name the field
-        // instead gate on the per-object log bit, and nothing else sets it for an object
-        // promoted through the reference-counting path rather than through tracing. Leaving
-        // it clear makes such a binding skip the barrier for every mature object, losing the
-        // decrements and increments that keep reachable objects alive.
+        // Promotion above arms the per-field unlog bits. Do the same for object log bits.
         #[cfg(feature = "lxr-object-log")]
         VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(o, Ordering::SeqCst);
         let obj_in_defrag = !los && Block::in_defrag_block(o);

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -270,6 +270,14 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
                 cursor += step;
             }
         };
+        // Promotion above arms the per-field unlog bits, which is what LXR's own barrier
+        // consults. Bindings whose inlined write-barrier fast path cannot name the field
+        // instead gate on the per-object log bit, and nothing else sets it for an object
+        // promoted through the reference-counting path rather than through tracing. Leaving
+        // it clear makes such a binding skip the barrier for every mature object, losing the
+        // decrements and increments that keep reachable objects alive.
+        #[cfg(feature = "lxr-object-log")]
+        VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.mark_as_unlogged::<VM>(o, Ordering::SeqCst);
         let obj_in_defrag = !los && Block::in_defrag_block(o);
         let tls = worker.tls.0;
         o.iterate_fields::<VM, _>(tls, |slot| {

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -385,14 +385,24 @@ impl<VM: VMBinding> LXR<VM> {
             "LXR does not support placing forwarding bits on the side."
         );
         let num_workers = args.scheduler.num_workers();
-        let immix_specs = metadata::extract_side_metadata(&[
+        #[allow(unused_mut)]
+        let mut specs = vec![
             MetadataSpec::OnSide(RC_TABLE),
             MetadataSpec::OnSide(
                 *VM::VMObjectModel::GLOBAL_FIELD_UNLOG_BIT_SPEC
                     .as_spec()
                     .extract_side_spec(),
             ),
-        ]);
+        ];
+        // The per-object log bit has to be registered too, not just the per-field one. LXR's
+        // own barrier only consults the field bits, this can be an issue for the probable write API (no field given).
+        // With `lxr-object-log`, the probable write API also logs the object bit.
+        // TODO: We should examine if we can steal a bit from the field log its as the 'logical' object log bit.
+        // We potentially could use the field log bit at the object start, or (object ref - lower bound) -- there should
+        // be no field at those addresses.
+        #[cfg(feature = "lxr-object-log")]
+        specs.push(*VM::VMObjectModel::GLOBAL_LOG_BIT_SPEC.as_spec());
+        let immix_specs = metadata::extract_side_metadata(&specs);
         let global_side_metadata_specs = SideMetadataContext::new_global_specs(&immix_specs);
         let mut plan_args = CreateSpecificPlanArgs {
             global_args: args,


### PR DESCRIPTION
This PR adds object log bit to LXR as an optional feature. LXR uses field log bits. However it still implements `object_probable_write`, which does not specify the actual field to write -- so the barrier slowpath has to scan the object, push references to a buffer and log all the fields. For repetitive calls to `object_probable_write` to the same object, object scanning happens for every call. 

Julia happens to use `object_probable_write` often enough. The following is measured during the sysimg step during building Julia.

per GC | With object log bit | Without object log bit | ratio
-- | -- | -- | --
probable write slowpath | 8,162 | 2,098,992 | 257×
field visits | 233,040 | 1,510,149,064 | 6,480×
sysimg step | 62.79 s | 673.16 s | 10.7×
image output | 72.57 s | 1395.96 s | 19.2×
wall | 16:31 | 1:19:53 | 4.8×

This PR adds a feature that allows LXR to use object log bit to remember that an object is scanned in the probable write API.