### PR TITLE
LXR: add tuning knobs, fix survival predictor for non moving build

### DIFF
--- a/src/plan/lxr/block_allocation.rs
+++ b/src/plan/lxr/block_allocation.rs
@@ -2,6 +2,7 @@ use super::gc_work::nursery_sweeping::{RCLazySweepNurseryBlocks, RCSTWSweepNurse
 use super::LXR;
 use crate::plan::concurrent::global::ConcurrentPlan;
 use crate::plan::concurrent::Pause;
+use crate::plan::global::Plan;
 use crate::policy::immix::block::{Block, BlockState};
 use crate::policy::immix::{ImmixHooks, ImmixSpace};
 use crate::scheduler::{GCWork, GCWorkScheduler, WorkBucketStage};
@@ -128,7 +129,8 @@ impl<VM: VMBinding> BlockAllocation<VM> {
     /// Reset allocated_block_buffer and free nursery blocks.
     pub fn sweep_nursery_blocks(&self, scheduler: &GCWorkScheduler<VM>, pause: Pause) {
         const PARALLEL_STW_SWEEPING: bool = false;
-        let max_stw_sweep_blocks: usize = usize::MAX;
+        let max_stw_sweep_blocks: usize =
+            *self.lxr().base().options.lxr_max_stw_sweep_nursery_blocks;
         let space = self.space();
         self.nursery_blocks.visit_slice(|blocks| {
             if PARALLEL_STW_SWEEPING {

--- a/src/plan/lxr/gc_work/rc.rs
+++ b/src/plan/lxr/gc_work/rc.rs
@@ -18,6 +18,7 @@ use crate::vm::slot::Slot;
 use crate::{
     plan::concurrent::global::ConcurrentPlan,
     plan::concurrent::Pause,
+    plan::global::Plan,
     policy::{immix::block::Block, space::Space},
     scheduler::{GCWork, GCWorker, WorkBucketStage},
     util::{metadata::side_metadata, object_forwarding, ObjectReference},
@@ -189,10 +190,8 @@ impl<VM: VMBinding, const KIND: EdgeKind> ProcessIncs<VM, KIND> {
                 block.set_as_in_place_promoted();
             }
             self.rc.promote_with_size(o, size);
-            if copied {
-                self.survival_ratio_predictor_local
-                    .record_copied_promotion(size);
-            }
+            self.survival_ratio_predictor_local
+                .record_promotion(size, copied);
         } else {
             // println!("promote los {:?} {}", o, self.immix().is_marked(o));
         }
@@ -623,13 +622,17 @@ impl<VM: VMBinding, const KIND: EdgeKind> GCWork<VM> for ProcessIncs<VM, KIND> {
         // Process recursively generated buffer
         let mut depth = self.depth;
         let mut incs = vec![];
-        const ACTIVE_PACKET_SPLIT: bool = false;
+        // Incs are processed by the worker that discovered them, unless we split.
+        // Split size defaults to `usize::MAX` (never split).
+        let split_size = *self.lxr.base().options.lxr_min_packet_split_size;
+        // Split depth defaults to 16 (split after 16 recursions).
+        let split_depth = *self.lxr.base().options.lxr_min_packet_split_depth;
         while !self.new_incs.is_empty() {
             self.new_incs_count = 0;
             depth += 1;
             incs.clear();
             self.new_incs.swap(&mut incs);
-            if ACTIVE_PACKET_SPLIT && depth >= 16 && incs.len() > 1 {
+            if depth as usize >= split_depth && incs.len() > split_size {
                 let (a, b) = incs.split_at(incs.len() / 2);
                 let mut w = ProcessIncs::<VM, EDGE_KIND_NURSERY>::new(b.to_vec(), self.lxr);
                 w.depth = depth;

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -108,9 +108,8 @@ impl<VM: VMBinding> Plan for LXR<VM> {
         if self.concurrent_work_in_progress() && super::concurrent_marking_packets_drained() {
             return true;
         }
-        // Bound the pause by bounding the work it has to do (default to 0 - disabled)
-        let inc_buffer_limit = *self.base().options.lxr_inc_buffer_limit;
-        if inc_buffer_limit != 0 && self.rc.inc_buffer_size() >= inc_buffer_limit {
+        // Bound the pause by bounding the work it has to do (default to usize::MAX - disabled)
+        if self.rc.inc_buffer_size() >= *self.base().options.lxr_inc_buffer_limit {
             return true;
         }
         // Survival limits

--- a/src/plan/lxr/global.rs
+++ b/src/plan/lxr/global.rs
@@ -83,7 +83,7 @@ pub struct LXR<VM: VMBinding> {
 }
 
 pub static LXR_CONSTRAINTS: Lazy<PlanConstraints> = Lazy::new(|| PlanConstraints {
-    moves_objects: true,
+    moves_objects: super::NURSERY_EVACUATION || super::MATURE_EVACUATION,
     // Max immix object size is half of a block.
     max_non_los_default_alloc_bytes: crate::policy::immix::MAX_IMMIX_OBJECT_SIZE,
     barrier: BarrierSelector::FieldBarrier,
@@ -108,13 +108,23 @@ impl<VM: VMBinding> Plan for LXR<VM> {
         if self.concurrent_work_in_progress() && super::concurrent_marking_packets_drained() {
             return true;
         }
+        // Bound the pause by bounding the work it has to do (default to 0 - disabled)
+        let inc_buffer_limit = *self.base().options.lxr_inc_buffer_limit;
+        if inc_buffer_limit != 0 && self.rc.inc_buffer_size() >= inc_buffer_limit {
+            return true;
+        }
         // Survival limits
         let total_young_alloc_pages =
             self.block_allocation.total_young_allocation_in_bytes() >> LOG_BYTES_IN_MBYTE;
-        let predicted_survival_mb: usize =
-            ((total_young_alloc_pages as f64 * super::SURVIVAL_RATIO_PREDICTOR.ratio()) as usize)
-                << LOG_CONSERVATIVE_SURVIVAL_RATIO_MULTIPLER;
-        if predicted_survival_mb >= super::MAX_SURVIVAL_MB {
+        // Use copy promotion ratio, or just total promotion ratio.
+        let ratio = if LXR_CONSTRAINTS.moves_objects {
+            super::SURVIVAL_RATIO_PREDICTOR.copy_promote_ratio()
+        } else {
+            super::SURVIVAL_RATIO_PREDICTOR.promote_ratio()
+        };
+        let predicted_survival_mb: usize = ((total_young_alloc_pages as f64 * ratio) as usize)
+            << LOG_CONSERVATIVE_SURVIVAL_RATIO_MULTIPLER;
+        if predicted_survival_mb >= *self.base().options.lxr_max_survival_mb {
             return true;
         }
         if !self.immix_space.common().contiguous {
@@ -227,7 +237,7 @@ impl<VM: VMBinding> Plan for LXR<VM> {
     }
 
     fn release(&mut self, tls: VMWorkerThread) {
-        let _new_ratio = super::SURVIVAL_RATIO_PREDICTOR.update_ratio();
+        super::SURVIVAL_RATIO_PREDICTOR.update_ratios();
         let pause = self.current_pause().unwrap();
         if pause == Pause::FinalMark || pause == Pause::Full {
             VM::VMCollection::update_weak_processor(false);
@@ -259,7 +269,7 @@ impl<VM: VMBinding> Plan for LXR<VM> {
     fn get_collection_reserved_pages(&self) -> usize {
         let survival = {
             let predicted_survival = (self.block_allocation.clean_nursery_mb() as f64
-                * super::SURVIVAL_RATIO_PREDICTOR.ratio())
+                * super::SURVIVAL_RATIO_PREDICTOR.copy_promote_ratio())
                 as usize;
             predicted_survival << LOG_CONSERVATIVE_SURVIVAL_RATIO_MULTIPLER
         };

--- a/src/plan/lxr/mod.rs
+++ b/src/plan/lxr/mod.rs
@@ -35,9 +35,6 @@ pub(crate) const MATURE_EVACUATION: bool = !cfg!(feature = "lxr_no_mature_evac")
 /// Stop triggering CM or RC pauses, and trigger Full GCs instead if the available heap after a RC pause is still small.
 const RC_STOP_PERCENT: usize = 15;
 
-/// Trigger an RC pause when the predicted max survival size is larger than this threshold.
-const MAX_SURVIVAL_MB: usize = 128;
-
 /// Trigger a concurrent marking cycle when the predicted mature size is larger than this threshold.
 const TRACE_THRESHOLD: usize = 20;
 
@@ -153,15 +150,25 @@ static LAZY_SWEEPING_JOBS: Lazy<RwLock<LazySweepingJobs>> =
     Lazy::new(|| RwLock::new(LazySweepingJobs::new()));
 
 static SURVIVAL_RATIO_PREDICTOR: SurvivalRatioPredictor = SurvivalRatioPredictor {
-    prev_ratio: Atomic::new(0.01),
     alloc_vol: AtomicUsize::new(0),
     copy_promote_vol: AtomicUsize::new(0),
+    prev_copy_promote_ratio: Atomic::new(0.01),
+    promote_vol: AtomicUsize::new(0),
+    prev_promote_ratio: Atomic::new(0.01),
 };
 
+/// Predicts how much of the young allocation in the coming cycle will survive.
 struct SurvivalRatioPredictor {
-    prev_ratio: Atomic<f64>,
+    /// Young allocation over the current cycle: the denominator of both ratios.
     alloc_vol: AtomicUsize,
+    /// Volume promoted by copying during the current cycle.
     copy_promote_vol: AtomicUsize,
+    /// Smoothed `copy_promote_vol / alloc_vol` over previous cycles.
+    prev_copy_promote_ratio: Atomic<f64>,
+    /// Volume promoted by any means during the current cycle.
+    promote_vol: AtomicUsize,
+    /// Smoothed `promote_vol / alloc_vol` over previous cycles.
+    prev_promote_ratio: Atomic<f64>,
 }
 
 impl SurvivalRatioPredictor {
@@ -170,46 +177,53 @@ impl SurvivalRatioPredictor {
         self.alloc_vol.store(size, Ordering::SeqCst);
     }
 
-    pub fn ratio(&self) -> f64 {
-        self.prev_ratio.load(Ordering::Relaxed)
+    /// Fraction of young allocation that survived *by being copied*.
+    pub fn copy_promote_ratio(&self) -> f64 {
+        self.prev_copy_promote_ratio.load(Ordering::Relaxed)
     }
 
-    pub fn update_ratio(&self) -> f64 {
-        if self.alloc_vol.load(Ordering::SeqCst) == 0 {
-            self.copy_promote_vol.store(0, Ordering::SeqCst);
-            return self.ratio();
+    /// Fraction of young allocation that survived at all, copied or promoted in place.
+    pub fn promote_ratio(&self) -> f64 {
+        self.prev_promote_ratio.load(Ordering::Relaxed)
+    }
+
+    pub fn update_ratios(&self) {
+        let alloc_vol = self.alloc_vol.swap(0, Ordering::SeqCst);
+        let copy_promote_vol = self.copy_promote_vol.swap(0, Ordering::SeqCst);
+        let promote_vol = self.promote_vol.swap(0, Ordering::SeqCst);
+        if alloc_vol == 0 {
+            return;
         }
-        let prev = self.prev_ratio.load(Ordering::SeqCst);
-        let curr = self.copy_promote_vol.load(Ordering::SeqCst) as f64
-            / self.alloc_vol.load(Ordering::SeqCst) as f64;
-        let curr = f64::min(curr, 1.0);
-        let ratio = (curr * 3f64 + prev) / 4f64;
-        let ratio = f64::min(ratio, 1.0);
-        self.prev_ratio.store(ratio, Ordering::SeqCst);
-        self.alloc_vol.store(0, Ordering::SeqCst);
-        self.copy_promote_vol.store(0, Ordering::SeqCst);
-        ratio
+        let smooth = |prev_ratio: &Atomic<f64>, vol: usize| {
+            let curr = f64::min(vol as f64 / alloc_vol as f64, 1.0);
+            let prev = prev_ratio.load(Ordering::SeqCst);
+            prev_ratio.store(f64::min((curr * 3f64 + prev) / 4f64, 1.0), Ordering::SeqCst);
+        };
+        smooth(&self.prev_copy_promote_ratio, copy_promote_vol);
+        smooth(&self.prev_promote_ratio, promote_vol);
     }
 }
 
 struct SurvivalRatioPredictorLocal {
     copy_promote_vol: AtomicUsize,
+    promote_vol: AtomicUsize,
 }
 
 impl Default for SurvivalRatioPredictorLocal {
     fn default() -> Self {
         Self {
             copy_promote_vol: AtomicUsize::new(0),
+            promote_vol: AtomicUsize::new(0),
         }
     }
 }
 
 impl SurvivalRatioPredictorLocal {
-    pub fn record_copied_promotion(&self, size: usize) {
-        self.copy_promote_vol.store(
-            self.copy_promote_vol.load(Ordering::Relaxed) + size,
-            Ordering::Relaxed,
-        );
+    pub fn record_promotion(&self, size: usize, copied: bool) {
+        self.promote_vol.fetch_add(size, Ordering::Relaxed);
+        if copied {
+            self.copy_promote_vol.fetch_add(size, Ordering::Relaxed);
+        }
     }
 
     pub fn sync(&self) {
@@ -217,6 +231,9 @@ impl SurvivalRatioPredictorLocal {
             self.copy_promote_vol.load(Ordering::Relaxed),
             Ordering::Relaxed,
         );
+        SURVIVAL_RATIO_PREDICTOR
+            .promote_vol
+            .fetch_add(self.promote_vol.load(Ordering::Relaxed), Ordering::Relaxed);
     }
 }
 

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -1010,7 +1010,29 @@ options! {
     /// headroom between 1% to 3% of the heap size.
     immix_defrag_headroom_percent: usize            [|v: &usize| *v <= 50] = 5,
     /// Disable concurrent marking in ConcurrentImmix. Setting this to true will make ConcurrentImmix behave exactly like full heap Immix. This option is only intended for debugging.
-    concurrent_immix_disable_concurrent_marking: bool              [always_valid] = false
+    concurrent_immix_disable_concurrent_marking: bool              [always_valid] = false,
+    /// Trigger an LXR pause once this many reference-count increments are pending, bounding the
+    /// `RCProcessIncs` work a single pause has to do. Each pending increment is one slot the write
+    /// barrier recorded, so the limit is roughly "words of reference stores between pauses".
+    /// Zero, the default, means unlimited, leaving the pause bounded only by heap occupancy.
+    lxr_inc_buffer_limit: usize                     [always_valid] = 0,
+    /// Trigger an LXR pause when the predicted surviving young data exceeds this many megabytes.
+    /// This is the bound that limits pause time, since a pause is dominated by promoting the young
+    /// objects that survived.
+    lxr_max_survival_mb: usize                      [|v: &usize| *v > 0] = 128,
+    /// How many nursery blocks a non-`Full` LXR pause may sweep before handing the rest to the
+    /// concurrent phase. `usize::MAX`, the default, sweeps the whole nursery inside the pause;
+    /// zero defers all of it.
+    lxr_max_stw_sweep_nursery_blocks: usize         [always_valid] = usize::MAX,
+    /// The smallest generation of recursively-discovered reference-count increments that LXR will
+    /// split with another worker instead of processing entirely.
+    /// `usize::MAX`, the default, disables splitting.
+    lxr_min_packet_split_size: usize                [always_valid] = usize::MAX,
+    /// The earliest generation of recursively-discovered reference-count increments that LXR will
+    /// consider splitting. Early generations are small and near the roots, where splitting costs a
+    /// work packet and buys little; the chain only gets long enough to matter further down. Zero
+    /// considers every generation.
+    lxr_min_packet_split_depth: usize               [always_valid] = 16
 }
 
 #[cfg(test)]

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -1014,8 +1014,8 @@ options! {
     /// Trigger an LXR pause once this many reference-count increments are pending, bounding the
     /// `RCProcessIncs` work a single pause has to do. Each pending increment is one slot the write
     /// barrier recorded, so the limit is roughly "words of reference stores between pauses".
-    /// Zero, the default, means unlimited, leaving the pause bounded only by heap occupancy.
-    lxr_inc_buffer_limit: usize                     [always_valid] = 0,
+    /// `usize::MAX`, the default, leaves the pause bounded only by heap occupancy.
+    lxr_inc_buffer_limit: usize                     [always_valid] = usize::MAX,
     /// Trigger an LXR pause when the predicted surviving young data exceeds this many megabytes.
     /// This is the bound that limits pause time, since a pause is dominated by promoting the young
     /// objects that survived.


### PR DESCRIPTION
This PR exposes some tuning knobs for LXR as options, and maintains total promotion volume and ratio (besides the existing copy promotion volume and ratio). 

The behavior on OpenJDK using those options' default values should be identical to `master`.